### PR TITLE
Refactored to eliminate `forWrittenPitch`

### DIFF
--- a/src/musx/dom/Entries.h
+++ b/src/musx/dom/Entries.h
@@ -183,6 +183,15 @@ public:
         A = 5,
         B = 6
     };
+
+    /**
+     * @brief Note properites. A tuple containing:
+     *         - NoteName: The note name (C, D, E, F, G, A, B)
+     *         - int: The octave number (where 4 is the middle C octave)
+     *         - int: The actual alteration in EDO divisions (normally semitones), relative to natural
+     *         - int: The staff position of the note relative to the staff reference line. (For 5-line staves this is the top line.)
+     */
+    using NoteProperties = std::tuple<Note::NoteName, int, int, int>;
     
     int harmLev{};      ///< Diatonic displacement relative to middle C or to the tonic in the middle C octave (if the key signature tonic is not C).
     int harmAlt{};      ///< Chromatic alteration relative to the key signature. Never has a magnitude greater than +/-7.
@@ -233,17 +242,14 @@ public:
      * See #KeySignature::setTransposition for information about differences in key signature transposition.
      *
      * @param key The key signature in effect.
+     * @param ctx The key context (concert or written pitch).
      * @param clefIndex The index of the clef in effect.
      * @param staff If provided, the notes are transposed by any Chromatic Transposition specified for the staff. If
      * calling #calcNoteProperties for Concert Pitch (sounding pitch) values, omit this parameter.
      * @param respellEnharmonic If true, the notes are enharmonically respelled using the default enharmonic spelling.
-     * @return A tuple containing:
-     *         - NoteName: The note name (C, D, E, F, G, A, B)
-     *         - int: The octave number (where 4 is the middle C octave)
-     *         - int: The actual alteration in EDO divisions (normally semitones), relative to natural
-     *         - int: The staff position of the note relative to the staff reference line. (For 5-line staves this is the top line.)
+     * @return #NoteProperties
      */
-    std::tuple<NoteName, int, int, int> calcNoteProperties(const std::shared_ptr<KeySignature>& key, KeySignature::KeyContext ctx, ClefIndex clefIndex,
+    NoteProperties calcNoteProperties(const std::shared_ptr<KeySignature>& key, KeySignature::KeyContext ctx, ClefIndex clefIndex,
         const std::shared_ptr<const others::Staff>& staff = nullptr, bool respellEnharmonic = false) const;
 
     bool requireAllFields() const override { return false; }
@@ -871,25 +877,25 @@ public:
      * the staff position returned by #calcNoteProperties for whole rests.
      * @param enharmonicRespell If supplied, return the default enharmonic respelling based on this value. If omitted,
      * this value is calculated automatically based on the score or part settings. Normally you will omit it.
-     * @return A tuple containing:
-     *         - NoteName: The note name (C, D, E, F, G, A, B)
-     *         - int: The octave number (where 4 is the middle C octave)
-     *         - int: The actual alteration in EDO divisions (normally semitones), relative to natural
-     *         - int: The staff position of the note relative to the staff reference line. (For 5-line staves this is the top line.)
+     * @return #Note::NoteProperties
      */
-    std::tuple<Note::NoteName, int, int, int> calcNoteProperties(const std::optional<bool>& enharmonicRespell = std::nullopt) const;
+    Note::NoteProperties calcNoteProperties(const std::optional<bool>& enharmonicRespell = std::nullopt) const;
 
     /**
-     * @brief Calculates the note name, octave number, actual alteration, and staff position for the concert pitch of thenote. This function does
+     * @brief Calculates the note name, octave number, actual alteration, and staff position for the concert pitch of the note. This function does
      * not take into account percussion notes and their staff position override. To discover if a note is a percussion
      * note, call #calcPercussionNoteInfo. If it returns non-null, use that for staff position instead of this function.
-     * @return A tuple containing:
-     *         - NoteName: The note name (C, D, E, F, G, A, B)
-     *         - int: The octave number (where 4 is the middle C octave)
-     *         - int: The actual alteration in EDO divisions (normally semitones), relative to natural
-     *         - int: The staff position of the note relative to the staff reference line. (For 5-line staves this is the top line.)
+     * @return #Note::NoteProperties
      */
-    std::tuple<Note::NoteName, int, int, int> calcNotePropertiesConcert() const;
+    Note::NoteProperties calcNotePropertiesConcert() const;
+
+    /**
+     * @brief Calculates the note name, octave number, actual alteration, and staff position for the pitch of the note in view. This may be
+     * particularly useful with non-floating rests, but it can be used with any note. As with other versions of the function, it does not
+     * handle the staff position override of percussion notes.
+     * @return #Note::NoteProperties
+     */
+    Note::NoteProperties calcNotePropertiesInView() const;
 
     /// @brief Calculates the percussion note info for this note, if any.
     /// @return If the note is on a percussion staff and has percussion note info assigned, returns it. Otherwise `nullptr`.

--- a/src/musx/dom/Implementations.cpp
+++ b/src/musx/dom/Implementations.cpp
@@ -2424,7 +2424,7 @@ std::tuple<Note::NoteName, int, int, int> NoteInfoPtr::calcNotePropertiesConcert
         }
         return m_entry->clefIndexConcert;
     }();
