### PR TITLE
QDom support for Xml reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ option(MUSX_THROW_ON_INTEGRITY_CHECK_FAIL "Enable throwing integrity check failu
 option(MUSX_USE_TINYXML2 "Enable tinyxml2 parsing classes" OFF)
 option(MUSX_USE_RAPIDXML "Enable rapidxml parsing classes" OFF)
 option(MUSX_USE_PUGIXML "Enable pugixml parsing classes" OFF)
+option(MUSX_USE_QTXML "Enable Qt xml parsing classes" OFF)
 option(MUSX_DISPLAY_NODE_NAMES "Write node names to std::cout as they are processed" OFF)
 
 # Override defaults for stand-alone builds
@@ -74,6 +75,7 @@ target_compile_definitions(musx INTERFACE
     $<$<BOOL:${MUSX_USE_TINYXML2}>:MUSX_USE_TINYXML2>
     $<$<BOOL:${MUSX_USE_RAPIDXML}>:MUSX_USE_RAPIDXML>
     $<$<BOOL:${MUSX_USE_PUGIXML}>:MUSX_USE_PUGIXML>
+    $<$<BOOL:${MUSX_USE_QTXML}>:MUSX_USE_QTXML>
 )
 
 # Ensure the library uses the correct include paths

--- a/src/musx/dom/Details.h
+++ b/src/musx/dom/Details.h
@@ -308,11 +308,11 @@ public:
     MeasCmper getMeasure() const { return MeasCmper(getCmper2()); }
 
     /// @brief Returns the clef index in effect for at the specified @ref Edu position.
-    /// @todo This function will need to be augmented for transposing staves.
+    /// This function does not take into account transposing clefs. Those are addressed in #createEntryFrame.
     ClefIndex calcClefIndexAt(Edu position) const;
 
     /// @brief Returns the clef index in effect for at the specified @ref util::Fraction position (as a fraction of whole notes).
-    /// @todo This function will need to be augmented for transposing staves.
+    /// This function does not take into account transposing clefs. Those are addressed in #createEntryFrame.
     ClefIndex calcClefIndexAt(util::Fraction position) const
     { return calcClefIndexAt(position.calcEduDuration()); }
 

--- a/src/musx/dom/Entries.h
+++ b/src/musx/dom/Entries.h
@@ -431,7 +431,6 @@ public:
     */
     std::vector<TupletInfo> tupletInfo;
     std::shared_ptr<KeySignature> keySignature; ///< this can be different than the measure key sig if the staff has independent key signatures
-                                                ///< @todo This must be adjusted based on concert or transposed pitch.
 
     /// @brief Get the staff for the entry
     InstCmper getStaff() const { return m_staff; }

--- a/src/musx/dom/Entries.h
+++ b/src/musx/dom/Entries.h
@@ -211,7 +211,7 @@ public:
     void integrityCheck() override
     {
         this->Base::integrityCheck();
-        if (numNotes != notes.size()) {
+        if (size_t(numNotes) != notes.size()) {
             MUSX_INTEGRITY_ERROR("Entry " + std::to_string(m_entnum) + " has an incorrect number of notes.");
         }
     }

--- a/src/musx/dom/Entries.h
+++ b/src/musx/dom/Entries.h
@@ -507,7 +507,6 @@ public:
     unsigned graceIndex{};              ///< the Finale grace note index, counting from 1 starting from the leftmost grace note counting rightward.
                                         ///< the main note has a grace index of zero.
     ClefIndex clefIndex{};              ///< the clef index in effect for the entry.
-                                        ///< @todo This must be adjusted based on concert or transposed pitch.
 
     /// @brief Get the entry
     /// @throws std::logic_error if the entry pointer is no longer valid 

--- a/src/musx/dom/Implementations.cpp
+++ b/src/musx/dom/Implementations.cpp
@@ -907,8 +907,6 @@ std::shared_ptr<const EntryFrame> details::GFrameHold::createEntryFrame(LayerInd
                     activeTuplets.emplace_back(tuplet, index);
                 }
 
-                // @todo: calculate and add running values (clef, key)
-
                 // It appears that Finale allows exactly one entry per 0-length tuplet, no matter
                 // what the symbolic duration of the tuplet is. This makes life *much* easier.
                 bool zeroLengthTuplet = false;
@@ -2152,7 +2150,6 @@ std::string others::Staff::getAbbreviatedInstrumentName(util::EnigmaString::Acci
 
 ClefIndex others::Staff::calcClefIndexAt(MeasCmper measureId, Edu position) const
 {
-    /// @todo Take into accound clef changes caused by transposition.
     for (MeasCmper tryMeasure = measureId; tryMeasure > 0; tryMeasure--) {
         if (auto gfhold = getDocument()->getDetails()->get<details::GFrameHold>(getPartId(), getCmper(), tryMeasure)) {
             return gfhold->calcClefIndexAt(position);

--- a/src/musx/dom/Implementations.cpp
+++ b/src/musx/dom/Implementations.cpp
@@ -1539,8 +1539,7 @@ NoteInfoPtr NoteInfoPtr::findEqualPitch(const EntryInfoPtr& entry) const
         for (auto note = NoteInfoPtr(entry, 0); note; note = note.getNext()) {
             auto [pitch, octave, alter, staffPos] = note.calcNoteProperties();
             if (srcPitch == pitch && srcOctave == octave && srcAlter == alter) {
-                int entryOccurrence = 1;
-                for (int entryOccurence = 1; entryOccurrence < srcOccurrence; entryOccurrence++) {
+                for (int entryOccurrence = 1; entryOccurrence < srcOccurrence; entryOccurrence++) {
                     auto next = note.getNext();
                     if (!next.isSamePitchValues(note)) break;
                     note = next;
@@ -1604,7 +1603,7 @@ NoteInfoPtr NoteInfoPtr::calcTieFrom() const
                 continue;
             }
             bool skipBackToV1 = !thisRawEntry->voice2
-                              || currRawEntry->voice2 && currEntry.getPreviousInFrame()->v2Launch;
+                              || (currRawEntry->voice2 && currEntry.getPreviousInFrame()->v2Launch);
             if (skipBackToV1 && currRawEntry->voice2) {
                 while (currEntry) {
                     auto testEntry = currEntry.getPreviousInLayer();
@@ -2452,7 +2451,10 @@ std::string others::TextBlock::getText(bool trimTags, util::EnigmaString::Accide
     auto block = getRawTextBlock();
     if (!block) return {};
     auto retval = musx::util::EnigmaString::replaceAccidentalTags(block->text, accidentalStyle);
-    return musx::util::EnigmaString::trimTags(retval);
+    if (trimTags) {
+        return musx::util::EnigmaString::trimTags(retval);
+    }
+    return retval;
 }
 
 std::string others::TextBlock::getText(const DocumentPtr& document, const Cmper textId, bool trimTags, util::EnigmaString::AccidentalStyle accidentalStyle)

--- a/src/musx/dom/InstrumentUuids.h
+++ b/src/musx/dom/InstrumentUuids.h
@@ -27,7 +27,7 @@ namespace musx {
 namespace dom {
 
 /**
- * @namespace musx::uuid
+ * @namespace musx::dom::uuid
  * @brief Constants for all supported instruments (identified by UUID) in Finale.
  */
 namespace uuid {

--- a/src/musx/dom/ObjectPool.h
+++ b/src/musx/dom/ObjectPool.h
@@ -114,7 +114,7 @@ public:
             ObjectKey noInciKey = key;
             noInciKey.inci = std::nullopt;
             auto currentIncis = getArray<ObjectBaseType>(noInciKey);
-            if (key.inci.value() != currentIncis.size()) {
+            if (key.inci.value() != int(currentIncis.size())) {
                 MUSX_INTEGRITY_ERROR("Node " + key.nodeString() + " has inci " + std::to_string(key.inci.value()) + " that is out of sequence.");
             }
         }

--- a/src/musx/factory/DocumentFactory.h
+++ b/src/musx/factory/DocumentFactory.h
@@ -41,20 +41,21 @@ class DocumentFactory : FactoryBase
 
 public:
     /**
-     * @brief Creates a `Document` object from an XML element.
+     * @brief Creates a `Document` object from an XML buffer.
      * 
-     * @param xmlBuffer Buffer containing EnigmaXML for a musx file.
+     * @param data Pointer to a buffer containing EnigmaXML for a musx file.
+     * @param size The size of the buffer.
      * @return A fully populated `Document` object.
      * @throws std::invalid_argument If required nodes or attributes are missing or invalid.
      */
     template <typename XmlDocumentType>
-    static DocumentPtr create(const std::vector<char>& xmlBuffer)
+    static DocumentPtr create(const char * data, size_t size)
     {
         static_assert(std::is_base_of<musx::xml::IXmlDocument, XmlDocumentType>::value, 
                       "XmlReaderType must derive from IXmlDocument.");
 
         std::unique_ptr<musx::xml::IXmlDocument> xmlDocument = std::make_unique<XmlDocumentType>();
-        xmlDocument->loadFromString(xmlBuffer);
+        xmlDocument->loadFromBuffer(data, size);
 
         auto rootElement = xmlDocument->getRootElement();
         if (!rootElement || rootElement->getTagName() != "finale") {
@@ -91,6 +92,19 @@ public:
         util::Logger::log(util::Logger::LogLevel::Verbose, "============");
 #endif        
         return document;
+    }
+
+    /**
+     * @brief Creates a `Document` object from an XML buffer.
+     * 
+     * @param xmlBuffer Buffer containing EnigmaXML for a musx file.
+     * @return A fully populated `Document` object.
+     * @throws std::invalid_argument If required nodes or attributes are missing or invalid.
+     */
+    template <typename XmlDocumentType>
+    static DocumentPtr create(const std::vector<char>& xmlBuffer)
+    {
+        return create<XmlDocumentType>(xmlBuffer.data(), xmlBuffer.size());
     }
 };
 

--- a/src/musx/factory/FieldPopulatorsOthers.cpp
+++ b/src/musx/factory/FieldPopulatorsOthers.cpp
@@ -408,7 +408,7 @@ MUSX_XML_ELEMENT_ARRAY(ChordSuffixElement, {
     { "suffix", [](const XmlElementPtr& e, const std::shared_ptr<ChordSuffixElement>& i) { i->symbol = e->getTextAs<char32_t>(); }},
     { "xdisp", [](const XmlElementPtr& e, const std::shared_ptr<ChordSuffixElement>& i) { i->xdisp = e->getTextAs<Evpu>(); }},
     { "ydisp", [](const XmlElementPtr& e, const std::shared_ptr<ChordSuffixElement>& i) { i->ydisp = e->getTextAs<Evpu>(); }},
-    { "isNumber", [](const XmlElementPtr& e, const std::shared_ptr<ChordSuffixElement>& i) { i->isNumber = true; }},
+    { "isNumber", [](const XmlElementPtr&, const std::shared_ptr<ChordSuffixElement>& i) { i->isNumber = true; }},
     { "prefix", [](const XmlElementPtr& e, const std::shared_ptr<ChordSuffixElement>& i) { i->prefix = toEnum<ChordSuffixElement::Prefix>(e); }},
 });
 
@@ -423,8 +423,8 @@ MUSX_XML_ELEMENT_ARRAY(ClefList, {
     {"percent", [](const XmlElementPtr& e, const std::shared_ptr<ClefList>& i) { i->percent = e->getTextAs<int>(); }},
     {"xEvpuOffset", [](const XmlElementPtr& e, const std::shared_ptr<ClefList>& i) { i->xEvpuOffset = e->getTextAs<int>(); }},
     {"clefMode", [](const XmlElementPtr& e, const std::shared_ptr<ClefList>& i) { i->clefMode = toEnum<ShowClefMode>(e); }},
-    {"unlockVert", [](const XmlElementPtr& e, const std::shared_ptr<ClefList>& i) { i->unlockVert = true; }},
-    {"afterBarline", [](const XmlElementPtr& e, const std::shared_ptr<ClefList>& i) { i->afterBarline = true; }},
+    {"unlockVert", [](const XmlElementPtr&, const std::shared_ptr<ClefList>& i) { i->unlockVert = true; }},
+    {"afterBarline", [](const XmlElementPtr&, const std::shared_ptr<ClefList>& i) { i->afterBarline = true; }},
 });
 
 MUSX_XML_ELEMENT_ARRAY(FontDefinition, {
@@ -991,8 +991,8 @@ MUSX_XML_ELEMENT_ARRAY(TextRepeatDef, {
     {"fontID", [](const XmlElementPtr& e, const std::shared_ptr<TextRepeatDef>& i) { FieldPopulator<FontInfo>::populateField(i->font, e); }},
     {"fontSize", [](const XmlElementPtr& e, const std::shared_ptr<TextRepeatDef>& i) { FieldPopulator<FontInfo>::populateField(i->font, e); }},
     {"efx", [](const XmlElementPtr& e, const std::shared_ptr<TextRepeatDef>& i) { FieldPopulator<FontInfo>::populateField(i->font, e); }},
-    {"newEnclosure", [](const XmlElementPtr& e, const std::shared_ptr<TextRepeatDef>& i) { i->hasEnclosure = true; }},
-    {"useThisFont", [](const XmlElementPtr& e, const std::shared_ptr<TextRepeatDef>& i) { i->useThisFont = true; }},
+    {"newEnclosure", [](const XmlElementPtr&, const std::shared_ptr<TextRepeatDef>& i) { i->hasEnclosure = true; }},
+    {"useThisFont", [](const XmlElementPtr&, const std::shared_ptr<TextRepeatDef>& i) { i->useThisFont = true; }},
     {"poundReplace", [](const XmlElementPtr& e, const std::shared_ptr<TextRepeatDef>& i) { i->poundReplace = toEnum<TextRepeatDef::PoundReplaceOption>(e); }},
     {"justify", [](const XmlElementPtr& e, const std::shared_ptr<TextRepeatDef>& i) { i->justification = toEnum<HorizontalTextJustification>(e); }},
     {"act", [](const XmlElementPtr& e, const std::shared_ptr<TextRepeatDef>& i) { i->passList.push_back(e->getTextAs<int>()); }},

--- a/src/musx/musx.h
+++ b/src/musx/musx.h
@@ -84,3 +84,7 @@
 #ifdef MUSX_USE_PUGIXML // usually defined on the compile line or in CMakeLists.txt
 #include "xml/PugiXmlImpl.h"
 #endif
+
+#ifdef MUSX_USE_QTXML // usually defined on the compile line or in CMakeLists.txt
+#include "xml/QtXmlImpl.h"
+#endif

--- a/src/musx/xml/PugiXmlImpl.h
+++ b/src/musx/xml/PugiXmlImpl.h
@@ -130,8 +130,8 @@ public:
         }
     }
 
-    void loadFromString(const std::vector<char>& xmlContent) override {
-        ::pugi::xml_parse_result result = m_document.load_buffer(xmlContent.data(), xmlContent.size());
+    void loadFromBuffer(const char * data, size_t size) override {
+        ::pugi::xml_parse_result result = m_document.load_buffer(data, size);
         if (!result) {
             throw musx::xml::load_error(result.description());
         }

--- a/src/musx/xml/QtXmlImpl.h
+++ b/src/musx/xml/QtXmlImpl.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2025, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+
+#ifdef MUSX_USE_QTXML
+
+#include <QString>
+#include <QDomDocument>
+#include <QDomElement>
+#include <QDomAttr>
+#include <QByteArray>
+#include <memory>
+#include "XmlInterface.h"
+
+namespace musx {
+namespace xml {
+
+/**
+ * @namespace musx::xml::qt
+ * @brief Provides an implementation of #musx::xml::IXmlAttribute, #musx::xml::IXmlElement, and #musx::xml::IXmlDocument using Qt's QDom classes.
+ */
+namespace qt {
+
+/**
+ * @brief Implementation of IXmlAttribute using Qt's QDomAttr.
+ */
+class Attribute : public musx::xml::IXmlAttribute {
+    QDomAttr m_attr;
+    int m_index;
+
+public:
+    Attribute(const QDomAttr& attr, int index)
+        : m_attr(attr), m_index(index) {}
+
+    std::string getName() const override {
+        return m_attr.name().toStdString();
+    }
+
+    std::string getValue() const override {
+        return m_attr.value().toStdString();
+    }
+
+    std::shared_ptr<IXmlAttribute> nextAttribute() const override {
+        QDomNamedNodeMap attributes = m_attr.parentNode().attributes();
+        if (m_index + 1 >= attributes.count()) {
+            return nullptr;
+        }
+        QDomAttr nextAttr = attributes.item(m_index + 1).toAttr();
+        if (nextAttr.isNull()) { // [[unlikely]]
+            return nullptr;
+        }
+        return std::make_shared<Attribute>(nextAttr, m_index + 1);
+    }
+};
+
+/**
+ * @brief Implementation of IXmlElement using Qt's QDomElement.
+ */
+class Element : public musx::xml::IXmlElement {
+    const QDomElement m_element;
+
+public:
+    explicit Element(const QDomElement& elem) : m_element(elem) {}
+
+    std::string getTagName() const override { return m_element.tagName().toStdString(); }
+
+    std::string getText() const override { return m_element.text().toStdString(); }
+
+    std::shared_ptr<IXmlAttribute> getFirstAttribute() const override {
+        QDomNamedNodeMap attributes = m_element.attributes();
+        if (attributes.isEmpty()) {
+            return nullptr;
+        }
+        QDomAttr attr = attributes.item(0).toAttr();
+        if (attr.isNull()) { // [[unlikely]]
+            return nullptr;
+        }
+        return std::make_shared<Attribute>(attr, 0);
+    }
+    
+    std::shared_ptr<IXmlAttribute> findAttribute(const std::string& name) const override {
+        QDomAttr attr = m_element.attributeNode(QString::fromStdString(name));
+        return attr.isNull() ? nullptr : std::make_shared<Attribute>(attr);
+    }
+
+    std::shared_ptr<IXmlElement> getFirstChildElement(const std::string& tagName = {}) const override {
+        QDomNode child = tagName.empty()
+            ? m_element.firstChildElement()
+            : m_element.firstChildElement(QString::fromStdString(tagName));
+        return child.isNull() ? nullptr : std::make_shared<Element>(child.toElement());
+    }
+
+    std::shared_ptr<IXmlElement> getNextSibling(const std::string& tagName = {}) const override {
+        QDomNode sibling = m_element.nextSiblingElement(QString::fromStdString(tagName));
+        if (tagName.empty() && sibling.isNull()) {
+            sibling = m_element.nextSibling();
+            while (!sibling.isNull() && !sibling.isElement()) {
+                sibling = sibling.nextSibling();
+            }
+        }
+        return sibling.isNull() ? nullptr : std::make_shared<Element>(sibling.toElement());
+    }
+
+    std::shared_ptr<IXmlElement> getPreviousSibling(const std::string& tagName = {}) const override {
+        QDomNode sibling = m_element.previousSiblingElement(QString::fromStdString(tagName));
+        if (tagName.empty() && sibling.isNull()) {
+            sibling = m_element.previousSibling();
+            while (!sibling.isNull() && !sibling.isElement()) {
+                sibling = sibling.previousSibling();
+            }
+        }
+        return sibling.isNull() ? nullptr : std::make_shared<Element>(sibling.toElement());
+    }
+
+    std::shared_ptr<IXmlElement> getParent() const override {
+        QDomNode parent = m_element.parentNode();
+        return parent.isNull() || !parent.isElement() ? nullptr : std::make_shared<Element>(parent.toElement());
+    }
+};
+
+/**
+ * @brief Implementation of IXmlDocument using Qt's QDomDocument.
+ */
+class Document : public musx::xml::IXmlDocument {
+    QDomDocument m_document;
+
+public:
+    void loadFromString(const std::string& xmlContent) override {
+        QString errorMsg;
+        int errorLine = 0, errorColumn = 0;
+        if (!m_document.setContent(QString::fromUtf8(xmlContent.c_str()), &errorMsg, &errorLine, &errorColumn)) {
+            throw musx::xml::load_error("Error parsing XML at line " + std::to_string(errorLine) +
+                                        ", column " + std::to_string(errorColumn) + ": " + errorMsg.toStdString());
+        }
+    }
+
+    void loadFromString(const std::vector<char>& xmlContent) override {
+        QString errorMsg;
+        int errorLine = 0, errorColumn = 0;
+        if (!m_document.setContent(QByteArray(xmlContent.data(), xmlContent.size()), &errorMsg, &errorLine, &errorColumn)) {
+            throw musx::xml::load_error("Error parsing XML at line " + std::to_string(errorLine) +
+                                        ", column " + std::to_string(errorColumn) + ": " + errorMsg.toStdString());
+        }
+    }
+
+    std::shared_ptr<IXmlElement> getRootElement() const override {
+        QDomElement root = m_document.documentElement();
+        return root.isNull() ? nullptr : std::make_shared<Element>(root);
+    }
+};
+
+} // namespace qt
+} // namespace xml
+} // namespace musx
+
+#endif // MUSX_USE_QTXML

--- a/src/musx/xml/RapidXmlImpl.h
+++ b/src/musx/xml/RapidXmlImpl.h
@@ -95,8 +95,10 @@ public:
     }
 
     std::shared_ptr<IXmlAttribute> findAttribute(const std::string& tagName) const override {
-        ::rapidxml::xml_attribute<>* attr = m_element->first_attribute(tagName.c_str());
-        return attr ? std::make_shared<Attribute>(attr) : nullptr;
+        // work around Qt bug that attributeNode is not marked const
+        QDomElement& nonConstElement = const_cast<QDomElement&>(m_element);
+        QDomAttr attr = nonConstElement.attributeNode(QString::fromStdString(name));
+        return attr.isNull() ? nullptr : std::make_shared<Attribute>(attr, 0);
     }
 
     std::shared_ptr<IXmlElement> getFirstChildElement(const std::string& tagName = {}) const override {

--- a/src/musx/xml/TinyXmlImpl.h
+++ b/src/musx/xml/TinyXmlImpl.h
@@ -134,8 +134,8 @@ public:
         }
     }
 
-    void loadFromString(const std::vector<char>& xmlContent) override {
-        if (m_document.Parse(xmlContent.data(), xmlContent.size()) != ::tinyxml2::XML_SUCCESS) {
+    void loadFromBuffer(const char * data, size_t size) override {
+        if (m_document.Parse(data, size) != ::tinyxml2::XML_SUCCESS) {
             throw musx::xml::load_error(m_document.ErrorStr());
         }
     }

--- a/src/musx/xml/XmlInterface.h
+++ b/src/musx/xml/XmlInterface.h
@@ -233,7 +233,8 @@ public:
 
     /**
      * @brief Loads XML content from buffer
-     * @param xmlContent The XML content as a pointer and size.
+     * @param data pointer to the XML content.
+     * @param size size of the XML content.
      * @throws musx::xml::load_error if the load fails.
      */
     virtual void loadFromBuffer(const char * data, size_t size) = 0;

--- a/src/musx/xml/XmlInterface.h
+++ b/src/musx/xml/XmlInterface.h
@@ -232,6 +232,13 @@ public:
     virtual ~IXmlDocument() = default;
 
     /**
+     * @brief Loads XML content from buffer
+     * @param xmlContent The XML content as a pointer and size.
+     * @throws musx::xml::load_error if the load fails.
+     */
+    virtual void loadFromBuffer(const char * data, size_t size) = 0;
+
+    /**
      * @brief Loads XML content from a string.
      * @param xmlContent The XML content as a string.
      * @throws musx::xml::load_error if the load fails.
@@ -243,7 +250,10 @@ public:
      * @param xmlContent The XML content as a vector of characters.
      * @throws musx::xml::load_error if the load fails.
      */
-    virtual void loadFromString(const std::vector<char>& xmlContent) = 0;
+    void loadFromString(const std::vector<char>& xmlContent)
+    {
+        loadFromBuffer(xmlContent.data(), xmlContent.size());
+    }
 
     /**
      * @brief Gets the root element of the document.


### PR DESCRIPTION
- Added QtXmlImpl.h for using Qt's QDom as an xml reader
- fix various pedantic warnings
- fix various doxygen warnings in the comments