-    return (*this)->calcNoteProperties(m_entry.getKeySignature(), KeySignature::KeyContext::Concert, m_entry->clefIndexConcert, nullptr, calcIsEnharmonicRespell());
+    return (*this)->calcNoteProperties(m_entry.getKeySignature(), KeySignature::KeyContext::Concert, clefIndex, nullptr, calcIsEnharmonicRespell());
 }
 
 std::shared_ptr<others::PercussionNoteInfo> NoteInfoPtr::calcPercussionNoteInfo() const

--- a/src/musx/dom/Implementations.cpp
+++ b/src/musx/dom/Implementations.cpp
@@ -2244,7 +2244,7 @@ std::pair<int, int> Note::calcDefaultEnharmonic(const std::shared_ptr<KeySignatu
     return {upDisp, upAlt};
 }
 
-std::tuple<Note::NoteName, int, int, int> Note::calcNoteProperties(const std::shared_ptr<KeySignature>& key, KeySignature::KeyContext ctx, ClefIndex clefIndex,
+Note::NoteProperties Note::calcNoteProperties(const std::shared_ptr<KeySignature>& key, KeySignature::KeyContext ctx, ClefIndex clefIndex,
     const std::shared_ptr<const others::Staff>& staff, bool respellEnharmonic) const
 {
     static constexpr std::array<Note::NoteName, music_theory::STANDARD_DIATONIC_STEPS> noteNames = {
@@ -2398,7 +2398,7 @@ InstCmper NoteInfoPtr::calcStaff() const
     return m_entry.getStaff();
 }
 
-std::tuple<Note::NoteName, int, int, int> NoteInfoPtr::calcNoteProperties(const std::optional<bool>& enharmonicRespell) const
+Note::NoteProperties NoteInfoPtr::calcNoteProperties(const std::optional<bool>& enharmonicRespell) const
 {
     InstCmper staffId = calcStaff();
     const ClefIndex clefIndex = [&]() {
@@ -2413,7 +2413,7 @@ std::tuple<Note::NoteName, int, int, int> NoteInfoPtr::calcNoteProperties(const 
             enharmonicRespell.value_or(calcIsEnharmonicRespell()));
 }
 
-std::tuple<Note::NoteName, int, int, int> NoteInfoPtr::calcNotePropertiesConcert() const
+Note::NoteProperties NoteInfoPtr::calcNotePropertiesConcert() const
 {
     const ClefIndex clefIndex = [&]() {
         InstCmper staffId = calcStaff();
@@ -2425,6 +2425,16 @@ std::tuple<Note::NoteName, int, int, int> NoteInfoPtr::calcNotePropertiesConcert
         return m_entry->clefIndexConcert;
     }();
     return (*this)->calcNoteProperties(m_entry.getKeySignature(), KeySignature::KeyContext::Concert, clefIndex, nullptr, calcIsEnharmonicRespell());
+}
+
+Note::NoteProperties NoteInfoPtr::calcNotePropertiesInView() const
+{
+    bool forWrittenPitch = false;
+    auto entryFrame = m_entry.getFrame();
+    if (auto partGlobals = entryFrame->getDocument()->getOthers()->get<others::PartGlobals>(entryFrame->getRequestedPartId(), MUSX_GLOBALS_CMPER)) {
+        forWrittenPitch = partGlobals->showTransposed;
+    }
+    return forWrittenPitch ? calcNoteProperties() : calcNotePropertiesConcert();
 }
 
 std::shared_ptr<others::PercussionNoteInfo> NoteInfoPtr::calcPercussionNoteInfo() const

--- a/src/musx/dom/Others.h
+++ b/src/musx/dom/Others.h
@@ -1063,9 +1063,8 @@ public:
 
     /// @brief Creates and returns a shared pointer to an instance of the @ref KeySignature for this measure and staff.
     /// @param forStaff If present, specifies the specific staff for which to create the key signature.
-    /// @param forWrittenPitch If @p forStaff is present, this value determines if the key signature is created for concert or written pitch.
     /// @return A shared pointer to a new instance of KeySignature. The caller may modify it (*e.g.*, for tranposition) without affecting the values in the document.
-    std::shared_ptr<KeySignature> createKeySignature(const std::optional<InstCmper>& forStaff = std::nullopt, bool forWrittenPitch = false) const;
+    std::shared_ptr<KeySignature> createKeySignature(const std::optional<InstCmper>& forStaff = std::nullopt) const;
 
     /// @brief Create a shared pointer to an instance of the @ref TimeSignature for this measure and staff.
     /// @param forStaff If present, specifies the specific staff for which to create the time signature.

--- a/tests/entries/keysigs.cpp
+++ b/tests/entries/keysigs.cpp
@@ -69,8 +69,8 @@ TEST(KeySigs, Test12EDO)
 
     for (size_t i = 0; i < expectedKeyAlters.size(); i++) {
         auto key = measures[i]->createKeySignature();
-        EXPECT_EQ(key->getAlteration(), expectedKeyAlters[i]);
-        EXPECT_EQ(key->calcTonalCenterIndex(), expectedIndices[i]);
+        EXPECT_EQ(key->getAlteration(KeySignature::KeyContext::Written), expectedKeyAlters[i]);
+        EXPECT_EQ(key->calcTonalCenterIndex(KeySignature::KeyContext::Written), expectedIndices[i]);
         EXPECT_EQ(key->calcDiatonicMode(), expectedModes[i]);
         EXPECT_EQ(key->calcKeyMap(), expectedKeyMaps[i]);
         if (auto keyMap = key->calcKeyMap()) {
@@ -84,7 +84,7 @@ TEST(KeySigs, Test12EDO)
             if (x >= expectedNotes.size()) return false;
             //ASSERT_GE(entryInfo->getEntry()->notes.size(), 1);
             auto note = entryInfo->getEntry()->notes[0];
-            auto [noteName, octave, alter, position] = note->calcNoteProperties(key, entryInfo->clefIndex);
+            auto [noteName, octave, alter, position] = note->calcNoteProperties(key, KeySignature::KeyContext::Written, entryInfo->clefIndex);
             EXPECT_EQ(expectedOctaves[x], octave);
             EXPECT_EQ(expectedAlters[x], alter);
             EXPECT_EQ(expectedPositions[x], position);
@@ -136,8 +136,8 @@ TEST(KeySigs, Test31EDO)
     for (size_t i = 0; i < expectedKeyAlters.size(); i++) {
         auto measure = measures[i + FIRST_31EDO_MEASURE_INDEX];
         auto key = measure->createKeySignature();
-        EXPECT_EQ(key->getAlteration(), expectedKeyAlters[i]);
-        EXPECT_EQ(key->calcTonalCenterIndex(), expectedIndices[i]);
+        EXPECT_EQ(key->getAlteration(KeySignature::KeyContext::Written), expectedKeyAlters[i]);
+        EXPECT_EQ(key->calcTonalCenterIndex(KeySignature::KeyContext::Written), expectedIndices[i]);
         EXPECT_EQ(key->calcDiatonicMode(), expectedModes[i]);
         EXPECT_EQ(key->calcKeyMap(), expectedKeyMaps[i]);
         if (auto keyMap = key->calcKeyMap()) {
@@ -151,7 +151,7 @@ TEST(KeySigs, Test31EDO)
             if (x >= expectedNotes.size()) return false;
             //ASSERT_GE(entryInfo->getEntry()->notes.size(), 1);
             auto note = entryInfo->getEntry()->notes[0];
-            auto [noteName, octave, alter, position] = note->calcNoteProperties(key, entryInfo->clefIndex);
+            auto [noteName, octave, alter, position] = note->calcNoteProperties(key,KeySignature::KeyContext::Written, entryInfo->clefIndex);
             EXPECT_EQ(expectedOctaves[x], octave);
             EXPECT_EQ(expectedAlters[x], alter);
             EXPECT_EQ(expectedPositions[x], position);

--- a/tests/others/staff.cpp
+++ b/tests/others/staff.cpp
@@ -402,20 +402,15 @@ TEST(StaffTest, Transposition)
         auto gfhold = details::GFrameHoldContext(doc, SCORE_PARTID, 1, measId);
         ASSERT_TRUE(gfhold);
 
-        auto writtenEntries = gfhold.createEntryFrame(0, true);
-        ASSERT_TRUE(writtenEntries);
-        ASSERT_GE(writtenEntries->getEntries().size(), 2);
-
-        auto concertEntries = gfhold.createEntryFrame(0, false);
-        ASSERT_TRUE(concertEntries);
-        ASSERT_GE(concertEntries->getEntries().size(), 2);
+        auto entries = gfhold.createEntryFrame(0);
+        ASSERT_TRUE(entries);
+        ASSERT_GE(entries->getEntries().size(), 2);
 
         for (size_t x = 0; x < 2; x++) {
-            auto writtenNote = NoteInfoPtr(EntryInfoPtr(writtenEntries, x), 0);
-            auto concertNote = NoteInfoPtr(EntryInfoPtr(concertEntries, x), 0);
+            auto note = NoteInfoPtr(EntryInfoPtr(entries, x), 0);
 
-            auto [wNote, wOctave, wAlter, wStaff] = writtenNote.calcNoteProperties();
-            auto [cNote, cOctave, cAlter, cStaff] = concertNote.calcNoteProperties();
+            auto [wNote, wOctave, wAlter, wStaff] = note.calcNoteProperties();
+            auto [cNote, cOctave, cAlter, cStaff] = note.calcNotePropertiesConcert();
 
             const auto& [expWNote, expWOct, expWAlt, expWStaff] = expectedWrittenResults[measId - 1][x];
             const auto& [expCNote, expCOct, expCAlt, expCStaff] = expectedConcertResult[x];
@@ -475,20 +470,15 @@ TEST(StaffTest, Transposition31Edo)
         auto gfhold = details::GFrameHoldContext(doc, SCORE_PARTID, 1, measId);
         ASSERT_TRUE(gfhold);
 
-        auto writtenEntries = gfhold.createEntryFrame(0, true);
-        ASSERT_TRUE(writtenEntries);
-        ASSERT_GE(writtenEntries->getEntries().size(), 2);
-
-        auto concertEntries = gfhold.createEntryFrame(0, false);
-        ASSERT_TRUE(concertEntries);
-        ASSERT_GE(concertEntries->getEntries().size(), 2);
+        auto entries = gfhold.createEntryFrame(0);
+        ASSERT_TRUE(entries);
+        ASSERT_GE(entries->getEntries().size(), 2);
 
         for (size_t x = 0; x < 2; x++) {
-            auto writtenNote = NoteInfoPtr(EntryInfoPtr(writtenEntries, x), 0);
-            auto concertNote = NoteInfoPtr(EntryInfoPtr(concertEntries, x), 0);
+            auto note = NoteInfoPtr(EntryInfoPtr(entries, x), 0);
 
-            auto [wNote, wOctave, wAlter, wStaff] = writtenNote.calcNoteProperties();
-            auto [cNote, cOctave, cAlter, cStaff] = concertNote.calcNoteProperties();
+            auto [wNote, wOctave, wAlter, wStaff] = note.calcNoteProperties();
+            auto [cNote, cOctave, cAlter, cStaff] = note.calcNotePropertiesConcert();
 
             const auto& [expWNote, expWOct, expWAlt, expWStaff] = expectedWrittenResults[measId - 1][x];
             const auto& [expCNote, expCOct, expCAlt, expCStaff] = expectedConcertResult[x];


### PR DESCRIPTION
Refactored createEntryFrame and KeySignature to eliminate the need for `forWrittenPitch` parameter