### PR TITLE
Add test maestro metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ set(MUSX_SRC_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/factory/FieldPopulatorsOthers.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/EnigmaString.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/Fraction.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/TestSupport.cpp
 )
 
 # Create a static library for the project

--- a/src/musx/dom/Implementations.cpp
+++ b/src/musx/dom/Implementations.cpp
@@ -1468,14 +1468,11 @@ bool FontInfo::calcIsSymbolFont() const
     throw std::invalid_argument("font definition not found for font id " + std::to_string(fontId));
 }
 
-#if defined(MUSX_TEST_DATA_PATH)
 std::vector<std::filesystem::path> FontInfo::calcSMuFLPaths()
 {
-    return { std::filesystem::path(MUSX_TEST_DATA_PATH) / "font_metadata" };
-}
-#else
-std::vector<std::filesystem::path> FontInfo::calcSMuFLPaths()
-{
+    if (const auto& testPath = util::TestConfiguration::getTestDataPath()) {
+        return { std::filesystem::path(testPath.value()) / "font_metadata" };
+    }
 #if defined(MUSX_RUNNING_ON_WINDOWS)
     auto systemEnv = "COMMONPROGRAMFILES";
     auto userEnv = "LOCALAPPDATA";
@@ -1565,7 +1562,6 @@ std::vector<std::filesystem::path> FontInfo::calcSMuFLPaths()
     }
     return retval;
 }
-#endif // !defined MUSX_TEST_DATA_PATH
 
 // *****************
 // ***** Frame *****

--- a/src/musx/dom/Implementations.cpp
+++ b/src/musx/dom/Implementations.cpp
@@ -1468,6 +1468,12 @@ bool FontInfo::calcIsSymbolFont() const
     throw std::invalid_argument("font definition not found for font id " + std::to_string(fontId));
 }
 
+#if defined(MUSX_TEST_DATA_PATH)
+std::vector<std::filesystem::path> FontInfo::calcSMuFLPaths()
+{
+    return { std::filesystem::path(MUSX_TEST_DATA_PATH) / "font_metadata" };
+}
+#else
 std::vector<std::filesystem::path> FontInfo::calcSMuFLPaths()
 {
 #if defined(MUSX_RUNNING_ON_WINDOWS)
@@ -1559,6 +1565,7 @@ std::vector<std::filesystem::path> FontInfo::calcSMuFLPaths()
     }
     return retval;
 }
+#endif // !defined MUSX_TEST_DATA_PATH
 
 // *****************
 // ***** Frame *****

--- a/src/musx/musx.h
+++ b/src/musx/musx.h
@@ -42,6 +42,7 @@
  * which are always silently skipped.
  * - `MUSX_THROW_ON_INTEGRITY_CHECK_FAIL`: Throws `musx::dom::integrity_error` if a class fails its integrity check.
  * Otherwise it it logs the message, which by default sends it to `std::cerr`.
+ * - `MUSX_TEST_DATA_PATH`: Specifies the data path for test files. Normally only used for CI builds on GitHub or on the local machines.
  *
  * The recommended way to define these macros is from your make file or build project. They are primarily intended
  * for debugging.

--- a/src/musx/musx.h
+++ b/src/musx/musx.h
@@ -42,7 +42,6 @@
  * which are always silently skipped.
  * - `MUSX_THROW_ON_INTEGRITY_CHECK_FAIL`: Throws `musx::dom::integrity_error` if a class fails its integrity check.
  * Otherwise it it logs the message, which by default sends it to `std::cerr`.
- * - `MUSX_TEST_DATA_PATH`: Specifies the data path for test files. Normally only used for CI builds on GitHub or on the local machines.
  *
  * The recommended way to define these macros is from your make file or build project. They are primarily intended
  * for debugging.
@@ -72,6 +71,7 @@
 #include "util/DateTimeFormat.h"
 #include "util/EnigmaString.h"
 #include "util/Logger.h"
+#include "util/TestSupport.h"
 #include "xml/XmlInterface.h"
 #include "dom/Document.h"
 #include "factory/DocumentFactory.h"

--- a/src/musx/util/TestSupport.cpp
+++ b/src/musx/util/TestSupport.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include "musx/util/TestSupport.h"
+
+namespace musx {
+namespace util {
+
+namespace {
+    struct TestConfigState {
+        std::optional<std::filesystem::path> testDataPath;
+        // Add future test config fields here
+    };
+
+    TestConfigState& state() {
+        static TestConfigState instance;
+        return instance;
+    }
+}
+
+void TestConfiguration::setTestDataPath(std::filesystem::path path) {
+    state().testDataPath = std::move(path);
+}
+
+const std::optional<std::filesystem::path>& TestConfiguration::getTestDataPath() {
+    return state().testDataPath;
+}
+
+} // namespace util
+} // namespace musx

--- a/src/musx/util/TestSupport.h
+++ b/src/musx/util/TestSupport.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+
+#include <string>
+#include <optional>
+#include <filesystem>
+
+namespace musx {
+namespace util {
+
+/// @class TestConfiguration
+/// @brief Provides access to test-specific configuration values (e.g., file paths).
+class TestConfiguration
+{
+public:
+    /// @brief Set the base path for test-only resources like SMuFL metadata files.
+    static void setTestDataPath(std::filesystem::path path);
+
+    /// @brief Get the test data path, if one has been set.
+    static const std::optional<std::filesystem::path>& getTestDataPath();
+
+    // Future test configuration accessors can be added here.
+};
+
+} // namespace util
+} // namespace musx

--- a/tests/data/font_metadata/Finale Maestro/Finale Maestro.json
+++ b/tests/data/font_metadata/Finale Maestro/Finale Maestro.json
@@ -1,0 +1,32059 @@
+{
+ "engravingDefaults": {
+  "arrowShaftThickness": 0.1, 
+  "barlineSeparation": 0.5, 
+  "beamSpacing": 0.25, 
+  "beamThickness": 0.5, 
+  "bracketThickness": 0.5, 
+  "dashedBarlineDashLength": 0.42, 
+  "dashedBarlineGapLength": 0.3, 
+  "dashedBarlineThickness": 0.08, 
+  "hairpinThickness": 0.1, 
+  "legerLineExtension": 0.25, 
+  "legerLineThickness": 0.11, 
+  "lyricLineThickness": 0.1, 
+  "octaveLineThickness": 0.1, 
+  "pedalLineThickness": 0.1, 
+  "repeatBarlineDotSeparation": 0.34, 
+  "repeatEndingLineThickness": 0.13, 
+  "slurEndpointThickness": 0.05, 
+  "slurMidpointThickness": 0.25, 
+  "staffLineThickness": 0.091, 
+  "stemThickness": 0.091, 
+  "subBracketThickness": 0.1, 
+  "textEnclosureThickness": 0.13,
+  "textFontFamily": [
+    "Finale Maestro Text",
+    "Times",
+    "serif"
+  ], 
+  "thickBarlineThickness": 0.5, 
+  "thinBarlineThickness": 0.1,
+  "thinThickBarlineSeparation": 0.5,
+  "tieEndpointThickness": 0.05, 
+  "tieMidpointThickness": 0.25, 
+  "tupletBracketThickness": 0.1
+ }, 
+ "fontName": "Finale Maestro", 
+ "fontVersion": 2.7, 
+ "glyphBBoxes": {
+  "4stringTabClef": {
+   "bBoxNE": [
+    1.136, 
+    2.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.08
+   ]
+  }, 
+  "4stringTabClefSerif": {
+   "bBoxNE": [
+    1.256, 
+    2.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.096
+   ]
+  }, 
+  "4stringTabClefTall": {
+   "bBoxNE": [
+    1.268, 
+    2.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.38
+   ]
+  }, 
+  "6stringTabClef": {
+   "bBoxNE": [
+    1.656, 
+    3.336
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.356
+   ]
+  }, 
+  "6stringTabClefSerif": {
+   "bBoxNE": [
+    1.96, 
+    3.344
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.364
+   ]
+  }, 
+  "6stringTabClefTall": {
+   "bBoxNE": [
+    2.14, 
+    4.016
+   ], 
+   "bBoxSW": [
+    -0.016, 
+    -3.976
+   ]
+  }, 
+  "U+F43F": {
+   "bBoxNE": [
+    1.78, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "U+F600": {
+   "bBoxNE": [
+    2.456, 
+    0.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.984
+   ]
+  }, 
+  "U+F601": {
+   "bBoxNE": [
+    1.864, 
+    0.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.984
+   ]
+  }, 
+  "U+F602": {
+   "bBoxNE": [
+    1.864, 
+    0.548
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F603": {
+   "bBoxNE": [
+    1.412, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F604": {
+   "bBoxNE": [
+    1.372, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "U+F605": {
+   "bBoxNE": [
+    1.412, 
+    3.604
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F606": {
+   "bBoxNE": [
+    1.412, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.624
+   ]
+  }, 
+  "U+F607": {
+   "bBoxNE": [
+    1.372, 
+    3.584
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "U+F608": {
+   "bBoxNE": [
+    1.372, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.524
+   ]
+  }, 
+  "U+F609": {
+   "bBoxNE": [
+    2.348, 
+    3.604
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "U+F60A": {
+   "bBoxNE": [
+    1.372, 
+    0.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.54
+   ]
+  }, 
+  "U+F60B": {
+   "bBoxNE": [
+    2.48, 
+    3.42
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "U+F60C": {
+   "bBoxNE": [
+    1.372, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.664
+   ]
+  }, 
+  "U+F610": {
+   "bBoxNE": [
+    0.88, 
+    1.128
+   ], 
+   "bBoxSW": [
+    0.024, 
+    -0.1
+   ]
+  }, 
+  "U+F611": {
+   "bBoxNE": [
+    1.14, 
+    0.576
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "U+F612": {
+   "bBoxNE": [
+    1.536, 
+    0.768
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.768
+   ]
+  }, 
+  "U+F613": {
+   "bBoxNE": [
+    1.04, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "U+F614": {
+   "bBoxNE": [
+    1.04, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "U+F615": {
+   "bBoxNE": [
+    1.04, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "U+F616": {
+   "bBoxNE": [
+    1.4, 
+    0.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "U+F617": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "U+F618": {
+   "bBoxNE": [
+    1.148, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.496
+   ]
+  }, 
+  "U+F619": {
+   "bBoxNE": [
+    1.148, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.532
+   ]
+  }, 
+  "U+F61A": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "U+F61B": {
+   "bBoxNE": [
+    1.26, 
+    0.468
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.468
+   ]
+  }, 
+  "U+F61C": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "U+F624": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "U+F625": {
+   "bBoxNE": [
+    1.132, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "U+F626": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "U+F627": {
+   "bBoxNE": [
+    1.092, 
+    0.548
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F628": {
+   "bBoxNE": [
+    1.324, 
+    0.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.844
+   ]
+  }, 
+  "U+F629": {
+   "bBoxNE": [
+    0.952, 
+    0.476
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.476
+   ]
+  }, 
+  "U+F62A": {
+   "bBoxNE": [
+    0.952, 
+    0.876
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.876
+   ]
+  }, 
+  "U+F62B": {
+   "bBoxNE": [
+    1.592, 
+    1.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.2
+   ]
+  }, 
+  "U+F62C": {
+   "bBoxNE": [
+    1.588, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.676
+   ]
+  }, 
+  "U+F62D": {
+   "bBoxNE": [
+    1.112, 
+    1.252
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.032
+   ]
+  }, 
+  "U+F62E": {
+   "bBoxNE": [
+    1.112, 
+    0.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.256
+   ]
+  }, 
+  "U+F62F": {
+   "bBoxNE": [
+    1.144, 
+    0.852
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.032
+   ]
+  }, 
+  "U+F630": {
+   "bBoxNE": [
+    1.588, 
+    1.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "U+F631": {
+   "bBoxNE": [
+    1.588, 
+    1.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "U+F632": {
+   "bBoxNE": [
+    1.588, 
+    1.22
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "U+F633": {
+   "bBoxNE": [
+    0.96, 
+    1.82
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.056
+   ]
+  }, 
+  "U+F634": {
+   "bBoxNE": [
+    1.352, 
+    1.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "U+F635": {
+   "bBoxNE": [
+    0.728, 
+    1.32
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    -0.004
+   ]
+  }, 
+  "U+F636": {
+   "bBoxNE": [
+    1.144, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.884
+   ]
+  }, 
+  "U+F670": {
+   "bBoxNE": [
+    1.272, 
+    1.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.428
+   ]
+  }, 
+  "U+F673": {
+   "bBoxNE": [
+    2.536, 
+    2.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "U+F674": {
+   "bBoxNE": [
+    2.536, 
+    2.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.012
+   ]
+  }, 
+  "U+F675": {
+   "bBoxNE": [
+    3.38, 
+    2.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "U+F676": {
+   "bBoxNE": [
+    1.46, 
+    1.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.616
+   ]
+  }, 
+  "U+F677": {
+   "bBoxNE": [
+    2.896, 
+    1.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.616
+   ]
+  }, 
+  "U+F678": {
+   "bBoxNE": [
+    2.868, 
+    1.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.616
+   ]
+  }, 
+  "U+F679": {
+   "bBoxNE": [
+    3.028, 
+    1.552
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.62
+   ]
+  }, 
+  "U+F67A": {
+   "bBoxNE": [
+    2.408, 
+    1.232
+   ], 
+   "bBoxSW": [
+    0.004, 
+    -0.648
+   ]
+  }, 
+  "U+F67B": {
+   "bBoxNE": [
+    4.272, 
+    1.232
+   ], 
+   "bBoxSW": [
+    0.004, 
+    -0.648
+   ]
+  }, 
+  "U+F67C": {
+   "bBoxNE": [
+    4.216, 
+    1.568
+   ], 
+   "bBoxSW": [
+    0.004, 
+    -0.652
+   ]
+  }, 
+  "U+F67D": {
+   "bBoxNE": [
+    3.068, 
+    1.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.648
+   ]
+  }, 
+  "U+F67E": {
+   "bBoxNE": [
+    5.176, 
+    1.192
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.644
+   ]
+  }, 
+  "U+F67F": {
+   "bBoxNE": [
+    5.068, 
+    1.576
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    -0.64
+   ]
+  }, 
+  "U+F680": {
+   "bBoxNE": [
+    0.64, 
+    0.392
+   ], 
+   "bBoxSW": [
+    -0.636, 
+    -0.392
+   ]
+  }, 
+  "U+F681": {
+   "bBoxNE": [
+    0.64, 
+    0.792
+   ], 
+   "bBoxSW": [
+    -0.636, 
+    -0.792
+   ]
+  }, 
+  "U+F682": {
+   "bBoxNE": [
+    0.64, 
+    1.192
+   ], 
+   "bBoxSW": [
+    -0.636, 
+    -1.192
+   ]
+  }, 
+  "U+F683": {
+   "bBoxNE": [
+    0.64, 
+    1.592
+   ], 
+   "bBoxSW": [
+    -0.636, 
+    -1.592
+   ]
+  }, 
+  "U+F684": {
+   "bBoxNE": [
+    0.64, 
+    1.992
+   ], 
+   "bBoxSW": [
+    -0.636, 
+    -1.992
+   ]
+  }, 
+  "U+F685": {
+   "bBoxNE": [
+    4.672, 
+    2.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.04
+   ]
+  }, 
+  "U+F686": {
+   "bBoxNE": [
+    4.684, 
+    2.544
+   ], 
+   "bBoxSW": [
+    0.012, 
+    -1.412
+   ]
+  }, 
+  "U+F687": {
+   "bBoxNE": [
+    1.716, 
+    2.952
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "U+F688": {
+   "bBoxNE": [
+    2.06, 
+    2.368
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.032
+   ]
+  }, 
+  "U+F689": {
+   "bBoxNE": [
+    2.38, 
+    0.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.98
+   ]
+  }, 
+  "U+F68A": {
+   "bBoxNE": [
+    1.78, 
+    0.992
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.98
+   ]
+  }, 
+  "U+F68C": {
+   "bBoxNE": [
+    2.784, 
+    1.58
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.504
+   ]
+  }, 
+  "U+F68D": {
+   "bBoxNE": [
+    2.652, 
+    1.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.848
+   ]
+  }, 
+  "U+F68E": {
+   "bBoxNE": [
+    2.768, 
+    1.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.66
+   ]
+  }, 
+  "U+F690": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F691": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F692": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F693": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F694": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F695": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F696": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F697": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F698": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F699": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F69A": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F69B": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F69C": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F69D": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F69E": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F69F": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F6A0": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F6A1": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F6A2": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6A3": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6A4": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6A5": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6A6": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6A7": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6A8": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6A9": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6AA": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6AB": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6AC": {
+   "bBoxNE": [
+    1.768, 
+    0.804
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6AD": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "U+F6AE": {
+   "bBoxNE": [
+    1.396, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "U+F6AF": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "U+F6B0": {
+   "bBoxNE": [
+    1.416, 
+    0.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "U+F700": {
+   "bBoxNE": [
+    0.56, 
+    2.368
+   ], 
+   "bBoxSW": [
+    0.036, 
+    -0.096
+   ]
+  }, 
+  "U+F701": {
+   "bBoxNE": [
+    1.188, 
+    0.096
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.384
+   ]
+  }, 
+  "U+F702": {
+   "bBoxNE": [
+    1.184, 
+    0.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.784
+   ]
+  }, 
+  "U+F703": {
+   "bBoxNE": [
+    1.188, 
+    0.328
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.58
+   ]
+  }, 
+  "U+F704": {
+   "bBoxNE": [
+    1.28, 
+    2.452
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.092
+   ]
+  }, 
+  "U+F705": {
+   "bBoxNE": [
+    1.276, 
+    3.508
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.448
+   ]
+  }, 
+  "U+F706": {
+   "bBoxNE": [
+    0.78, 
+    2.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.36
+   ]
+  }, 
+  "U+F707": {
+   "bBoxNE": [
+    0.78, 
+    0.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.16
+   ]
+  }, 
+  "U+F710": {
+   "bBoxNE": [
+    0.756, 
+    0.392
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.364
+   ]
+  }, 
+  "U+F714": {
+   "bBoxNE": [
+    1.228, 
+    1.24
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "U+F715": {
+   "bBoxNE": [
+    1.448, 
+    0.736
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.736
+   ]
+  }, 
+  "U+F716": {
+   "bBoxNE": [
+    1.616, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.012
+   ]
+  }, 
+  "U+F717": {
+   "bBoxNE": [
+    1.548, 
+    1.148
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.124
+   ]
+  }, 
+  "U+F718": {
+   "bBoxNE": [
+    1.46, 
+    1.3
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.736
+   ]
+  }, 
+  "U+F719": {
+   "bBoxNE": [
+    2.056, 
+    1.24
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.736
+   ]
+  }, 
+  "U+F720": {
+   "bBoxNE": [
+    2.22, 
+    3.32
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.636
+   ]
+  }, 
+  "U+F721": {
+   "bBoxNE": [
+    1.96, 
+    3.32
+   ], 
+   "bBoxSW": [
+    -0.144, 
+    -0.636
+   ]
+  }, 
+  "U+F722": {
+   "bBoxNE": [
+    0.692, 
+    3.32
+   ], 
+   "bBoxSW": [
+    -1.528, 
+    -0.636
+   ]
+  }, 
+  "U+F7C2": {
+   "bBoxNE": [
+    3.76, 
+    3.592
+   ], 
+   "bBoxSW": [
+    0.004, 
+    0.0
+   ]
+  }, 
+  "U+F7C3": {
+   "bBoxNE": [
+    2.956, 
+    3.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "U+F7E0": {
+   "bBoxNE": [
+    3.348, 
+    -0.828
+   ], 
+   "bBoxSW": [
+    0.116, 
+    -5.34
+   ]
+  }, 
+  "U+F7E1": {
+   "bBoxNE": [
+    0.468, 
+    3.636
+   ], 
+   "bBoxSW": [
+    -5.232, 
+    -5.34
+   ]
+  }, 
+  "U+F7E2": {
+   "bBoxNE": [
+    0.464, 
+    3.636
+   ], 
+   "bBoxSW": [
+    -2.016, 
+    -0.996
+   ]
+  }, 
+  "U+F7E3": {
+   "bBoxNE": [
+    2.968, 
+    -0.84
+   ], 
+   "bBoxSW": [
+    -0.032, 
+    -1.0
+   ]
+  }, 
+  "U+F7E4": {
+   "bBoxNE": [
+    4.204, 
+    3.556
+   ], 
+   "bBoxSW": [
+    -3.372, 
+    -0.996
+   ]
+  }, 
+  "U+F7E5": {
+   "bBoxNE": [
+    3.416, 
+    3.556
+   ], 
+   "bBoxSW": [
+    -0.132, 
+    3.396
+   ]
+  }, 
+  "U+F7E6": {
+   "bBoxNE": [
+    3.512, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.032, 
+    -1.28
+   ]
+  }, 
+  "U+F7E7": {
+   "bBoxNE": [
+    3.3, 
+    -0.012
+   ], 
+   "bBoxSW": [
+    -0.012, 
+    -1.312
+   ]
+  }, 
+  "U+F7E8": {
+   "bBoxNE": [
+    3.152, 
+    -0.132
+   ], 
+   "bBoxSW": [
+    -0.02, 
+    -1.312
+   ]
+  }, 
+  "U+F7E9": {
+   "bBoxNE": [
+    2.672, 
+    -0.132
+   ], 
+   "bBoxSW": [
+    -0.5, 
+    -1.312
+   ]
+  }, 
+  "U+F7EA": {
+   "bBoxNE": [
+    1.168, 
+    -1.152
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    -1.312
+   ]
+  }, 
+  "U+F7EB": {
+   "bBoxNE": [
+    3.708, 
+    3.124
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    -1.312
+   ]
+  }, 
+  "U+F7EC": {
+   "bBoxNE": [
+    3.216, 
+    3.124
+   ], 
+   "bBoxSW": [
+    -0.5, 
+    -1.312
+   ]
+  }, 
+  "U+F7ED": {
+   "bBoxNE": [
+    3.3, 
+    -0.012
+   ], 
+   "bBoxSW": [
+    -0.012, 
+    -1.312
+   ]
+  }, 
+  "U+F7EE": {
+   "bBoxNE": [
+    2.912, 
+    0.0
+   ], 
+   "bBoxSW": [
+    -0.568, 
+    -1.28
+   ]
+  }, 
+  "accSagittal11LargeDiesisDown": {
+   "bBoxNE": [
+    1.328, 
+    1.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittal11LargeDiesisUp": {
+   "bBoxNE": [
+    1.332, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.392
+   ]
+  }, 
+  "accSagittal11MediumDiesisDown": {
+   "bBoxNE": [
+    1.312, 
+    1.392
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.7
+   ]
+  }, 
+  "accSagittal11MediumDiesisUp": {
+   "bBoxNE": [
+    1.308, 
+    0.66
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.436
+   ]
+  }, 
+  "accSagittal11v19LargeDiesisDown": {
+   "bBoxNE": [
+    1.192, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittal11v19LargeDiesisUp": {
+   "bBoxNE": [
+    1.192, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittal11v19MediumDiesisDown": {
+   "bBoxNE": [
+    1.312, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittal11v19MediumDiesisUp": {
+   "bBoxNE": [
+    1.312, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittal11v49CommaDown": {
+   "bBoxNE": [
+    0.716, 
+    1.42
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accSagittal11v49CommaUp": {
+   "bBoxNE": [
+    0.716, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittal143CommaDown": {
+   "bBoxNE": [
+    0.608, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accSagittal143CommaUp": {
+   "bBoxNE": [
+    0.608, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittal17CommaDown": {
+   "bBoxNE": [
+    1.096, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.696
+   ]
+  }, 
+  "accSagittal17CommaUp": {
+   "bBoxNE": [
+    1.096, 
+    0.7
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittal17KleismaDown": {
+   "bBoxNE": [
+    0.596, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittal17KleismaUp": {
+   "bBoxNE": [
+    0.596, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittal19CommaDown": {
+   "bBoxNE": [
+    1.032, 
+    1.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.676
+   ]
+  }, 
+  "accSagittal19CommaUp": {
+   "bBoxNE": [
+    1.032, 
+    0.676
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittal19SchismaDown": {
+   "bBoxNE": [
+    0.48, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.676
+   ]
+  }, 
+  "accSagittal19SchismaUp": {
+   "bBoxNE": [
+    0.48, 
+    0.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.424
+   ]
+  }, 
+  "accSagittal23CommaDown": {
+   "bBoxNE": [
+    0.724, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittal23CommaUp": {
+   "bBoxNE": [
+    0.724, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittal23SmallDiesisDown": {
+   "bBoxNE": [
+    1.324, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.676
+   ]
+  }, 
+  "accSagittal23SmallDiesisUp": {
+   "bBoxNE": [
+    1.324, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittal25SmallDiesisDown": {
+   "bBoxNE": [
+    0.984, 
+    1.42
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.676
+   ]
+  }, 
+  "accSagittal25SmallDiesisUp": {
+   "bBoxNE": [
+    0.988, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.404
+   ]
+  }, 
+  "accSagittal35LargeDiesisDown": {
+   "bBoxNE": [
+    1.444, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittal35LargeDiesisUp": {
+   "bBoxNE": [
+    1.444, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "accSagittal35MediumDiesisDown": {
+   "bBoxNE": [
+    1.12, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittal35MediumDiesisUp": {
+   "bBoxNE": [
+    1.12, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "accSagittal49LargeDiesisDown": {
+   "bBoxNE": [
+    1.008, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accSagittal49LargeDiesisUp": {
+   "bBoxNE": [
+    1.004, 
+    0.784
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.348
+   ]
+  }, 
+  "accSagittal49MediumDiesisDown": {
+   "bBoxNE": [
+    0.972, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittal49MediumDiesisUp": {
+   "bBoxNE": [
+    0.972, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittal49SmallDiesisDown": {
+   "bBoxNE": [
+    1.084, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittal49SmallDiesisUp": {
+   "bBoxNE": [
+    1.08, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittal55CommaDown": {
+   "bBoxNE": [
+    0.832, 
+    1.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.756
+   ]
+  }, 
+  "accSagittal55CommaUp": {
+   "bBoxNE": [
+    0.836, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittal5CommaDown": {
+   "bBoxNE": [
+    0.62, 
+    1.412
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accSagittal5CommaUp": {
+   "bBoxNE": [
+    0.62, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.404
+   ]
+  }, 
+  "accSagittal5v11SmallDiesisDown": {
+   "bBoxNE": [
+    1.22, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittal5v11SmallDiesisUp": {
+   "bBoxNE": [
+    1.236, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittal5v13LargeDiesisDown": {
+   "bBoxNE": [
+    1.668, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittal5v13LargeDiesisUp": {
+   "bBoxNE": [
+    1.668, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.432
+   ]
+  }, 
+  "accSagittal5v13MediumDiesisDown": {
+   "bBoxNE": [
+    0.968, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittal5v13MediumDiesisUp": {
+   "bBoxNE": [
+    0.968, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.428
+   ]
+  }, 
+  "accSagittal5v19CommaDown": {
+   "bBoxNE": [
+    0.612, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittal5v19CommaUp": {
+   "bBoxNE": [
+    0.612, 
+    0.7
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittal5v23SmallDiesisDown": {
+   "bBoxNE": [
+    1.208, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.652
+   ]
+  }, 
+  "accSagittal5v23SmallDiesisUp": {
+   "bBoxNE": [
+    1.208, 
+    0.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittal5v49MediumDiesisDown": {
+   "bBoxNE": [
+    1.224, 
+    1.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.66
+   ]
+  }, 
+  "accSagittal5v49MediumDiesisUp": {
+   "bBoxNE": [
+    1.224, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.428
+   ]
+  }, 
+  "accSagittal5v7KleismaDown": {
+   "bBoxNE": [
+    0.612, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittal5v7KleismaUp": {
+   "bBoxNE": [
+    0.612, 
+    0.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittal7CommaDown": {
+   "bBoxNE": [
+    0.616, 
+    1.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittal7CommaUp": {
+   "bBoxNE": [
+    0.616, 
+    0.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "accSagittal7v11CommaDown": {
+   "bBoxNE": [
+    0.716, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittal7v11CommaUp": {
+   "bBoxNE": [
+    0.716, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittal7v11KleismaDown": {
+   "bBoxNE": [
+    0.848, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittal7v11KleismaUp": {
+   "bBoxNE": [
+    0.856, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittal7v19CommaDown": {
+   "bBoxNE": [
+    0.976, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.66
+   ]
+  }, 
+  "accSagittal7v19CommaUp": {
+   "bBoxNE": [
+    0.976, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalAcute": {
+   "bBoxNE": [
+    0.492, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.252
+   ]
+  }, 
+  "accSagittalDoubleFlat": {
+   "bBoxNE": [
+    1.804, 
+    1.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.66
+   ]
+  }, 
+  "accSagittalDoubleFlat11v49CUp": {
+   "bBoxNE": [
+    1.596, 
+    1.42
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accSagittalDoubleFlat143CUp": {
+   "bBoxNE": [
+    1.78, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittalDoubleFlat17CUp": {
+   "bBoxNE": [
+    1.656, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittalDoubleFlat17kUp": {
+   "bBoxNE": [
+    1.684, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittalDoubleFlat19CUp": {
+   "bBoxNE": [
+    1.568, 
+    1.468
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittalDoubleFlat19sUp": {
+   "bBoxNE": [
+    1.736, 
+    1.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalDoubleFlat23CUp": {
+   "bBoxNE": [
+    1.488, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittalDoubleFlat23SUp": {
+   "bBoxNE": [
+    1.452, 
+    1.448
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittalDoubleFlat25SUp": {
+   "bBoxNE": [
+    1.58, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accSagittalDoubleFlat49SUp": {
+   "bBoxNE": [
+    1.484, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittalDoubleFlat55CUp": {
+   "bBoxNE": [
+    1.404, 
+    1.464
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalDoubleFlat5CUp": {
+   "bBoxNE": [
+    1.612, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.7
+   ]
+  }, 
+  "accSagittalDoubleFlat5v11SUp": {
+   "bBoxNE": [
+    1.5, 
+    1.448
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittalDoubleFlat5v19CUp": {
+   "bBoxNE": [
+    1.408, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.676
+   ]
+  }, 
+  "accSagittalDoubleFlat5v23SUp": {
+   "bBoxNE": [
+    1.52, 
+    1.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittalDoubleFlat5v7kUp": {
+   "bBoxNE": [
+    1.576, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalDoubleFlat7CUp": {
+   "bBoxNE": [
+    1.472, 
+    1.448
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittalDoubleFlat7v11CUp": {
+   "bBoxNE": [
+    1.396, 
+    1.448
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittalDoubleFlat7v11kUp": {
+   "bBoxNE": [
+    1.684, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittalDoubleFlat7v19CUp": {
+   "bBoxNE": [
+    1.452, 
+    1.412
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.696
+   ]
+  }, 
+  "accSagittalDoubleSharp": {
+   "bBoxNE": [
+    1.792, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.46
+   ]
+  }, 
+  "accSagittalDoubleSharp11v49CDown": {
+   "bBoxNE": [
+    1.596, 
+    0.7
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.404
+   ]
+  }, 
+  "accSagittalDoubleSharp143CDown": {
+   "bBoxNE": [
+    1.78, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.432
+   ]
+  }, 
+  "accSagittalDoubleSharp17CDown": {
+   "bBoxNE": [
+    1.656, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalDoubleSharp17kDown": {
+   "bBoxNE": [
+    1.684, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.444
+   ]
+  }, 
+  "accSagittalDoubleSharp19CDown": {
+   "bBoxNE": [
+    1.568, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.436
+   ]
+  }, 
+  "accSagittalDoubleSharp19sDown": {
+   "bBoxNE": [
+    1.736, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalDoubleSharp23CDown": {
+   "bBoxNE": [
+    1.488, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittalDoubleSharp23SDown": {
+   "bBoxNE": [
+    1.452, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.428
+   ]
+  }, 
+  "accSagittalDoubleSharp25SDown": {
+   "bBoxNE": [
+    1.58, 
+    0.676
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.444
+   ]
+  }, 
+  "accSagittalDoubleSharp49SDown": {
+   "bBoxNE": [
+    1.484, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.432
+   ]
+  }, 
+  "accSagittalDoubleSharp55CDown": {
+   "bBoxNE": [
+    1.404, 
+    0.676
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.456
+   ]
+  }, 
+  "accSagittalDoubleSharp5CDown": {
+   "bBoxNE": [
+    1.58, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.424
+   ]
+  }, 
+  "accSagittalDoubleSharp5v11SDown": {
+   "bBoxNE": [
+    1.508, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.448
+   ]
+  }, 
+  "accSagittalDoubleSharp5v19CDown": {
+   "bBoxNE": [
+    1.408, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalDoubleSharp5v23SDown": {
+   "bBoxNE": [
+    1.52, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.432
+   ]
+  }, 
+  "accSagittalDoubleSharp5v7kDown": {
+   "bBoxNE": [
+    1.576, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalDoubleSharp7CDown": {
+   "bBoxNE": [
+    1.472, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.424
+   ]
+  }, 
+  "accSagittalDoubleSharp7v11CDown": {
+   "bBoxNE": [
+    1.396, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.44
+   ]
+  }, 
+  "accSagittalDoubleSharp7v11kDown": {
+   "bBoxNE": [
+    1.684, 
+    0.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.428
+   ]
+  }, 
+  "accSagittalDoubleSharp7v19CDown": {
+   "bBoxNE": [
+    1.452, 
+    0.704
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.404
+   ]
+  }, 
+  "accSagittalFlat": {
+   "bBoxNE": [
+    1.52, 
+    1.452
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.64
+   ]
+  }, 
+  "accSagittalFlat11LDown": {
+   "bBoxNE": [
+    1.772, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat11MDown": {
+   "bBoxNE": [
+    1.796, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittalFlat11v19LDown": {
+   "bBoxNE": [
+    1.664, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittalFlat11v19MDown": {
+   "bBoxNE": [
+    1.676, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat11v49CDown": {
+   "bBoxNE": [
+    1.212, 
+    1.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.692
+   ]
+  }, 
+  "accSagittalFlat11v49CUp": {
+   "bBoxNE": [
+    1.356, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat143CDown": {
+   "bBoxNE": [
+    1.208, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittalFlat143CUp": {
+   "bBoxNE": [
+    1.58, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittalFlat17CDown": {
+   "bBoxNE": [
+    1.544, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.692
+   ]
+  }, 
+  "accSagittalFlat17CUp": {
+   "bBoxNE": [
+    1.432, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat17kDown": {
+   "bBoxNE": [
+    1.244, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittalFlat17kUp": {
+   "bBoxNE": [
+    1.24, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat19CDown": {
+   "bBoxNE": [
+    1.492, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accSagittalFlat19CUp": {
+   "bBoxNE": [
+    1.112, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.66
+   ]
+  }, 
+  "accSagittalFlat19sDown": {
+   "bBoxNE": [
+    1.096, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittalFlat19sUp": {
+   "bBoxNE": [
+    1.568, 
+    1.448
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittalFlat23CDown": {
+   "bBoxNE": [
+    1.248, 
+    1.452
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.66
+   ]
+  }, 
+  "accSagittalFlat23CUp": {
+   "bBoxNE": [
+    1.384, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittalFlat23SDown": {
+   "bBoxNE": [
+    1.784, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.692
+   ]
+  }, 
+  "accSagittalFlat23SUp": {
+   "bBoxNE": [
+    0.94, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.676
+   ]
+  }, 
+  "accSagittalFlat25SDown": {
+   "bBoxNE": [
+    1.448, 
+    1.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accSagittalFlat25SUp": {
+   "bBoxNE": [
+    1.348, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittalFlat35LDown": {
+   "bBoxNE": [
+    1.932, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat35MDown": {
+   "bBoxNE": [
+    1.54, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat49LDown": {
+   "bBoxNE": [
+    1.548, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittalFlat49MDown": {
+   "bBoxNE": [
+    1.472, 
+    1.448
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittalFlat49SDown": {
+   "bBoxNE": [
+    1.572, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittalFlat49SUp": {
+   "bBoxNE": [
+    0.98, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittalFlat55CDown": {
+   "bBoxNE": [
+    1.28, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.704
+   ]
+  }, 
+  "accSagittalFlat55CUp": {
+   "bBoxNE": [
+    0.988, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.656
+   ]
+  }, 
+  "accSagittalFlat5CDown": {
+   "bBoxNE": [
+    1.204, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat5CUp": {
+   "bBoxNE": [
+    1.08, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat5v11SDown": {
+   "bBoxNE": [
+    1.596, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat5v11SUp": {
+   "bBoxNE": [
+    1.336, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat5v13LDown": {
+   "bBoxNE": [
+    1.932, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "accSagittalFlat5v13MDown": {
+   "bBoxNE": [
+    1.484, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.7
+   ]
+  }, 
+  "accSagittalFlat5v19CDown": {
+   "bBoxNE": [
+    1.192, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat5v19CUp": {
+   "bBoxNE": [
+    1.192, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittalFlat5v23SDown": {
+   "bBoxNE": [
+    1.504, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.644
+   ]
+  }, 
+  "accSagittalFlat5v23SUp": {
+   "bBoxNE": [
+    1.076, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat5v49MDown": {
+   "bBoxNE": [
+    1.832, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittalFlat5v7kDown": {
+   "bBoxNE": [
+    1.22, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.66
+   ]
+  }, 
+  "accSagittalFlat5v7kUp": {
+   "bBoxNE": [
+    1.296, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat7CDown": {
+   "bBoxNE": [
+    1.216, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.66
+   ]
+  }, 
+  "accSagittalFlat7CUp": {
+   "bBoxNE": [
+    0.948, 
+    1.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittalFlat7v11CDown": {
+   "bBoxNE": [
+    1.264, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.664
+   ]
+  }, 
+  "accSagittalFlat7v11CUp": {
+   "bBoxNE": [
+    1.308, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.68
+   ]
+  }, 
+  "accSagittalFlat7v11kDown": {
+   "bBoxNE": [
+    1.512, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.668
+   ]
+  }, 
+  "accSagittalFlat7v11kUp": {
+   "bBoxNE": [
+    1.144, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.66
+   ]
+  }, 
+  "accSagittalFlat7v19CDown": {
+   "bBoxNE": [
+    1.496, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accSagittalFlat7v19CUp": {
+   "bBoxNE": [
+    0.984, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.676
+   ]
+  }, 
+  "accSagittalGrave": {
+   "bBoxNE": [
+    0.492, 
+    0.252
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "accSagittalShaftDown": {
+   "bBoxNE": [
+    0.108, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "accSagittalShaftUp": {
+   "bBoxNE": [
+    0.108, 
+    0.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.436
+   ]
+  }, 
+  "accSagittalSharp": {
+   "bBoxNE": [
+    1.52, 
+    0.656
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.436
+   ]
+  }, 
+  "accSagittalSharp11LUp": {
+   "bBoxNE": [
+    1.772, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp11MUp": {
+   "bBoxNE": [
+    1.796, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "accSagittalSharp11v19LUp": {
+   "bBoxNE": [
+    1.664, 
+    0.704
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp11v19MUp": {
+   "bBoxNE": [
+    1.676, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp11v49CDown": {
+   "bBoxNE": [
+    1.356, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp11v49CUp": {
+   "bBoxNE": [
+    1.212, 
+    0.7
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "accSagittalSharp143CDown": {
+   "bBoxNE": [
+    1.58, 
+    0.7
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp143CUp": {
+   "bBoxNE": [
+    1.208, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "accSagittalSharp17CDown": {
+   "bBoxNE": [
+    1.432, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittalSharp17CUp": {
+   "bBoxNE": [
+    1.544, 
+    0.704
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp17kDown": {
+   "bBoxNE": [
+    1.24, 
+    0.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittalSharp17kUp": {
+   "bBoxNE": [
+    1.244, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.424
+   ]
+  }, 
+  "accSagittalSharp19CDown": {
+   "bBoxNE": [
+    1.112, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp19CUp": {
+   "bBoxNE": [
+    1.492, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp19sDown": {
+   "bBoxNE": [
+    1.568, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp19sUp": {
+   "bBoxNE": [
+    1.096, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp23CDown": {
+   "bBoxNE": [
+    1.384, 
+    0.676
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp23CUp": {
+   "bBoxNE": [
+    1.248, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp23SDown": {
+   "bBoxNE": [
+    0.94, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp23SUp": {
+   "bBoxNE": [
+    1.784, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "accSagittalSharp25SDown": {
+   "bBoxNE": [
+    1.344, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittalSharp25SUp": {
+   "bBoxNE": [
+    1.452, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittalSharp35LUp": {
+   "bBoxNE": [
+    1.928, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp35MUp": {
+   "bBoxNE": [
+    1.544, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.4
+   ]
+  }, 
+  "accSagittalSharp49LUp": {
+   "bBoxNE": [
+    1.548, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.44
+   ]
+  }, 
+  "accSagittalSharp49MUp": {
+   "bBoxNE": [
+    1.472, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp49SDown": {
+   "bBoxNE": [
+    0.98, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp49SUp": {
+   "bBoxNE": [
+    1.572, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp55CDown": {
+   "bBoxNE": [
+    0.988, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.404
+   ]
+  }, 
+  "accSagittalSharp55CUp": {
+   "bBoxNE": [
+    1.276, 
+    0.7
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittalSharp5CDown": {
+   "bBoxNE": [
+    1.084, 
+    0.704
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.392
+   ]
+  }, 
+  "accSagittalSharp5CUp": {
+   "bBoxNE": [
+    1.208, 
+    0.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp5v11SDown": {
+   "bBoxNE": [
+    1.336, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.424
+   ]
+  }, 
+  "accSagittalSharp5v11SUp": {
+   "bBoxNE": [
+    1.604, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp5v13LUp": {
+   "bBoxNE": [
+    1.932, 
+    0.704
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "accSagittalSharp5v13MUp": {
+   "bBoxNE": [
+    1.484, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.428
+   ]
+  }, 
+  "accSagittalSharp5v19CDown": {
+   "bBoxNE": [
+    1.192, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp5v19CUp": {
+   "bBoxNE": [
+    1.192, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp5v23SDown": {
+   "bBoxNE": [
+    1.076, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp5v23SUp": {
+   "bBoxNE": [
+    1.504, 
+    0.664
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.424
+   ]
+  }, 
+  "accSagittalSharp5v49MUp": {
+   "bBoxNE": [
+    1.832, 
+    0.704
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp5v7kDown": {
+   "bBoxNE": [
+    1.296, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "accSagittalSharp5v7kUp": {
+   "bBoxNE": [
+    1.22, 
+    0.676
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.42
+   ]
+  }, 
+  "accSagittalSharp7CDown": {
+   "bBoxNE": [
+    0.948, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.392
+   ]
+  }, 
+  "accSagittalSharp7CUp": {
+   "bBoxNE": [
+    1.22, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.392
+   ]
+  }, 
+  "accSagittalSharp7v11CDown": {
+   "bBoxNE": [
+    1.308, 
+    0.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp7v11CUp": {
+   "bBoxNE": [
+    1.264, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittalSharp7v11kDown": {
+   "bBoxNE": [
+    1.14, 
+    0.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accSagittalSharp7v11kUp": {
+   "bBoxNE": [
+    1.512, 
+    0.668
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accSagittalSharp7v19CDown": {
+   "bBoxNE": [
+    0.984, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.424
+   ]
+  }, 
+  "accSagittalSharp7v19CUp": {
+   "bBoxNE": [
+    1.496, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.416
+   ]
+  }, 
+  "accdnCombDot": {
+   "bBoxNE": [
+    0.584, 
+    0.584
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnCombLH2RanksEmpty": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnCombLH3RanksEmptySquare": {
+   "bBoxNE": [
+    2.756, 
+    3.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnCombRH3RanksEmpty": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnCombRH4RanksEmpty": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnDiatonicClef": {
+   "bBoxNE": [
+    1.16, 
+    1.884
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.92
+   ]
+  }, 
+  "accdnLH2Ranks16Round": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH2Ranks8Plus16Round": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH2Ranks8Round": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH2RanksFullMasterRound": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH2RanksMasterPlus16Round": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH2RanksMasterRound": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH3Ranks2Plus8Square": {
+   "bBoxNE": [
+    2.756, 
+    3.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH3Ranks2Square": {
+   "bBoxNE": [
+    2.756, 
+    3.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH3Ranks8Square": {
+   "bBoxNE": [
+    2.756, 
+    3.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH3RanksDouble8Square": {
+   "bBoxNE": [
+    2.756, 
+    3.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnLH3RanksTuttiSquare": {
+   "bBoxNE": [
+    2.756, 
+    3.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnPull": {
+   "bBoxNE": [
+    0.648, 
+    2.096
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnPush": {
+   "bBoxNE": [
+    0.912, 
+    2.304
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnPushAlt": {
+   "bBoxNE": [
+    0.86, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "accdnRH3RanksAccordion": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksAuthenticMusette": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksBandoneon": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksBassoon": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksClarinet": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksDoubleTremoloLower8ve": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksDoubleTremoloUpper8ve": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksFullFactory": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksHarmonium": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksImitationMusette": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksLowerTremolo8": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksMaster": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksOboe": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksOrgan": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksPiccolo": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksTremoloLower8ve": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksTremoloUpper8ve": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksTwoChoirs": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksUpperTremolo8": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH3RanksViolin": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH4RanksAlto": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH4RanksBassAlto": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH4RanksMaster": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH4RanksSoftBass": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH4RanksSoftTenor": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH4RanksSoprano": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRH4RanksTenor": {
+   "bBoxNE": [
+    3.564, 
+    3.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRicochet2": {
+   "bBoxNE": [
+    1.544, 
+    2.452
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRicochet3": {
+   "bBoxNE": [
+    1.664, 
+    2.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRicochet4": {
+   "bBoxNE": [
+    2.344, 
+    2.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRicochet5": {
+   "bBoxNE": [
+    2.852, 
+    2.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRicochet6": {
+   "bBoxNE": [
+    3.46, 
+    2.464
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "accdnRicochetStem2": {
+   "bBoxNE": [
+    0.844, 
+    0.408
+   ], 
+   "bBoxSW": [
+    -0.84, 
+    -0.408
+   ]
+  }, 
+  "accdnRicochetStem3": {
+   "bBoxNE": [
+    0.844, 
+    0.58
+   ], 
+   "bBoxSW": [
+    -0.84, 
+    -0.58
+   ]
+  }, 
+  "accdnRicochetStem4": {
+   "bBoxNE": [
+    0.844, 
+    0.748
+   ], 
+   "bBoxSW": [
+    -0.84, 
+    -0.748
+   ]
+  }, 
+  "accdnRicochetStem5": {
+   "bBoxNE": [
+    0.844, 
+    0.92
+   ], 
+   "bBoxSW": [
+    -0.84, 
+    -0.916
+   ]
+  }, 
+  "accdnRicochetStem6": {
+   "bBoxNE": [
+    0.844, 
+    1.088
+   ], 
+   "bBoxSW": [
+    -0.84, 
+    -1.088
+   ]
+  }, 
+  "accidental1CommaFlat": {
+   "bBoxNE": [
+    0.84, 
+    2.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidental1CommaSharp": {
+   "bBoxNE": [
+    1.364, 
+    2.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.352
+   ]
+  }, 
+  "accidental2CommaFlat": {
+   "bBoxNE": [
+    0.976, 
+    2.204
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidental2CommaSharp": {
+   "bBoxNE": [
+    1.596, 
+    2.192
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.352
+   ]
+  }, 
+  "accidental3CommaFlat": {
+   "bBoxNE": [
+    0.944, 
+    2.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidental3CommaSharp": {
+   "bBoxNE": [
+    1.556, 
+    2.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.352
+   ]
+  }, 
+  "accidental4CommaFlat": {
+   "bBoxNE": [
+    0.924, 
+    2.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidental5CommaSharp": {
+   "bBoxNE": [
+    1.584, 
+    2.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.352
+   ]
+  }, 
+  "accidentalArrowDown": {
+   "bBoxNE": [
+    0.8, 
+    1.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "accidentalArrowUp": {
+   "bBoxNE": [
+    0.8, 
+    1.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "accidentalBakiyeFlat": {
+   "bBoxNE": [
+    1.128, 
+    1.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.636
+   ]
+  }, 
+  "accidentalBakiyeSharp": {
+   "bBoxNE": [
+    0.952, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.352
+   ]
+  }, 
+  "accidentalBracketLeft": {
+   "bBoxNE": [
+    0.308, 
+    0.792
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.792
+   ]
+  }, 
+  "accidentalBracketRight": {
+   "bBoxNE": [
+    0.308, 
+    0.792
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.792
+   ]
+  }, 
+  "accidentalBuyukMucennebFlat": {
+   "bBoxNE": [
+    1.128, 
+    1.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.636
+   ]
+  }, 
+  "accidentalBuyukMucennebSharp": {
+   "bBoxNE": [
+    1.4, 
+    1.452
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.384
+   ]
+  }, 
+  "accidentalCombiningCloseCurlyBrace": {
+   "bBoxNE": [
+    0.424, 
+    1.308
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.452
+   ]
+  }, 
+  "accidentalCombiningLower17Schisma": {
+   "bBoxNE": [
+    0.764, 
+    0.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.72
+   ]
+  }, 
+  "accidentalCombiningLower19Schisma": {
+   "bBoxNE": [
+    0.764, 
+    0.408
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.404
+   ]
+  }, 
+  "accidentalCombiningLower23Limit29LimitComma": {
+   "bBoxNE": [
+    0.984, 
+    1.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "accidentalCombiningLower31Schisma": {
+   "bBoxNE": [
+    1.152, 
+    0.328
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.172
+   ]
+  }, 
+  "accidentalCombiningLower53LimitComma": {
+   "bBoxNE": [
+    0.764, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.028
+   ]
+  }, 
+  "accidentalCombiningOpenCurlyBrace": {
+   "bBoxNE": [
+    0.424, 
+    1.308
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.452
+   ]
+  }, 
+  "accidentalCombiningRaise17Schisma": {
+   "bBoxNE": [
+    0.764, 
+    0.72
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.716
+   ]
+  }, 
+  "accidentalCombiningRaise19Schisma": {
+   "bBoxNE": [
+    0.764, 
+    0.408
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.404
+   ]
+  }, 
+  "accidentalCombiningRaise23Limit29LimitComma": {
+   "bBoxNE": [
+    0.984, 
+    0.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.012
+   ]
+  }, 
+  "accidentalCombiningRaise31Schisma": {
+   "bBoxNE": [
+    1.152, 
+    0.824
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.328
+   ]
+  }, 
+  "accidentalCombiningRaise53LimitComma": {
+   "bBoxNE": [
+    0.764, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.028
+   ]
+  }, 
+  "accidentalCommaSlashDown": {
+   "bBoxNE": [
+    1.136, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.504
+   ]
+  }, 
+  "accidentalCommaSlashUp": {
+   "bBoxNE": [
+    1.136, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.504
+   ]
+  }, 
+  "accidentalDoubleFlat": {
+   "bBoxNE": [
+    1.74, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalDoubleFlatEqualTempered": {
+   "bBoxNE": [
+    1.74, 
+    1.78
+   ], 
+   "bBoxSW": [
+    -0.388, 
+    -0.632
+   ]
+  }, 
+  "accidentalDoubleFlatJoinedStems": {
+   "bBoxNE": [
+    1.568, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalDoubleFlatOneArrowDown": {
+   "bBoxNE": [
+    1.74, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.36
+   ]
+  }, 
+  "accidentalDoubleFlatOneArrowUp": {
+   "bBoxNE": [
+    1.74, 
+    2.22
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -0.632
+   ]
+  }, 
+  "accidentalDoubleFlatParens": {
+   "bBoxNE": [
+    2.552, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.852
+   ]
+  }, 
+  "accidentalDoubleFlatReversed": {
+   "bBoxNE": [
+    1.74, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalDoubleFlatThreeArrowsDown": {
+   "bBoxNE": [
+    1.74, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.288
+   ]
+  }, 
+  "accidentalDoubleFlatThreeArrowsUp": {
+   "bBoxNE": [
+    1.74, 
+    3.232
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -0.632
+   ]
+  }, 
+  "accidentalDoubleFlatTurned": {
+   "bBoxNE": [
+    1.74, 
+    0.668
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.696
+   ]
+  }, 
+  "accidentalDoubleFlatTwoArrowsDown": {
+   "bBoxNE": [
+    1.74, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.828
+   ]
+  }, 
+  "accidentalDoubleFlatTwoArrowsUp": {
+   "bBoxNE": [
+    1.74, 
+    2.732
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -0.632
+   ]
+  }, 
+  "accidentalDoubleSharp": {
+   "bBoxNE": [
+    1.008, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.488
+   ]
+  }, 
+  "accidentalDoubleSharpEqualTempered": {
+   "bBoxNE": [
+    1.008, 
+    1.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.488
+   ]
+  }, 
+  "accidentalDoubleSharpOneArrowDown": {
+   "bBoxNE": [
+    1.008, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.396
+   ]
+  }, 
+  "accidentalDoubleSharpOneArrowUp": {
+   "bBoxNE": [
+    1.008, 
+    1.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.488
+   ]
+  }, 
+  "accidentalDoubleSharpParens": {
+   "bBoxNE": [
+    1.8, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.852
+   ]
+  }, 
+  "accidentalDoubleSharpThreeArrowsDown": {
+   "bBoxNE": [
+    1.008, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.336
+   ]
+  }, 
+  "accidentalDoubleSharpThreeArrowsUp": {
+   "bBoxNE": [
+    1.008, 
+    2.316
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.488
+   ]
+  }, 
+  "accidentalDoubleSharpTwoArrowsDown": {
+   "bBoxNE": [
+    1.008, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.868
+   ]
+  }, 
+  "accidentalDoubleSharpTwoArrowsUp": {
+   "bBoxNE": [
+    1.008, 
+    1.864
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.488
+   ]
+  }, 
+  "accidentalEnharmonicAlmostEqualTo": {
+   "bBoxNE": [
+    1.688, 
+    0.64
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.64
+   ]
+  }, 
+  "accidentalEnharmonicEquals": {
+   "bBoxNE": [
+    1.692, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "accidentalEnharmonicTilde": {
+   "bBoxNE": [
+    1.688, 
+    0.336
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.344
+   ]
+  }, 
+  "accidentalFilledReversedFlatAndFlat": {
+   "bBoxNE": [
+    1.576, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.624
+   ]
+  }, 
+  "accidentalFilledReversedFlatAndFlatArrowDown": {
+   "bBoxNE": [
+    1.576, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.668
+   ]
+  }, 
+  "accidentalFilledReversedFlatAndFlatArrowUp": {
+   "bBoxNE": [
+    1.576, 
+    1.968
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.624
+   ]
+  }, 
+  "accidentalFilledReversedFlatArrowDown": {
+   "bBoxNE": [
+    1.18, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.556
+   ]
+  }, 
+  "accidentalFilledReversedFlatArrowUp": {
+   "bBoxNE": [
+    1.192, 
+    2.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalFiveQuarterTonesFlatArrowDown": {
+   "bBoxNE": [
+    1.74, 
+    1.732
+   ], 
+   "bBoxSW": [
+    -0.216, 
+    -1.484
+   ]
+  }, 
+  "accidentalFiveQuarterTonesSharpArrowUp": {
+   "bBoxNE": [
+    1.232, 
+    1.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.488
+   ]
+  }, 
+  "accidentalFlat": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalFlatEqualTempered": {
+   "bBoxNE": [
+    0.84, 
+    1.78
+   ], 
+   "bBoxSW": [
+    -0.388, 
+    -0.632
+   ]
+  }, 
+  "accidentalFlatJohnstonDown": {
+   "bBoxNE": [
+    1.148, 
+    1.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.264
+   ]
+  }, 
+  "accidentalFlatJohnstonEl": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.204
+   ]
+  }, 
+  "accidentalFlatJohnstonElDown": {
+   "bBoxNE": [
+    1.144, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.764
+   ]
+  }, 
+  "accidentalFlatJohnstonUp": {
+   "bBoxNE": [
+    1.148, 
+    1.748
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalFlatJohnstonUpEl": {
+   "bBoxNE": [
+    1.148, 
+    1.748
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.204
+   ]
+  }, 
+  "accidentalFlatOneArrowDown": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -1.36
+   ]
+  }, 
+  "accidentalFlatOneArrowUp": {
+   "bBoxNE": [
+    0.84, 
+    2.22
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -0.632
+   ]
+  }, 
+  "accidentalFlatParens": {
+   "bBoxNE": [
+    1.728, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.852
+   ]
+  }, 
+  "accidentalFlatSmall": {
+   "bBoxNE": [
+    0.556, 
+    1.148
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.396
+   ]
+  }, 
+  "accidentalFlatThreeArrowsDown": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -2.292
+   ]
+  }, 
+  "accidentalFlatThreeArrowsUp": {
+   "bBoxNE": [
+    0.84, 
+    3.232
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -0.632
+   ]
+  }, 
+  "accidentalFlatTurned": {
+   "bBoxNE": [
+    0.84, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.668
+   ]
+  }, 
+  "accidentalFlatTwoArrowsDown": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -1.828
+   ]
+  }, 
+  "accidentalFlatTwoArrowsUp": {
+   "bBoxNE": [
+    0.84, 
+    2.732
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -0.632
+   ]
+  }, 
+  "accidentalHalfSharpArrowDown": {
+   "bBoxNE": [
+    0.952, 
+    1.26
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.116
+   ]
+  }, 
+  "accidentalHalfSharpArrowUp": {
+   "bBoxNE": [
+    0.952, 
+    2.104
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.316
+   ]
+  }, 
+  "accidentalJohnston13": {
+   "bBoxNE": [
+    0.712, 
+    0.364
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.372
+   ]
+  }, 
+  "accidentalJohnston31": {
+   "bBoxNE": [
+    0.752, 
+    0.364
+   ], 
+   "bBoxSW": [
+    0.04, 
+    -0.372
+   ]
+  }, 
+  "accidentalJohnstonDown": {
+   "bBoxNE": [
+    0.72, 
+    0.576
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "accidentalJohnstonDownEl": {
+   "bBoxNE": [
+    0.864, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.732
+   ]
+  }, 
+  "accidentalJohnstonEl": {
+   "bBoxNE": [
+    0.488, 
+    0.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.708
+   ]
+  }, 
+  "accidentalJohnstonMinus": {
+   "bBoxNE": [
+    0.772, 
+    0.052
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.052
+   ]
+  }, 
+  "accidentalJohnstonPlus": {
+   "bBoxNE": [
+    0.772, 
+    0.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.384
+   ]
+  }, 
+  "accidentalJohnstonSeven": {
+   "bBoxNE": [
+    0.488, 
+    0.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.484
+   ]
+  }, 
+  "accidentalJohnstonSevenDown": {
+   "bBoxNE": [
+    0.864, 
+    1.22
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.22
+   ]
+  }, 
+  "accidentalJohnstonSevenFlat": {
+   "bBoxNE": [
+    1.224, 
+    1.712
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalJohnstonSevenFlatDown": {
+   "bBoxNE": [
+    1.224, 
+    1.736
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.212
+   ]
+  }, 
+  "accidentalJohnstonSevenFlatUp": {
+   "bBoxNE": [
+    1.224, 
+    1.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalJohnstonSevenSharp": {
+   "bBoxNE": [
+    1.18, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalJohnstonSevenSharpDown": {
+   "bBoxNE": [
+    1.308, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.8
+   ]
+  }, 
+  "accidentalJohnstonSevenSharpUp": {
+   "bBoxNE": [
+    1.308, 
+    1.792
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalJohnstonSevenUp": {
+   "bBoxNE": [
+    0.864, 
+    0.72
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.012
+   ]
+  }, 
+  "accidentalJohnstonUp": {
+   "bBoxNE": [
+    0.72, 
+    0.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.48
+   ]
+  }, 
+  "accidentalJohnstonUpEl": {
+   "bBoxNE": [
+    0.864, 
+    1.22
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.22
+   ]
+  }, 
+  "accidentalKomaFlat": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalKomaSharp": {
+   "bBoxNE": [
+    0.676, 
+    1.356
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.32
+   ]
+  }, 
+  "accidentalKoron": {
+   "bBoxNE": [
+    1.34, 
+    0.72
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.668
+   ]
+  }, 
+  "accidentalKucukMucennebFlat": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalKucukMucennebSharp": {
+   "bBoxNE": [
+    0.944, 
+    1.356
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.32
+   ]
+  }, 
+  "accidentalLargeDoubleSharp": {
+   "bBoxNE": [
+    1.368, 
+    0.684
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.684
+   ]
+  }, 
+  "accidentalLowerOneSeptimalComma": {
+   "bBoxNE": [
+    0.628, 
+    1.656
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.416
+   ]
+  }, 
+  "accidentalLowerOneTridecimalQuartertone": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalLowerOneUndecimalQuartertone": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalLowerTwoSeptimalCommas": {
+   "bBoxNE": [
+    0.628, 
+    1.592
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.104
+   ]
+  }, 
+  "accidentalNarrowReversedFlat": {
+   "bBoxNE": [
+    0.656, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalNarrowReversedFlatAndFlat": {
+   "bBoxNE": [
+    1.6, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalNatural": {
+   "bBoxNE": [
+    0.66, 
+    1.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.5
+   ]
+  }, 
+  "accidentalNaturalEqualTempered": {
+   "bBoxNE": [
+    0.66, 
+    1.58
+   ], 
+   "bBoxSW": [
+    -0.388, 
+    -1.5
+   ]
+  }, 
+  "accidentalNaturalFlat": {
+   "bBoxNE": [
+    1.72, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.5
+   ]
+  }, 
+  "accidentalNaturalOneArrowDown": {
+   "bBoxNE": [
+    1.008, 
+    1.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.78
+   ]
+  }, 
+  "accidentalNaturalOneArrowUp": {
+   "bBoxNE": [
+    0.66, 
+    1.9
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -1.528
+   ]
+  }, 
+  "accidentalNaturalParens": {
+   "bBoxNE": [
+    1.728, 
+    1.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.5
+   ]
+  }, 
+  "accidentalNaturalReversed": {
+   "bBoxNE": [
+    0.66, 
+    1.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.5
+   ]
+  }, 
+  "accidentalNaturalSharp": {
+   "bBoxNE": [
+    1.72, 
+    1.448
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.5
+   ]
+  }, 
+  "accidentalNaturalSmall": {
+   "bBoxNE": [
+    0.476, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.988
+   ]
+  }, 
+  "accidentalNaturalThreeArrowsDown": {
+   "bBoxNE": [
+    1.008, 
+    1.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.728
+   ]
+  }, 
+  "accidentalNaturalThreeArrowsUp": {
+   "bBoxNE": [
+    0.66, 
+    2.872
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -1.528
+   ]
+  }, 
+  "accidentalNaturalTwoArrowsDown": {
+   "bBoxNE": [
+    1.008, 
+    1.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.256
+   ]
+  }, 
+  "accidentalNaturalTwoArrowsUp": {
+   "bBoxNE": [
+    0.66, 
+    2.312
+   ], 
+   "bBoxSW": [
+    -0.348, 
+    -1.528
+   ]
+  }, 
+  "accidentalOneAndAHalfSharpsArrowDown": {
+   "bBoxNE": [
+    1.252, 
+    1.44
+   ], 
+   "bBoxSW": [
+    -0.22, 
+    -2.28
+   ]
+  }, 
+  "accidentalOneAndAHalfSharpsArrowUp": {
+   "bBoxNE": [
+    1.472, 
+    2.392
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.364
+   ]
+  }, 
+  "accidentalOneQuarterToneFlatFerneyhough": {
+   "bBoxNE": [
+    0.896, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.44
+   ]
+  }, 
+  "accidentalOneQuarterToneSharpFerneyhough": {
+   "bBoxNE": [
+    0.884, 
+    1.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "accidentalOneThirdToneFlatFerneyhough": {
+   "bBoxNE": [
+    0.76, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.444
+   ]
+  }, 
+  "accidentalOneThirdToneSharpFerneyhough": {
+   "bBoxNE": [
+    0.76, 
+    1.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.492
+   ]
+  }, 
+  "accidentalParensLeft": {
+   "bBoxNE": [
+    0.376, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.852
+   ]
+  }, 
+  "accidentalParensRight": {
+   "bBoxNE": [
+    0.38, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.852
+   ]
+  }, 
+  "accidentalQuarterFlatEqualTempered": {
+   "bBoxNE": [
+    1.228, 
+    1.78
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalQuarterSharpEqualTempered": {
+   "bBoxNE": [
+    1.124, 
+    1.348
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.308
+   ]
+  }, 
+  "accidentalQuarterToneFlat4": {
+   "bBoxNE": [
+    0.964, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.42
+   ]
+  }, 
+  "accidentalQuarterToneFlatArrowUp": {
+   "bBoxNE": [
+    0.964, 
+    2.26
+   ], 
+   "bBoxSW": [
+    -0.224, 
+    -0.632
+   ]
+  }, 
+  "accidentalQuarterToneFlatFilledReversed": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalQuarterToneFlatNaturalArrowDown": {
+   "bBoxNE": [
+    1.012, 
+    1.536
+   ], 
+   "bBoxSW": [
+    0.004, 
+    -2.136
+   ]
+  }, 
+  "accidentalQuarterToneFlatPenderecki": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalQuarterToneFlatStein": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalQuarterToneFlatVanBlankenburg": {
+   "bBoxNE": [
+    0.844, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.636
+   ]
+  }, 
+  "accidentalQuarterToneSharp4": {
+   "bBoxNE": [
+    0.944, 
+    1.808
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.716
+   ]
+  }, 
+  "accidentalQuarterToneSharpArrowDown": {
+   "bBoxNE": [
+    0.952, 
+    1.376
+   ], 
+   "bBoxSW": [
+    -0.168, 
+    -2.492
+   ]
+  }, 
+  "accidentalQuarterToneSharpBusotti": {
+   "bBoxNE": [
+    0.672, 
+    1.356
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.32
+   ]
+  }, 
+  "accidentalQuarterToneSharpNaturalArrowUp": {
+   "bBoxNE": [
+    0.852, 
+    2.152
+   ], 
+   "bBoxSW": [
+    -0.156, 
+    -1.52
+   ]
+  }, 
+  "accidentalQuarterToneSharpStein": {
+   "bBoxNE": [
+    0.676, 
+    1.356
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.32
+   ]
+  }, 
+  "accidentalQuarterToneSharpWiggle": {
+   "bBoxNE": [
+    2.648, 
+    1.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.352
+   ]
+  }, 
+  "accidentalRaiseOneSeptimalComma": {
+   "bBoxNE": [
+    0.628, 
+    0.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.656
+   ]
+  }, 
+  "accidentalRaiseOneTridecimalQuartertone": {
+   "bBoxNE": [
+    0.952, 
+    1.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.364
+   ]
+  }, 
+  "accidentalRaiseOneUndecimalQuartertone": {
+   "bBoxNE": [
+    0.952, 
+    1.348
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.284
+   ]
+  }, 
+  "accidentalRaiseTwoSeptimalCommas": {
+   "bBoxNE": [
+    0.628, 
+    1.104
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.592
+   ]
+  }, 
+  "accidentalReversedFlatAndFlatArrowDown": {
+   "bBoxNE": [
+    1.576, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.628
+   ]
+  }, 
+  "accidentalReversedFlatAndFlatArrowUp": {
+   "bBoxNE": [
+    1.576, 
+    1.968
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.624
+   ]
+  }, 
+  "accidentalReversedFlatArrowDown": {
+   "bBoxNE": [
+    1.18, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.556
+   ]
+  }, 
+  "accidentalReversedFlatArrowUp": {
+   "bBoxNE": [
+    1.192, 
+    2.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalSharp": {
+   "bBoxNE": [
+    0.952, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalSharpEqualTempered": {
+   "bBoxNE": [
+    0.952, 
+    1.78
+   ], 
+   "bBoxSW": [
+    -0.212, 
+    -1.356
+   ]
+  }, 
+  "accidentalSharpJohnstonDown": {
+   "bBoxNE": [
+    1.084, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.836
+   ]
+  }, 
+  "accidentalSharpJohnstonDownEl": {
+   "bBoxNE": [
+    1.368, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.816
+   ]
+  }, 
+  "accidentalSharpJohnstonEl": {
+   "bBoxNE": [
+    1.18, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalSharpJohnstonUp": {
+   "bBoxNE": [
+    1.096, 
+    2.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalSharpJohnstonUpEl": {
+   "bBoxNE": [
+    1.244, 
+    1.752
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalSharpOneArrowDown": {
+   "bBoxNE": [
+    1.136, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.136
+   ]
+  }, 
+  "accidentalSharpOneArrowUp": {
+   "bBoxNE": [
+    0.952, 
+    2.304
+   ], 
+   "bBoxSW": [
+    -0.184, 
+    -1.352
+   ]
+  }, 
+  "accidentalSharpOneHorizontalStroke": {
+   "bBoxNE": [
+    0.912, 
+    1.356
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.456
+   ]
+  }, 
+  "accidentalSharpParens": {
+   "bBoxNE": [
+    1.936, 
+    1.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalSharpReversed": {
+   "bBoxNE": [
+    0.952, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.352
+   ]
+  }, 
+  "accidentalSharpSharp": {
+   "bBoxNE": [
+    1.832, 
+    1.344
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.352
+   ]
+  }, 
+  "accidentalSharpSmall": {
+   "bBoxNE": [
+    0.668, 
+    0.912
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.892
+   ]
+  }, 
+  "accidentalSharpThreeArrowsDown": {
+   "bBoxNE": [
+    1.136, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.096
+   ]
+  }, 
+  "accidentalSharpThreeArrowsUp": {
+   "bBoxNE": [
+    0.952, 
+    3.12
+   ], 
+   "bBoxSW": [
+    -0.188, 
+    -1.352
+   ]
+  }, 
+  "accidentalSharpTwoArrowsDown": {
+   "bBoxNE": [
+    1.136, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.616
+   ]
+  }, 
+  "accidentalSharpTwoArrowsUp": {
+   "bBoxNE": [
+    0.952, 
+    2.64
+   ], 
+   "bBoxSW": [
+    -0.188, 
+    -1.352
+   ]
+  }, 
+  "accidentalSims12Down": {
+   "bBoxNE": [
+    1.328, 
+    2.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "accidentalSims12Up": {
+   "bBoxNE": [
+    1.328, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.016
+   ]
+  }, 
+  "accidentalSims4Down": {
+   "bBoxNE": [
+    1.756, 
+    2.484
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.436
+   ]
+  }, 
+  "accidentalSims4Up": {
+   "bBoxNE": [
+    0.88, 
+    0.5
+   ], 
+   "bBoxSW": [
+    -0.276, 
+    -2.476
+   ]
+  }, 
+  "accidentalSims6Down": {
+   "bBoxNE": [
+    0.884, 
+    2.156
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.436
+   ]
+  }, 
+  "accidentalSims6Up": {
+   "bBoxNE": [
+    0.884, 
+    0.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.096
+   ]
+  }, 
+  "accidentalSori": {
+   "bBoxNE": [
+    1.312, 
+    0.876
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.852
+   ]
+  }, 
+  "accidentalTavenerFlat": {
+   "bBoxNE": [
+    2.056, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalTavenerSharp": {
+   "bBoxNE": [
+    2.136, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalThreeQuarterTonesFlatArrowDown": {
+   "bBoxNE": [
+    0.98, 
+    1.632
+   ], 
+   "bBoxSW": [
+    -0.208, 
+    -1.664
+   ]
+  }, 
+  "accidentalThreeQuarterTonesFlatArrowUp": {
+   "bBoxNE": [
+    1.74, 
+    2.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalThreeQuarterTonesFlatCouper": {
+   "bBoxNE": [
+    1.576, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.624
+   ]
+  }, 
+  "accidentalThreeQuarterTonesFlatGrisey": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalThreeQuarterTonesFlatTartini": {
+   "bBoxNE": [
+    1.312, 
+    1.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.752
+   ]
+  }, 
+  "accidentalThreeQuarterTonesFlatZimmermann": {
+   "bBoxNE": [
+    1.8, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalThreeQuarterTonesSharpArrowDown": {
+   "bBoxNE": [
+    1.008, 
+    0.516
+   ], 
+   "bBoxSW": [
+    -0.228, 
+    -1.392
+   ]
+  }, 
+  "accidentalThreeQuarterTonesSharpArrowUp": {
+   "bBoxNE": [
+    1.12, 
+    2.464
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalThreeQuarterTonesSharpBusotti": {
+   "bBoxNE": [
+    1.348, 
+    1.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.456
+   ]
+  }, 
+  "accidentalThreeQuarterTonesSharpStein": {
+   "bBoxNE": [
+    1.348, 
+    1.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.456
+   ]
+  }, 
+  "accidentalTripleFlat": {
+   "bBoxNE": [
+    2.636, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalTripleFlatJoinedStems": {
+   "bBoxNE": [
+    2.296, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalTripleSharp": {
+   "bBoxNE": [
+    2.028, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.352
+   ]
+  }, 
+  "accidentalTwoThirdTonesFlatFerneyhough": {
+   "bBoxNE": [
+    0.764, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.44
+   ]
+  }, 
+  "accidentalTwoThirdTonesSharpFerneyhough": {
+   "bBoxNE": [
+    0.764, 
+    1.492
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "accidentalWilsonMinus": {
+   "bBoxNE": [
+    1.072, 
+    0.756
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.756
+   ]
+  }, 
+  "accidentalWilsonPlus": {
+   "bBoxNE": [
+    1.072, 
+    0.804
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.804
+   ]
+  }, 
+  "accidentalWyschnegradsky10TwelfthsFlat": {
+   "bBoxNE": [
+    1.78, 
+    2.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalWyschnegradsky10TwelfthsSharp": {
+   "bBoxNE": [
+    1.688, 
+    2.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.456
+   ]
+  }, 
+  "accidentalWyschnegradsky11TwelfthsFlat": {
+   "bBoxNE": [
+    1.776, 
+    1.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalWyschnegradsky11TwelfthsSharp": {
+   "bBoxNE": [
+    1.688, 
+    2.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.456
+   ]
+  }, 
+  "accidentalWyschnegradsky1TwelfthsFlat": {
+   "bBoxNE": [
+    0.844, 
+    1.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.172
+   ]
+  }, 
+  "accidentalWyschnegradsky1TwelfthsSharp": {
+   "bBoxNE": [
+    0.612, 
+    1.328
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.444
+   ]
+  }, 
+  "accidentalWyschnegradsky2TwelfthsFlat": {
+   "bBoxNE": [
+    0.844, 
+    1.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.172
+   ]
+  }, 
+  "accidentalWyschnegradsky2TwelfthsSharp": {
+   "bBoxNE": [
+    0.612, 
+    1.336
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "accidentalWyschnegradsky3TwelfthsFlat": {
+   "bBoxNE": [
+    0.844, 
+    1.736
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.172
+   ]
+  }, 
+  "accidentalWyschnegradsky3TwelfthsSharp": {
+   "bBoxNE": [
+    0.676, 
+    1.276
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalWyschnegradsky4TwelfthsFlat": {
+   "bBoxNE": [
+    0.84, 
+    2.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalWyschnegradsky4TwelfthsSharp": {
+   "bBoxNE": [
+    0.888, 
+    1.468
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalWyschnegradsky5TwelfthsFlat": {
+   "bBoxNE": [
+    0.844, 
+    1.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalWyschnegradsky5TwelfthsSharp": {
+   "bBoxNE": [
+    0.888, 
+    2.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalWyschnegradsky6TwelfthsFlat": {
+   "bBoxNE": [
+    0.84, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "accidentalWyschnegradsky6TwelfthsSharp": {
+   "bBoxNE": [
+    0.952, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalWyschnegradsky7TwelfthsFlat": {
+   "bBoxNE": [
+    1.772, 
+    1.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.144
+   ]
+  }, 
+  "accidentalWyschnegradsky7TwelfthsSharp": {
+   "bBoxNE": [
+    1.292, 
+    1.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalWyschnegradsky8TwelfthsFlat": {
+   "bBoxNE": [
+    1.772, 
+    1.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.144
+   ]
+  }, 
+  "accidentalWyschnegradsky8TwelfthsSharp": {
+   "bBoxNE": [
+    1.292, 
+    2.552
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.356
+   ]
+  }, 
+  "accidentalWyschnegradsky9TwelfthsFlat": {
+   "bBoxNE": [
+    1.772, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.144
+   ]
+  }, 
+  "accidentalWyschnegradsky9TwelfthsSharp": {
+   "bBoxNE": [
+    1.348, 
+    1.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.456
+   ]
+  }, 
+  "accidentalXenakisOneThirdToneSharp": {
+   "bBoxNE": [
+    0.856, 
+    1.344
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.332
+   ]
+  }, 
+  "accidentalXenakisTwoThirdTonesSharp": {
+   "bBoxNE": [
+    1.172, 
+    1.344
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.284
+   ]
+  }, 
+  "analyticsChoralmelodie": {
+   "bBoxNE": [
+    3.784, 
+    2.152
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.032
+   ]
+  }, 
+  "analyticsEndStimme": {
+   "bBoxNE": [
+    0.904, 
+    2.152
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.204
+   ]
+  }, 
+  "analyticsHauptrhythmus": {
+   "bBoxNE": [
+    3.808, 
+    2.152
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "analyticsHauptrhythmusR": {
+   "bBoxNE": [
+    2.188, 
+    2.152
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "analyticsHauptstimme": {
+   "bBoxNE": [
+    2.024, 
+    2.152
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "analyticsInversion1": {
+   "bBoxNE": [
+    1.684, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "analyticsNebenstimme": {
+   "bBoxNE": [
+    2.024, 
+    2.148
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "analyticsStartStimme": {
+   "bBoxNE": [
+    0.904, 
+    2.152
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.204
+   ]
+  }, 
+  "analyticsTheme": {
+   "bBoxNE": [
+    2.876, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "analyticsTheme1": {
+   "bBoxNE": [
+    1.684, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "analyticsThemeInversion": {
+   "bBoxNE": [
+    2.876, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "analyticsThemeRetrograde": {
+   "bBoxNE": [
+    2.876, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "analyticsThemeRetrogradeInversion": {
+   "bBoxNE": [
+    2.876, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arpeggiatoDown": {
+   "bBoxNE": [
+    0.912, 
+    5.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arpeggiatoUp": {
+   "bBoxNE": [
+    0.912, 
+    5.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowBlackDown": {
+   "bBoxNE": [
+    0.912, 
+    1.96
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowBlackDownLeft": {
+   "bBoxNE": [
+    1.44, 
+    1.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.288
+   ]
+  }, 
+  "arrowBlackDownRight": {
+   "bBoxNE": [
+    1.44, 
+    1.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.288
+   ]
+  }, 
+  "arrowBlackLeft": {
+   "bBoxNE": [
+    1.96, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.524
+   ]
+  }, 
+  "arrowBlackRight": {
+   "bBoxNE": [
+    1.96, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.524
+   ]
+  }, 
+  "arrowBlackUp": {
+   "bBoxNE": [
+    0.912, 
+    1.96
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowBlackUpLeft": {
+   "bBoxNE": [
+    1.44, 
+    1.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.288
+   ]
+  }, 
+  "arrowBlackUpRight": {
+   "bBoxNE": [
+    1.44, 
+    1.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.232
+   ]
+  }, 
+  "arrowOpenDown": {
+   "bBoxNE": [
+    0.92, 
+    1.956
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowOpenDownLeft": {
+   "bBoxNE": [
+    1.44, 
+    1.668
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.228
+   ]
+  }, 
+  "arrowOpenDownRight": {
+   "bBoxNE": [
+    1.44, 
+    1.668
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.228
+   ]
+  }, 
+  "arrowOpenLeft": {
+   "bBoxNE": [
+    1.956, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.516
+   ]
+  }, 
+  "arrowOpenRight": {
+   "bBoxNE": [
+    1.956, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.516
+   ]
+  }, 
+  "arrowOpenUp": {
+   "bBoxNE": [
+    0.92, 
+    1.956
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowOpenUpLeft": {
+   "bBoxNE": [
+    1.44, 
+    1.668
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.228
+   ]
+  }, 
+  "arrowOpenUpRight": {
+   "bBoxNE": [
+    1.44, 
+    1.668
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.228
+   ]
+  }, 
+  "arrowWhiteDown": {
+   "bBoxNE": [
+    0.912, 
+    1.96
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowWhiteDownLeft": {
+   "bBoxNE": [
+    1.44, 
+    1.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.232
+   ]
+  }, 
+  "arrowWhiteDownRight": {
+   "bBoxNE": [
+    1.44, 
+    1.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.232
+   ]
+  }, 
+  "arrowWhiteLeft": {
+   "bBoxNE": [
+    1.96, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.524
+   ]
+  }, 
+  "arrowWhiteRight": {
+   "bBoxNE": [
+    1.96, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.524
+   ]
+  }, 
+  "arrowWhiteUp": {
+   "bBoxNE": [
+    0.912, 
+    1.96
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowWhiteUpLeft": {
+   "bBoxNE": [
+    1.44, 
+    1.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.232
+   ]
+  }, 
+  "arrowWhiteUpRight": {
+   "bBoxNE": [
+    1.44, 
+    1.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.232
+   ]
+  }, 
+  "arrowheadBlackDown": {
+   "bBoxNE": [
+    0.912, 
+    1.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowheadBlackDownLeft": {
+   "bBoxNE": [
+    1.04, 
+    1.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.02
+   ]
+  }, 
+  "arrowheadBlackDownRight": {
+   "bBoxNE": [
+    1.04, 
+    1.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.02
+   ]
+  }, 
+  "arrowheadBlackLeft": {
+   "bBoxNE": [
+    1.016, 
+    0.964
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.052
+   ]
+  }, 
+  "arrowheadBlackRight": {
+   "bBoxNE": [
+    1.016, 
+    0.964
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.052
+   ]
+  }, 
+  "arrowheadBlackUp": {
+   "bBoxNE": [
+    0.912, 
+    1.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowheadBlackUpLeft": {
+   "bBoxNE": [
+    1.04, 
+    1.048
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "arrowheadBlackUpRight": {
+   "bBoxNE": [
+    1.04, 
+    1.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.02
+   ]
+  }, 
+  "arrowheadOpenDown": {
+   "bBoxNE": [
+    0.92, 
+    1.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowheadOpenDownLeft": {
+   "bBoxNE": [
+    1.036, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "arrowheadOpenDownRight": {
+   "bBoxNE": [
+    1.036, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "arrowheadOpenLeft": {
+   "bBoxNE": [
+    1.008, 
+    0.964
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.044
+   ]
+  }, 
+  "arrowheadOpenRight": {
+   "bBoxNE": [
+    1.008, 
+    0.964
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.044
+   ]
+  }, 
+  "arrowheadOpenUp": {
+   "bBoxNE": [
+    0.92, 
+    1.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowheadOpenUpLeft": {
+   "bBoxNE": [
+    1.036, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "arrowheadOpenUpRight": {
+   "bBoxNE": [
+    1.036, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "arrowheadWhiteDown": {
+   "bBoxNE": [
+    0.912, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.016
+   ]
+  }, 
+  "arrowheadWhiteDownLeft": {
+   "bBoxNE": [
+    1.04, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowheadWhiteDownRight": {
+   "bBoxNE": [
+    1.04, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowheadWhiteLeft": {
+   "bBoxNE": [
+    1.016, 
+    0.948
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.036
+   ]
+  }, 
+  "arrowheadWhiteRight": {
+   "bBoxNE": [
+    1.016, 
+    0.948
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.036
+   ]
+  }, 
+  "arrowheadWhiteUp": {
+   "bBoxNE": [
+    0.912, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.016
+   ]
+  }, 
+  "arrowheadWhiteUpLeft": {
+   "bBoxNE": [
+    1.04, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "arrowheadWhiteUpRight": {
+   "bBoxNE": [
+    1.04, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articAccentAbove": {
+   "bBoxNE": [
+    1.656, 
+    0.92
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articAccentBelow": {
+   "bBoxNE": [
+    1.656, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.92
+   ]
+  }, 
+  "articAccentStaccatoAbove": {
+   "bBoxNE": [
+    1.656, 
+    1.448
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articAccentStaccatoBelow": {
+   "bBoxNE": [
+    1.656, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.448
+   ]
+  }, 
+  "articLaissezVibrerAbove": {
+   "bBoxNE": [
+    1.4, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articLaissezVibrerBelow": {
+   "bBoxNE": [
+    1.4, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "articMarcatoAbove": {
+   "bBoxNE": [
+    1.132, 
+    1.296
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articMarcatoBelow": {
+   "bBoxNE": [
+    1.132, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.296
+   ]
+  }, 
+  "articMarcatoStaccatoAbove": {
+   "bBoxNE": [
+    1.132, 
+    1.336
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articMarcatoStaccatoBelow": {
+   "bBoxNE": [
+    1.132, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.336
+   ]
+  }, 
+  "articMarcatoTenutoAbove": {
+   "bBoxNE": [
+    1.212, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articMarcatoTenutoBelow": {
+   "bBoxNE": [
+    1.212, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.796
+   ]
+  }, 
+  "articStaccatissimoAbove": {
+   "bBoxNE": [
+    0.336, 
+    0.884
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articStaccatissimoBelow": {
+   "bBoxNE": [
+    0.336, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.884
+   ]
+  }, 
+  "articStaccatissimoStrokeAbove": {
+   "bBoxNE": [
+    0.256, 
+    0.892
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articStaccatissimoStrokeBelow": {
+   "bBoxNE": [
+    0.256, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.892
+   ]
+  }, 
+  "articStaccatissimoWedgeAbove": {
+   "bBoxNE": [
+    0.496, 
+    0.932
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.008
+   ]
+  }, 
+  "articStaccatissimoWedgeBelow": {
+   "bBoxNE": [
+    0.5, 
+    0.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.912
+   ]
+  }, 
+  "articStaccatoAbove": {
+   "bBoxNE": [
+    0.416, 
+    0.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articStaccatoBelow": {
+   "bBoxNE": [
+    0.416, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.404
+   ]
+  }, 
+  "articStressAbove": {
+   "bBoxNE": [
+    0.716, 
+    0.712
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "articStressBelow": {
+   "bBoxNE": [
+    0.716, 
+    0.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.704
+   ]
+  }, 
+  "articTenutoAbove": {
+   "bBoxNE": [
+    1.144, 
+    0.14
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articTenutoAccentAbove": {
+   "bBoxNE": [
+    1.656, 
+    1.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articTenutoAccentBelow": {
+   "bBoxNE": [
+    1.656, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.268
+   ]
+  }, 
+  "articTenutoBelow": {
+   "bBoxNE": [
+    1.144, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.14
+   ]
+  }, 
+  "articTenutoStaccatoAbove": {
+   "bBoxNE": [
+    1.296, 
+    0.856
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articTenutoStaccatoBelow": {
+   "bBoxNE": [
+    1.296, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.856
+   ]
+  }, 
+  "articUnstressAbove": {
+   "bBoxNE": [
+    1.072, 
+    0.608
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "articUnstressBelow": {
+   "bBoxNE": [
+    1.072, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.608
+   ]
+  }, 
+  "augmentationDot": {
+   "bBoxNE": [
+    0.416, 
+    0.204
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.2
+   ]
+  }, 
+  "barlineDashed": {
+   "bBoxNE": [
+    0.08, 
+    4.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "barlineDotted": {
+   "bBoxNE": [
+    0.192, 
+    3.892
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.108
+   ]
+  }, 
+  "barlineDouble": {
+   "bBoxNE": [
+    0.592, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "barlineFinal": {
+   "bBoxNE": [
+    1.0, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "barlineHeavy": {
+   "bBoxNE": [
+    0.48, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "barlineHeavyHeavy": {
+   "bBoxNE": [
+    1.4, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "barlineReverseFinal": {
+   "bBoxNE": [
+    1.0, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "barlineShort": {
+   "bBoxNE": [
+    0.08, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    2.0
+   ]
+  }, 
+  "barlineSingle": {
+   "bBoxNE": [
+    0.08, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "barlineTick": {
+   "bBoxNE": [
+    0.08, 
+    4.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    3.564
+   ]
+  }, 
+  "beamAccelRit1": {
+   "bBoxNE": [
+    2.6, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit10": {
+   "bBoxNE": [
+    1.16, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit11": {
+   "bBoxNE": [
+    1.0, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit12": {
+   "bBoxNE": [
+    0.84, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit13": {
+   "bBoxNE": [
+    0.68, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit14": {
+   "bBoxNE": [
+    0.52, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit15": {
+   "bBoxNE": [
+    0.36, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit2": {
+   "bBoxNE": [
+    2.44, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit3": {
+   "bBoxNE": [
+    2.28, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit4": {
+   "bBoxNE": [
+    2.12, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit5": {
+   "bBoxNE": [
+    1.96, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit6": {
+   "bBoxNE": [
+    1.8, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit7": {
+   "bBoxNE": [
+    1.64, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit8": {
+   "bBoxNE": [
+    1.48, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit9": {
+   "bBoxNE": [
+    1.32, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "beamAccelRitFinal": {
+   "bBoxNE": [
+    0.08, 
+    2.388
+   ], 
+   "bBoxSW": [
+    -0.08, 
+    0.0
+   ]
+  }, 
+  "brace": {
+   "bBoxNE": [
+    0.492, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "braceFlat": {
+   "bBoxNE": [
+    0.316, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "braceLarge": {
+   "bBoxNE": [
+    0.308, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "braceLarger": {
+   "bBoxNE": [
+    0.276, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "braceSmall": {
+   "bBoxNE": [
+    0.492, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "bracket": {
+   "bBoxNE": [
+    1.74, 
+    4.972
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.972
+   ]
+  }, 
+  "bracketBottom": {
+   "bBoxNE": [
+    1.74, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "bracketTop": {
+   "bBoxNE": [
+    1.74, 
+    0.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassBend": {
+   "bBoxNE": [
+    1.608, 
+    0.816
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassDoitLong": {
+   "bBoxNE": [
+    3.308, 
+    1.576
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.108
+   ]
+  }, 
+  "brassDoitMedium": {
+   "bBoxNE": [
+    1.58, 
+    1.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.112
+   ]
+  }, 
+  "brassDoitShort": {
+   "bBoxNE": [
+    1.14, 
+    1.408
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.104
+   ]
+  }, 
+  "brassFallLipLong": {
+   "bBoxNE": [
+    3.308, 
+    0.108
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.576
+   ]
+  }, 
+  "brassFallLipMedium": {
+   "bBoxNE": [
+    1.58, 
+    0.108
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.404
+   ]
+  }, 
+  "brassFallLipShort": {
+   "bBoxNE": [
+    1.14, 
+    0.104
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "brassFallRoughLong": {
+   "bBoxNE": [
+    5.464, 
+    3.76
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassFallRoughMedium": {
+   "bBoxNE": [
+    3.928, 
+    2.768
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassFallRoughShort": {
+   "bBoxNE": [
+    2.432, 
+    1.712
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassFallSmoothLong": {
+   "bBoxNE": [
+    4.864, 
+    3.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "brassFallSmoothMedium": {
+   "bBoxNE": [
+    3.544, 
+    2.224
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassFallSmoothShort": {
+   "bBoxNE": [
+    1.748, 
+    1.14
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassFlip": {
+   "bBoxNE": [
+    2.824, 
+    1.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "brassHarmonMuteClosed": {
+   "bBoxNE": [
+    1.068, 
+    1.064
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -0.176
+   ]
+  }, 
+  "brassHarmonMuteStemHalfLeft": {
+   "bBoxNE": [
+    1.068, 
+    1.064
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -0.176
+   ]
+  }, 
+  "brassHarmonMuteStemHalfRight": {
+   "bBoxNE": [
+    1.072, 
+    1.064
+   ], 
+   "bBoxSW": [
+    -0.168, 
+    -0.176
+   ]
+  }, 
+  "brassHarmonMuteStemOpen": {
+   "bBoxNE": [
+    1.068, 
+    1.064
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -0.176
+   ]
+  }, 
+  "brassJazzTurn": {
+   "bBoxNE": [
+    2.428, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "brassLiftLong": {
+   "bBoxNE": [
+    5.464, 
+    3.744
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.016
+   ]
+  }, 
+  "brassLiftMedium": {
+   "bBoxNE": [
+    3.928, 
+    2.776
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.008
+   ]
+  }, 
+  "brassLiftShort": {
+   "bBoxNE": [
+    2.432, 
+    1.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "brassLiftSmoothLong": {
+   "bBoxNE": [
+    4.864, 
+    3.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "brassLiftSmoothMedium": {
+   "bBoxNE": [
+    3.544, 
+    2.224
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassLiftSmoothShort": {
+   "bBoxNE": [
+    1.748, 
+    1.14
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassMuteClosed": {
+   "bBoxNE": [
+    1.08, 
+    1.08
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassMuteHalfClosed": {
+   "bBoxNE": [
+    0.908, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassMuteOpen": {
+   "bBoxNE": [
+    0.908, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassPlop": {
+   "bBoxNE": [
+    1.276, 
+    1.468
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.076
+   ]
+  }, 
+  "brassScoop": {
+   "bBoxNE": [
+    1.8, 
+    0.108
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.752
+   ]
+  }, 
+  "brassSmear": {
+   "bBoxNE": [
+    1.584, 
+    0.588
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "brassValveTrill": {
+   "bBoxNE": [
+    0.908, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "breathMarkComma": {
+   "bBoxNE": [
+    0.572, 
+    1.06
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "breathMarkSalzedo": {
+   "bBoxNE": [
+    2.08, 
+    1.844
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "breathMarkTick": {
+   "bBoxNE": [
+    1.768, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "breathMarkUpbow": {
+   "bBoxNE": [
+    0.9, 
+    1.76
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "bridgeClef": {
+   "bBoxNE": [
+    1.068, 
+    2.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.576
+   ]
+  }, 
+  "buzzRoll": {
+   "bBoxNE": [
+    0.484, 
+    0.524
+   ], 
+   "bBoxSW": [
+    -0.48, 
+    -0.52
+   ]
+  }, 
+  "cClef": {
+   "bBoxNE": [
+    2.616, 
+    2.044
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.044
+   ]
+  }, 
+  "cClef8vb": {
+   "bBoxNE": [
+    2.616, 
+    2.044
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.148
+   ]
+  }, 
+  "cClefArrowDown": {
+   "bBoxNE": [
+    2.616, 
+    2.044
+   ], 
+   "bBoxSW": [
+    -0.112, 
+    -3.32
+   ]
+  }, 
+  "cClefArrowUp": {
+   "bBoxNE": [
+    2.616, 
+    3.312
+   ], 
+   "bBoxSW": [
+    -0.112, 
+    -2.044
+   ]
+  }, 
+  "cClefChange": {
+   "bBoxNE": [
+    1.96, 
+    1.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.532
+   ]
+  }, 
+  "cClefCombining": {
+   "bBoxNE": [
+    0.84, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.0
+   ]
+  }, 
+  "cClefFrench": {
+   "bBoxNE": [
+    2.28, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.0
+   ]
+  }, 
+  "cClefReversed": {
+   "bBoxNE": [
+    2.616, 
+    2.044
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.044
+   ]
+  }, 
+  "cClefSmall": {
+   "bBoxNE": [
+    2.96, 
+    2.044
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.044
+   ]
+  }, 
+  "cClefSquare": {
+   "bBoxNE": [
+    2.36, 
+    2.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.004
+   ]
+  }, 
+  "caesura": {
+   "bBoxNE": [
+    1.748, 
+    2.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "caesuraCurved": {
+   "bBoxNE": [
+    1.464, 
+    2.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "caesuraShort": {
+   "bBoxNE": [
+    0.648, 
+    2.192
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "caesuraThick": {
+   "bBoxNE": [
+    2.496, 
+    2.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "chantAccentusAbove": {
+   "bBoxNE": [
+    0.364, 
+    0.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.384
+   ]
+  }, 
+  "chantAccentusBelow": {
+   "bBoxNE": [
+    0.364, 
+    -0.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.8
+   ]
+  }, 
+  "chantAuctumAsc": {
+   "bBoxNE": [
+    0.592, 
+    0.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.432
+   ]
+  }, 
+  "chantAuctumDesc": {
+   "bBoxNE": [
+    0.592, 
+    0.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.428
+   ]
+  }, 
+  "chantAugmentum": {
+   "bBoxNE": [
+    0.276, 
+    0.464
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.188
+   ]
+  }, 
+  "chantCaesura": {
+   "bBoxNE": [
+    0.584, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -0.084, 
+    1.016
+   ]
+  }, 
+  "chantCclef": {
+   "bBoxNE": [
+    0.568, 
+    0.888
+   ], 
+   "bBoxSW": [
+    0.004, 
+    -0.888
+   ]
+  }, 
+  "chantCirculusAbove": {
+   "bBoxNE": [
+    0.376, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.312
+   ]
+  }, 
+  "chantCirculusBelow": {
+   "bBoxNE": [
+    0.376, 
+    -0.312
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.688
+   ]
+  }, 
+  "chantConnectingLineAsc2nd": {
+   "bBoxNE": [
+    0.056, 
+    0.6
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantConnectingLineAsc3rd": {
+   "bBoxNE": [
+    0.056, 
+    1.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantConnectingLineAsc4th": {
+   "bBoxNE": [
+    0.056, 
+    1.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantConnectingLineAsc5th": {
+   "bBoxNE": [
+    0.056, 
+    2.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantConnectingLineAsc6th": {
+   "bBoxNE": [
+    0.056, 
+    3.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantCustosStemDownPosHigh": {
+   "bBoxNE": [
+    0.256, 
+    0.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.752
+   ]
+  }, 
+  "chantCustosStemDownPosHighest": {
+   "bBoxNE": [
+    0.256, 
+    0.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.244
+   ]
+  }, 
+  "chantCustosStemDownPosMiddle": {
+   "bBoxNE": [
+    0.256, 
+    0.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.26
+   ]
+  }, 
+  "chantCustosStemUpPosLow": {
+   "bBoxNE": [
+    0.256, 
+    1.76
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.384
+   ]
+  }, 
+  "chantCustosStemUpPosLowest": {
+   "bBoxNE": [
+    0.256, 
+    2.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.384
+   ]
+  }, 
+  "chantCustosStemUpPosMiddle": {
+   "bBoxNE": [
+    0.256, 
+    1.256
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.384
+   ]
+  }, 
+  "chantDeminutumLower": {
+   "bBoxNE": [
+    0.056, 
+    0.508
+   ], 
+   "bBoxSW": [
+    -0.268, 
+    -0.26
+   ]
+  }, 
+  "chantDeminutumUpper": {
+   "bBoxNE": [
+    0.056, 
+    0.268
+   ], 
+   "bBoxSW": [
+    -0.268, 
+    -0.492
+   ]
+  }, 
+  "chantDivisioFinalis": {
+   "bBoxNE": [
+    0.468, 
+    1.488
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.496
+   ]
+  }, 
+  "chantDivisioMaior": {
+   "bBoxNE": [
+    0.08, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.0
+   ]
+  }, 
+  "chantDivisioMaxima": {
+   "bBoxNE": [
+    0.08, 
+    1.488
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.496
+   ]
+  }, 
+  "chantDivisioMinima": {
+   "bBoxNE": [
+    0.08, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.0
+   ]
+  }, 
+  "chantEntryLineAsc2nd": {
+   "bBoxNE": [
+    0.056, 
+    0.6
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantEntryLineAsc3rd": {
+   "bBoxNE": [
+    0.056, 
+    1.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantEntryLineAsc4th": {
+   "bBoxNE": [
+    0.056, 
+    1.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantEntryLineAsc5th": {
+   "bBoxNE": [
+    0.056, 
+    2.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantEntryLineAsc6th": {
+   "bBoxNE": [
+    0.056, 
+    3.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.6
+   ]
+  }, 
+  "chantEpisema": {
+   "bBoxNE": [
+    0.616, 
+    0.58
+   ], 
+   "bBoxSW": [
+    -0.024, 
+    0.5
+   ]
+  }, 
+  "chantFclef": {
+   "bBoxNE": [
+    1.104, 
+    0.888
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.888
+   ]
+  }, 
+  "chantIctusAbove": {
+   "bBoxNE": [
+    0.128, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.116
+   ]
+  }, 
+  "chantIctusBelow": {
+   "bBoxNE": [
+    0.128, 
+    -0.116
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "chantLigaturaDesc2nd": {
+   "bBoxNE": [
+    1.82, 
+    0.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.908
+   ]
+  }, 
+  "chantLigaturaDesc3rd": {
+   "bBoxNE": [
+    2.22, 
+    0.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.408
+   ]
+  }, 
+  "chantLigaturaDesc4th": {
+   "bBoxNE": [
+    2.332, 
+    0.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -5.064
+   ]
+  }, 
+  "chantLigaturaDesc5th": {
+   "bBoxNE": [
+    2.332, 
+    0.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.384
+   ]
+  }, 
+  "chantOriscusAscending": {
+   "bBoxNE": [
+    0.596, 
+    0.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.432
+   ]
+  }, 
+  "chantOriscusDescending": {
+   "bBoxNE": [
+    0.596, 
+    0.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.432
+   ]
+  }, 
+  "chantOriscusLiquescens": {
+   "bBoxNE": [
+    0.596, 
+    0.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.964
+   ]
+  }, 
+  "chantPodatusLower": {
+   "bBoxNE": [
+    0.688, 
+    0.668
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.02
+   ]
+  }, 
+  "chantPodatusUpper": {
+   "bBoxNE": [
+    0.056, 
+    0.772
+   ], 
+   "bBoxSW": [
+    -0.508, 
+    -0.02
+   ]
+  }, 
+  "chantPunctum": {
+   "bBoxNE": [
+    0.592, 
+    0.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.372
+   ]
+  }, 
+  "chantPunctumCavum": {
+   "bBoxNE": [
+    0.592, 
+    0.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.372
+   ]
+  }, 
+  "chantPunctumDeminutum": {
+   "bBoxNE": [
+    0.368, 
+    0.232
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.228
+   ]
+  }, 
+  "chantPunctumInclinatum": {
+   "bBoxNE": [
+    0.592, 
+    0.412
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.412
+   ]
+  }, 
+  "chantPunctumInclinatumAuctum": {
+   "bBoxNE": [
+    0.648, 
+    0.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.464
+   ]
+  }, 
+  "chantPunctumInclinatumDeminutum": {
+   "bBoxNE": [
+    0.36, 
+    0.252
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.248
+   ]
+  }, 
+  "chantPunctumLinea": {
+   "bBoxNE": [
+    1.008, 
+    0.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.416
+   ]
+  }, 
+  "chantPunctumLineaCavum": {
+   "bBoxNE": [
+    1.008, 
+    0.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.416
+   ]
+  }, 
+  "chantPunctumVirga": {
+   "bBoxNE": [
+    0.592, 
+    0.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.608
+   ]
+  }, 
+  "chantPunctumVirgaReversed": {
+   "bBoxNE": [
+    0.592, 
+    0.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.608
+   ]
+  }, 
+  "chantQuilisma": {
+   "bBoxNE": [
+    0.616, 
+    0.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.432
+   ]
+  }, 
+  "chantSemicirculusAbove": {
+   "bBoxNE": [
+    0.376, 
+    0.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.288
+   ]
+  }, 
+  "chantSemicirculusBelow": {
+   "bBoxNE": [
+    0.376, 
+    -0.288
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.48
+   ]
+  }, 
+  "chantStaff": {
+   "bBoxNE": [
+    2.136, 
+    1.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.54
+   ]
+  }, 
+  "chantStaffNarrow": {
+   "bBoxNE": [
+    1.132, 
+    1.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.54
+   ]
+  }, 
+  "chantStaffWide": {
+   "bBoxNE": [
+    4.016, 
+    1.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.54
+   ]
+  }, 
+  "chantStrophicus": {
+   "bBoxNE": [
+    0.548, 
+    0.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.408
+   ]
+  }, 
+  "chantStrophicusAuctus": {
+   "bBoxNE": [
+    0.612, 
+    0.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.464
+   ]
+  }, 
+  "chantStrophicusLiquescens2nd": {
+   "bBoxNE": [
+    0.644, 
+    0.86
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.144
+   ]
+  }, 
+  "chantStrophicusLiquescens3rd": {
+   "bBoxNE": [
+    0.644, 
+    1.34
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.148
+   ]
+  }, 
+  "chantStrophicusLiquescens4th": {
+   "bBoxNE": [
+    0.676, 
+    1.84
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.18
+   ]
+  }, 
+  "chantStrophicusLiquescens5th": {
+   "bBoxNE": [
+    0.716, 
+    2.34
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.18
+   ]
+  }, 
+  "chantVirgula": {
+   "bBoxNE": [
+    0.34, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.988
+   ]
+  }, 
+  "clef15": {
+   "bBoxNE": [
+    1.224, 
+    1.184
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.02
+   ]
+  }, 
+  "clef8": {
+   "bBoxNE": [
+    0.804, 
+    1.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "coda": {
+   "bBoxNE": [
+    2.172, 
+    2.252
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.308
+   ]
+  }, 
+  "codaJapanese": {
+   "bBoxNE": [
+    2.204, 
+    2.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.356
+   ]
+  }, 
+  "codaSquare": {
+   "bBoxNE": [
+    2.044, 
+    2.24
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.32
+   ]
+  }, 
+  "conductorBeat2Compound": {
+   "bBoxNE": [
+    2.904, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorBeat2Simple": {
+   "bBoxNE": [
+    2.904, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorBeat3Compound": {
+   "bBoxNE": [
+    2.456, 
+    2.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorBeat3Simple": {
+   "bBoxNE": [
+    2.456, 
+    2.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorBeat4Compound": {
+   "bBoxNE": [
+    2.024, 
+    2.024
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorBeat4Simple": {
+   "bBoxNE": [
+    2.024, 
+    2.024
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorLeftBeat": {
+   "bBoxNE": [
+    0.796, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorRightBeat": {
+   "bBoxNE": [
+    0.796, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorStrongBeat": {
+   "bBoxNE": [
+    1.396, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorUnconducted": {
+   "bBoxNE": [
+    1.556, 
+    4.068
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "conductorWeakBeat": {
+   "bBoxNE": [
+    1.396, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "csymAlteredBassSlash": {
+   "bBoxNE": [
+    1.212, 
+    3.4
+   ], 
+   "bBoxSW": [
+    -0.168, 
+    -0.58
+   ]
+  }, 
+  "csymAugmented": {
+   "bBoxNE": [
+    0.948, 
+    0.948
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "csymBracketLeftTall": {
+   "bBoxNE": [
+    0.556, 
+    4.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "csymBracketRightTall": {
+   "bBoxNE": [
+    0.556, 
+    4.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "csymDiagonalArrangementSlash": {
+   "bBoxNE": [
+    3.98, 
+    3.976
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "csymDiminished": {
+   "bBoxNE": [
+    0.872, 
+    0.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "csymHalfDiminished": {
+   "bBoxNE": [
+    0.992, 
+    1.0
+   ], 
+   "bBoxSW": [
+    -0.144, 
+    -0.132
+   ]
+  }, 
+  "csymMajorSeventh": {
+   "bBoxNE": [
+    1.124, 
+    0.972
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "csymMinor": {
+   "bBoxNE": [
+    0.948, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.424
+   ]
+  }, 
+  "csymParensLeftTall": {
+   "bBoxNE": [
+    0.588, 
+    4.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "csymParensLeftVeryTall": {
+   "bBoxNE": [
+    0.548, 
+    4.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "csymParensRightTall": {
+   "bBoxNE": [
+    0.588, 
+    4.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "csymParensRightVeryTall": {
+   "bBoxNE": [
+    0.508, 
+    4.036
+   ], 
+   "bBoxSW": [
+    -0.04, 
+    -0.036
+   ]
+  }, 
+  "curlewSign": {
+   "bBoxNE": [
+    2.68, 
+    0.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "daCapo": {
+   "bBoxNE": [
+    4.5, 
+    1.924
+   ], 
+   "bBoxSW": [
+    0.04, 
+    -0.04
+   ]
+  }, 
+  "dalSegno": {
+   "bBoxNE": [
+    4.38, 
+    1.928
+   ], 
+   "bBoxSW": [
+    0.04, 
+    -0.04
+   ]
+  }, 
+  "doubleLateralRollStevens": {
+   "bBoxNE": [
+    0.492, 
+    1.576
+   ], 
+   "bBoxSW": [
+    -0.524, 
+    0.0
+   ]
+  }, 
+  "doubleTongueAbove": {
+   "bBoxNE": [
+    1.836, 
+    0.992
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "doubleTongueAboveNoSlur": {
+   "bBoxNE": [
+    1.104, 
+    0.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "doubleTongueBelow": {
+   "bBoxNE": [
+    1.836, 
+    0.992
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "doubleTongueBelowNoSlur": {
+   "bBoxNE": [
+    1.104, 
+    0.408
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "dynamicCombinedSeparatorColon": {
+   "bBoxNE": [
+    0.608, 
+    0.924
+   ], 
+   "bBoxSW": [
+    0.112, 
+    0.084
+   ]
+  }, 
+  "dynamicCombinedSeparatorHyphen": {
+   "bBoxNE": [
+    0.952, 
+    0.652
+   ], 
+   "bBoxSW": [
+    0.156, 
+    0.5
+   ]
+  }, 
+  "dynamicCombinedSeparatorSlash": {
+   "bBoxNE": [
+    0.972, 
+    1.84
+   ], 
+   "bBoxSW": [
+    -0.116, 
+    -0.584
+   ]
+  }, 
+  "dynamicCrescendoHairpin": {
+   "bBoxNE": [
+    3.464, 
+    1.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.396
+   ]
+  }, 
+  "dynamicDiminuendoHairpin": {
+   "bBoxNE": [
+    3.464, 
+    1.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.396
+   ]
+  }, 
+  "dynamicFF": {
+   "bBoxNE": [
+    2.58, 
+    1.804
+   ], 
+   "bBoxSW": [
+    -0.6, 
+    -0.78
+   ]
+  }, 
+  "dynamicFFF": {
+   "bBoxNE": [
+    3.624, 
+    1.804
+   ], 
+   "bBoxSW": [
+    -0.584, 
+    -0.78
+   ]
+  }, 
+  "dynamicFFFF": {
+   "bBoxNE": [
+    4.64, 
+    1.804
+   ], 
+   "bBoxSW": [
+    -0.596, 
+    -0.78
+   ]
+  }, 
+  "dynamicFFFFF": {
+   "bBoxNE": [
+    5.664, 
+    1.804
+   ], 
+   "bBoxSW": [
+    -0.596, 
+    -0.78
+   ]
+  }, 
+  "dynamicFFFFFF": {
+   "bBoxNE": [
+    6.7, 
+    1.804
+   ], 
+   "bBoxSW": [
+    -0.596, 
+    -0.78
+   ]
+  }, 
+  "dynamicForte": {
+   "bBoxNE": [
+    1.544, 
+    1.804
+   ], 
+   "bBoxSW": [
+    -0.604, 
+    -0.78
+   ]
+  }, 
+  "dynamicFortePiano": {
+   "bBoxNE": [
+    2.64, 
+    1.804
+   ], 
+   "bBoxSW": [
+    -0.604, 
+    -0.78
+   ]
+  }, 
+  "dynamicForzando": {
+   "bBoxNE": [
+    2.144, 
+    1.804
+   ], 
+   "bBoxSW": [
+    -0.604, 
+    -0.78
+   ]
+  }, 
+  "dynamicHairpinBracketLeft": {
+   "bBoxNE": [
+    0.324, 
+    0.792
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.792
+   ]
+  }, 
+  "dynamicHairpinBracketRight": {
+   "bBoxNE": [
+    0.324, 
+    0.792
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.792
+   ]
+  }, 
+  "dynamicHairpinParenthesisLeft": {
+   "bBoxNE": [
+    0.392, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.852
+   ]
+  }, 
+  "dynamicHairpinParenthesisRight": {
+   "bBoxNE": [
+    0.392, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.852
+   ]
+  }, 
+  "dynamicMF": {
+   "bBoxNE": [
+    3.456, 
+    1.804
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.78
+   ]
+  }, 
+  "dynamicMP": {
+   "bBoxNE": [
+    3.432, 
+    1.104
+   ], 
+   "bBoxSW": [
+    -0.012, 
+    -0.672
+   ]
+  }, 
+  "dynamicMessaDiVoce": {
+   "bBoxNE": [
+    7.296, 
+    1.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.396
+   ]
+  }, 
+  "dynamicMezzo": {
+   "bBoxNE": [
+    1.848, 
+    1.104
+   ], 
+   "bBoxSW": [
+    0.016, 
+    -0.052
+   ]
+  }, 
+  "dynamicNiente": {
+   "bBoxNE": [
+    1.448, 
+    1.104
+   ], 
+   "bBoxSW": [
+    0.012, 
+    -0.052
+   ]
+  }, 
+  "dynamicNienteForHairpin": {
+   "bBoxNE": [
+    0.532, 
+    0.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.264
+   ]
+  }, 
+  "dynamicPF": {
+   "bBoxNE": [
+    3.064, 
+    1.804
+   ], 
+   "bBoxSW": [
+    -0.504, 
+    -0.78
+   ]
+  }, 
+  "dynamicPP": {
+   "bBoxNE": [
+    3.016, 
+    1.092
+   ], 
+   "bBoxSW": [
+    -0.504, 
+    -0.672
+   ]
+  }, 
+  "dynamicPPP": {
+   "bBoxNE": [
+    4.496, 
+    1.092
+   ], 
+   "bBoxSW": [
+    -0.524, 
+    -0.672
+   ]
+  }, 
+  "dynamicPPPP": {
+   "bBoxNE": [
+    6.016, 
+    1.092
+   ], 
+   "bBoxSW": [
+    -0.512, 
+    -0.672
+   ]
+  }, 
+  "dynamicPPPPP": {
+   "bBoxNE": [
+    7.516, 
+    1.092
+   ], 
+   "bBoxSW": [
+    -0.512, 
+    -0.672
+   ]
+  }, 
+  "dynamicPPPPPP": {
+   "bBoxNE": [
+    9.012, 
+    1.092
+   ], 
+   "bBoxSW": [
+    -0.512, 
+    -0.672
+   ]
+  }, 
+  "dynamicPiano": {
+   "bBoxNE": [
+    1.52, 
+    1.092
+   ], 
+   "bBoxSW": [
+    -0.504, 
+    -0.672
+   ]
+  }, 
+  "dynamicRinforzando": {
+   "bBoxNE": [
+    1.208, 
+    1.12
+   ], 
+   "bBoxSW": [
+    -0.048, 
+    0.0
+   ]
+  }, 
+  "dynamicRinforzando1": {
+   "bBoxNE": [
+    2.672, 
+    1.808
+   ], 
+   "bBoxSW": [
+    -0.048, 
+    -0.776
+   ]
+  }, 
+  "dynamicRinforzando2": {
+   "bBoxNE": [
+    3.264, 
+    1.808
+   ], 
+   "bBoxSW": [
+    -0.048, 
+    -0.776
+   ]
+  }, 
+  "dynamicSforzando": {
+   "bBoxNE": [
+    1.06, 
+    1.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.1
+   ]
+  }, 
+  "dynamicSforzando1": {
+   "bBoxNE": [
+    2.684, 
+    1.804
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.78
+   ]
+  }, 
+  "dynamicSforzandoPianissimo": {
+   "bBoxNE": [
+    5.296, 
+    1.792
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.792
+   ]
+  }, 
+  "dynamicSforzandoPiano": {
+   "bBoxNE": [
+    3.784, 
+    1.816
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.768
+   ]
+  }, 
+  "dynamicSforzato": {
+   "bBoxNE": [
+    3.264, 
+    1.808
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.776
+   ]
+  }, 
+  "dynamicSforzatoFF": {
+   "bBoxNE": [
+    4.32, 
+    1.804
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.78
+   ]
+  }, 
+  "dynamicSforzatoPiano": {
+   "bBoxNE": [
+    4.716, 
+    1.808
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.776
+   ]
+  }, 
+  "dynamicZ": {
+   "bBoxNE": [
+    1.208, 
+    1.032
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    -0.104
+   ]
+  }, 
+  "elecAudioChannelsEight": {
+   "bBoxNE": [
+    3.936, 
+    3.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecAudioChannelsFive": {
+   "bBoxNE": [
+    3.936, 
+    3.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecAudioChannelsFour": {
+   "bBoxNE": [
+    3.936, 
+    3.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecAudioChannelsOne": {
+   "bBoxNE": [
+    3.672, 
+    3.936
+   ], 
+   "bBoxSW": [
+    0.264, 
+    0.264
+   ]
+  }, 
+  "elecAudioChannelsSeven": {
+   "bBoxNE": [
+    3.936, 
+    3.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecAudioChannelsSix": {
+   "bBoxNE": [
+    3.936, 
+    3.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecAudioChannelsThreeFrontal": {
+   "bBoxNE": [
+    3.936, 
+    3.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.264
+   ]
+  }, 
+  "elecAudioChannelsThreeSurround": {
+   "bBoxNE": [
+    3.936, 
+    3.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecAudioChannelsTwo": {
+   "bBoxNE": [
+    3.936, 
+    3.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.264
+   ]
+  }, 
+  "elecAudioIn": {
+   "bBoxNE": [
+    4.036, 
+    3.124
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecAudioMono": {
+   "bBoxNE": [
+    2.692, 
+    2.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecAudioOut": {
+   "bBoxNE": [
+    4.036, 
+    3.124
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecAudioStereo": {
+   "bBoxNE": [
+    3.936, 
+    2.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecCamera": {
+   "bBoxNE": [
+    3.968, 
+    3.648
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecDataIn": {
+   "bBoxNE": [
+    4.252, 
+    3.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecDataOut": {
+   "bBoxNE": [
+    4.252, 
+    3.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecDisc": {
+   "bBoxNE": [
+    4.032, 
+    4.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecDownload": {
+   "bBoxNE": [
+    2.172, 
+    3.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecEject": {
+   "bBoxNE": [
+    2.244, 
+    2.608
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecFastForward": {
+   "bBoxNE": [
+    3.62, 
+    2.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecHeadphones": {
+   "bBoxNE": [
+    3.52, 
+    3.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "elecHeadset": {
+   "bBoxNE": [
+    3.52, 
+    4.148
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecLineIn": {
+   "bBoxNE": [
+    3.196, 
+    3.96
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.004
+   ]
+  }, 
+  "elecLineOut": {
+   "bBoxNE": [
+    3.196, 
+    3.96
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.412
+   ]
+  }, 
+  "elecLoop": {
+   "bBoxNE": [
+    3.04, 
+    2.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecLoudspeaker": {
+   "bBoxNE": [
+    2.656, 
+    4.156
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMIDIController0": {
+   "bBoxNE": [
+    2.188, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMIDIController100": {
+   "bBoxNE": [
+    2.188, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMIDIController20": {
+   "bBoxNE": [
+    2.188, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMIDIController40": {
+   "bBoxNE": [
+    2.188, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMIDIController60": {
+   "bBoxNE": [
+    2.188, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMIDIController80": {
+   "bBoxNE": [
+    2.188, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMIDIIn": {
+   "bBoxNE": [
+    2.148, 
+    3.624
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMIDIOut": {
+   "bBoxNE": [
+    2.148, 
+    3.624
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMicrophone": {
+   "bBoxNE": [
+    1.952, 
+    4.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMicrophoneMute": {
+   "bBoxNE": [
+    1.952, 
+    5.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMicrophoneUnmute": {
+   "bBoxNE": [
+    2.356, 
+    5.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMixingConsole": {
+   "bBoxNE": [
+    3.472, 
+    4.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMonitor": {
+   "bBoxNE": [
+    3.952, 
+    2.968
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecMute": {
+   "bBoxNE": [
+    4.456, 
+    4.156
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecPause": {
+   "bBoxNE": [
+    1.988, 
+    2.156
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecPlay": {
+   "bBoxNE": [
+    1.9, 
+    2.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecPowerOnOff": {
+   "bBoxNE": [
+    2.792, 
+    3.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "elecProjector": {
+   "bBoxNE": [
+    3.996, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecReplay": {
+   "bBoxNE": [
+    2.664, 
+    3.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.02
+   ]
+  }, 
+  "elecRewind": {
+   "bBoxNE": [
+    3.62, 
+    2.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecShuffle": {
+   "bBoxNE": [
+    4.584, 
+    2.476
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "elecSkipBackwards": {
+   "bBoxNE": [
+    3.912, 
+    2.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecSkipForwards": {
+   "bBoxNE": [
+    3.912, 
+    2.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecStop": {
+   "bBoxNE": [
+    2.156, 
+    2.156
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecTape": {
+   "bBoxNE": [
+    4.004, 
+    1.808
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecUSB": {
+   "bBoxNE": [
+    1.776, 
+    4.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecUnmute": {
+   "bBoxNE": [
+    3.92, 
+    4.156
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecUpload": {
+   "bBoxNE": [
+    2.172, 
+    3.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecVideoCamera": {
+   "bBoxNE": [
+    3.788, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecVideoIn": {
+   "bBoxNE": [
+    3.256, 
+    4.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecVideoOut": {
+   "bBoxNE": [
+    3.256, 
+    4.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecVolumeFader": {
+   "bBoxNE": [
+    0.952, 
+    4.048
+   ], 
+   "bBoxSW": [
+    0.02, 
+    0.0
+   ]
+  }, 
+  "elecVolumeFaderThumb": {
+   "bBoxNE": [
+    0.848, 
+    1.084
+   ], 
+   "bBoxSW": [
+    0.124, 
+    -0.044
+   ]
+  }, 
+  "elecVolumeLevel0": {
+   "bBoxNE": [
+    0.932, 
+    4.048
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.044
+   ]
+  }, 
+  "elecVolumeLevel100": {
+   "bBoxNE": [
+    0.932, 
+    4.072
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecVolumeLevel20": {
+   "bBoxNE": [
+    0.932, 
+    4.048
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecVolumeLevel40": {
+   "bBoxNE": [
+    0.932, 
+    4.052
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "elecVolumeLevel60": {
+   "bBoxNE": [
+    0.932, 
+    4.048
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "elecVolumeLevel80": {
+   "bBoxNE": [
+    0.932, 
+    4.048
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fClef": {
+   "bBoxNE": [
+    2.66, 
+    1.0
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -2.344
+   ]
+  }, 
+  "fClef15ma": {
+   "bBoxNE": [
+    2.66, 
+    2.116
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -2.344
+   ]
+  }, 
+  "fClef15mb": {
+   "bBoxNE": [
+    2.66, 
+    1.0
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -3.648
+   ]
+  }, 
+  "fClef19thCentury": {
+   "bBoxNE": [
+    3.852, 
+    1.144
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.248
+   ]
+  }, 
+  "fClef5Below": {
+   "bBoxNE": [
+    2.828, 
+    1.0
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    -3.488
+   ]
+  }, 
+  "fClef8va": {
+   "bBoxNE": [
+    2.66, 
+    2.228
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -2.344
+   ]
+  }, 
+  "fClef8vb": {
+   "bBoxNE": [
+    2.66, 
+    1.0
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -3.664
+   ]
+  }, 
+  "fClefArrowDown": {
+   "bBoxNE": [
+    2.66, 
+    1.0
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -3.892
+   ]
+  }, 
+  "fClefArrowUp": {
+   "bBoxNE": [
+    2.66, 
+    2.42
+   ], 
+   "bBoxSW": [
+    -0.172, 
+    -2.344
+   ]
+  }, 
+  "fClefChange": {
+   "bBoxNE": [
+    1.972, 
+    0.74
+   ], 
+   "bBoxSW": [
+    -0.132, 
+    -1.768
+   ]
+  }, 
+  "fClefFrench": {
+   "bBoxNE": [
+    3.16, 
+    1.06
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.104
+   ]
+  }, 
+  "fClefReversed": {
+   "bBoxNE": [
+    2.836, 
+    0.992
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.352
+   ]
+  }, 
+  "fClefSmall": {
+   "bBoxNE": [
+    2.8, 
+    1.0
+   ], 
+   "bBoxSW": [
+    -0.18, 
+    -2.384
+   ]
+  }, 
+  "fClefTurned": {
+   "bBoxNE": [
+    2.836, 
+    2.32
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.024
+   ]
+  }, 
+  "fermataAbove": {
+   "bBoxNE": [
+    2.648, 
+    1.512
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.084
+   ]
+  }, 
+  "fermataBelow": {
+   "bBoxNE": [
+    2.648, 
+    0.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.516
+   ]
+  }, 
+  "fermataLongAbove": {
+   "bBoxNE": [
+    2.512, 
+    1.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.06
+   ]
+  }, 
+  "fermataLongBelow": {
+   "bBoxNE": [
+    2.512, 
+    0.06
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.52
+   ]
+  }, 
+  "fermataLongHenzeAbove": {
+   "bBoxNE": [
+    2.856, 
+    1.512
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.084
+   ]
+  }, 
+  "fermataLongHenzeBelow": {
+   "bBoxNE": [
+    2.856, 
+    0.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.512
+   ]
+  }, 
+  "fermataShortAbove": {
+   "bBoxNE": [
+    2.96, 
+    1.768
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.06
+   ]
+  }, 
+  "fermataShortBelow": {
+   "bBoxNE": [
+    2.96, 
+    0.06
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.768
+   ]
+  }, 
+  "fermataShortHenzeAbove": {
+   "bBoxNE": [
+    1.616, 
+    1.512
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.084
+   ]
+  }, 
+  "fermataShortHenzeBelow": {
+   "bBoxNE": [
+    1.616, 
+    0.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.512
+   ]
+  }, 
+  "fermataVeryLongAbove": {
+   "bBoxNE": [
+    2.672, 
+    1.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.088
+   ]
+  }, 
+  "fermataVeryLongBelow": {
+   "bBoxNE": [
+    2.672, 
+    0.088
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.672
+   ]
+  }, 
+  "fermataVeryShortAbove": {
+   "bBoxNE": [
+    2.96, 
+    1.768
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.044
+   ]
+  }, 
+  "fermataVeryShortBelow": {
+   "bBoxNE": [
+    2.96, 
+    0.052
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.768
+   ]
+  }, 
+  "figbass0": {
+   "bBoxNE": [
+    1.088, 
+    1.26
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass1": {
+   "bBoxNE": [
+    0.672, 
+    1.248
+   ], 
+   "bBoxSW": [
+    0.016, 
+    0.0
+   ]
+  }, 
+  "figbass2": {
+   "bBoxNE": [
+    1.096, 
+    1.272
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.004
+   ]
+  }, 
+  "figbass2Raised": {
+   "bBoxNE": [
+    1.096, 
+    1.272
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.152
+   ]
+  }, 
+  "figbass3": {
+   "bBoxNE": [
+    0.976, 
+    1.268
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass4": {
+   "bBoxNE": [
+    1.02, 
+    1.268
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass4Raised": {
+   "bBoxNE": [
+    1.248, 
+    1.268
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass5": {
+   "bBoxNE": [
+    0.964, 
+    1.292
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass5Raised1": {
+   "bBoxNE": [
+    0.964, 
+    1.476
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass5Raised2": {
+   "bBoxNE": [
+    0.972, 
+    1.484
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass5Raised3": {
+   "bBoxNE": [
+    1.188, 
+    1.292
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass6": {
+   "bBoxNE": [
+    1.012, 
+    1.268
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.004
+   ]
+  }, 
+  "figbass6Raised": {
+   "bBoxNE": [
+    1.136, 
+    1.268
+   ], 
+   "bBoxSW": [
+    -0.076, 
+    -0.004
+   ]
+  }, 
+  "figbass6Raised2": {
+   "bBoxNE": [
+    1.012, 
+    1.32
+   ], 
+   "bBoxSW": [
+    -0.056, 
+    0.0
+   ]
+  }, 
+  "figbass7": {
+   "bBoxNE": [
+    0.996, 
+    1.3
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass7Raised1": {
+   "bBoxNE": [
+    0.996, 
+    1.464
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass7Raised2": {
+   "bBoxNE": [
+    1.04, 
+    1.3
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass8": {
+   "bBoxNE": [
+    1.04, 
+    1.268
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "figbass9": {
+   "bBoxNE": [
+    1.04, 
+    1.264
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.008
+   ]
+  }, 
+  "figbass9Raised": {
+   "bBoxNE": [
+    1.28, 
+    1.264
+   ], 
+   "bBoxSW": [
+    -0.06, 
+    0.008
+   ]
+  }, 
+  "figbassBracketLeft": {
+   "bBoxNE": [
+    0.256, 
+    1.46
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.22
+   ]
+  }, 
+  "figbassBracketRight": {
+   "bBoxNE": [
+    0.148, 
+    1.46
+   ], 
+   "bBoxSW": [
+    -0.108, 
+    -0.22
+   ]
+  }, 
+  "figbassCombiningLowering": {
+   "bBoxNE": [
+    1.404, 
+    0.772
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.124
+   ]
+  }, 
+  "figbassCombiningRaising": {
+   "bBoxNE": [
+    1.404, 
+    0.772
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.124
+   ]
+  }, 
+  "figbassDoubleFlat": {
+   "bBoxNE": [
+    1.176, 
+    1.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.032
+   ]
+  }, 
+  "figbassDoubleSharp": {
+   "bBoxNE": [
+    0.884, 
+    0.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "figbassFlat": {
+   "bBoxNE": [
+    0.568, 
+    1.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.032
+   ]
+  }, 
+  "figbassNatural": {
+   "bBoxNE": [
+    0.368, 
+    1.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.092
+   ]
+  }, 
+  "figbassParensLeft": {
+   "bBoxNE": [
+    0.424, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.268
+   ]
+  }, 
+  "figbassParensRight": {
+   "bBoxNE": [
+    0.304, 
+    1.432
+   ], 
+   "bBoxSW": [
+    -0.12, 
+    -0.268
+   ]
+  }, 
+  "figbassPlus": {
+   "bBoxNE": [
+    0.7, 
+    0.88
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.18
+   ]
+  }, 
+  "figbassSharp": {
+   "bBoxNE": [
+    0.52, 
+    1.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.092
+   ]
+  }, 
+  "flag1024thDown": {
+   "bBoxNE": [
+    1.296, 
+    2.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.22
+   ]
+  }, 
+  "flag1024thDownStraight": {
+   "bBoxNE": [
+    1.272, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.872
+   ]
+  }, 
+  "flag1024thUp": {
+   "bBoxNE": [
+    1.188, 
+    4.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.932
+   ]
+  }, 
+  "flag1024thUpStraight": {
+   "bBoxNE": [
+    1.272, 
+    4.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.16
+   ]
+  }, 
+  "flag128thDown": {
+   "bBoxNE": [
+    1.296, 
+    2.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.412
+   ]
+  }, 
+  "flag128thDownStraight": {
+   "bBoxNE": [
+    1.272, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.436
+   ]
+  }, 
+  "flag128thUp": {
+   "bBoxNE": [
+    1.188, 
+    2.352
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.932
+   ]
+  }, 
+  "flag128thUpStraight": {
+   "bBoxNE": [
+    1.272, 
+    2.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.16
+   ]
+  }, 
+  "flag16thDown": {
+   "bBoxNE": [
+    1.28, 
+    3.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.044
+   ]
+  }, 
+  "flag16thDownStraight": {
+   "bBoxNE": [
+    1.272, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "flag16thUp": {
+   "bBoxNE": [
+    1.184, 
+    0.18
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.384
+   ]
+  }, 
+  "flag16thUpStraight": {
+   "bBoxNE": [
+    1.272, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.16
+   ]
+  }, 
+  "flag256thDown": {
+   "bBoxNE": [
+    1.296, 
+    2.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.012
+   ]
+  }, 
+  "flag256thDownStraight": {
+   "bBoxNE": [
+    1.272, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.248
+   ]
+  }, 
+  "flag256thUp": {
+   "bBoxNE": [
+    1.188, 
+    3.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.932
+   ]
+  }, 
+  "flag256thUpStraight": {
+   "bBoxNE": [
+    1.272, 
+    3.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.16
+   ]
+  }, 
+  "flag32ndDown": {
+   "bBoxNE": [
+    1.292, 
+    3.56
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.888
+   ]
+  }, 
+  "flag32ndDownStraight": {
+   "bBoxNE": [
+    1.272, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.812
+   ]
+  }, 
+  "flag32ndUp": {
+   "bBoxNE": [
+    1.188, 
+    0.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.328
+   ]
+  }, 
+  "flag32ndUpStraight": {
+   "bBoxNE": [
+    1.272, 
+    0.812
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.16
+   ]
+  }, 
+  "flag512thDown": {
+   "bBoxNE": [
+    1.296, 
+    2.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.612
+   ]
+  }, 
+  "flag512thDownStraight": {
+   "bBoxNE": [
+    1.272, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.06
+   ]
+  }, 
+  "flag512thUp": {
+   "bBoxNE": [
+    1.188, 
+    3.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.932
+   ]
+  }, 
+  "flag512thUpStraight": {
+   "bBoxNE": [
+    1.272, 
+    4.06
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.16
+   ]
+  }, 
+  "flag64thDown": {
+   "bBoxNE": [
+    1.292, 
+    2.892
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.616
+   ]
+  }, 
+  "flag64thDownStraight": {
+   "bBoxNE": [
+    1.272, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.624
+   ]
+  }, 
+  "flag64thUp": {
+   "bBoxNE": [
+    1.188, 
+    1.676
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.14
+   ]
+  }, 
+  "flag64thUpStraight": {
+   "bBoxNE": [
+    1.272, 
+    1.624
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.16
+   ]
+  }, 
+  "flag8thDown": {
+   "bBoxNE": [
+    1.14, 
+    3.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.136
+   ]
+  }, 
+  "flag8thDownStraight": {
+   "bBoxNE": [
+    1.272, 
+    1.348
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "flag8thUp": {
+   "bBoxNE": [
+    1.056, 
+    0.124
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.02
+   ]
+  }, 
+  "flag8thUpStraight": {
+   "bBoxNE": [
+    1.272, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.348
+   ]
+  }, 
+  "flagInternalDown": {
+   "bBoxNE": [
+    1.292, 
+    2.22
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "flagInternalUp": {
+   "bBoxNE": [
+    1.192, 
+    0.152
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.328
+   ]
+  }, 
+  "fretboard3String": {
+   "bBoxNE": [
+    1.416, 
+    4.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboard3StringNut": {
+   "bBoxNE": [
+    1.416, 
+    4.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboard4String": {
+   "bBoxNE": [
+    2.084, 
+    4.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboard4StringNut": {
+   "bBoxNE": [
+    2.084, 
+    4.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboard5String": {
+   "bBoxNE": [
+    2.748, 
+    4.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboard5StringNut": {
+   "bBoxNE": [
+    2.752, 
+    4.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboard6String": {
+   "bBoxNE": [
+    3.416, 
+    4.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboard6StringNut": {
+   "bBoxNE": [
+    3.416, 
+    4.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboardFilledCircle": {
+   "bBoxNE": [
+    0.592, 
+    0.592
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboardO": {
+   "bBoxNE": [
+    0.592, 
+    0.592
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "fretboardX": {
+   "bBoxNE": [
+    0.56, 
+    0.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "functionAngleLeft": {
+   "bBoxNE": [
+    1.764, 
+    3.14
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.044
+   ]
+  }, 
+  "functionAngleRight": {
+   "bBoxNE": [
+    1.764, 
+    3.14
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.044
+   ]
+  }, 
+  "functionBracketLeft": {
+   "bBoxNE": [
+    0.732, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.84
+   ]
+  }, 
+  "functionBracketRight": {
+   "bBoxNE": [
+    0.732, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.84
+   ]
+  }, 
+  "functionDD": {
+   "bBoxNE": [
+    3.24, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -1.0
+   ]
+  }, 
+  "functionDLower": {
+   "bBoxNE": [
+    1.976, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.064
+   ]
+  }, 
+  "functionDUpper": {
+   "bBoxNE": [
+    2.388, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionEight": {
+   "bBoxNE": [
+    1.972, 
+    2.844
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.044
+   ]
+  }, 
+  "functionFUpper": {
+   "bBoxNE": [
+    1.916, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.088, 
+    0.0
+   ]
+  }, 
+  "functionFive": {
+   "bBoxNE": [
+    1.976, 
+    2.776
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.052
+   ]
+  }, 
+  "functionFour": {
+   "bBoxNE": [
+    2.048, 
+    2.856
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionGLower": {
+   "bBoxNE": [
+    1.908, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.872
+   ]
+  }, 
+  "functionGUpper": {
+   "bBoxNE": [
+    2.756, 
+    3.004
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.08
+   ]
+  }, 
+  "functionGreaterThan": {
+   "bBoxNE": [
+    2.084, 
+    2.296
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.3
+   ]
+  }, 
+  "functionILower": {
+   "bBoxNE": [
+    0.684, 
+    2.86
+   ], 
+   "bBoxSW": [
+    0.24, 
+    0.0
+   ]
+  }, 
+  "functionIUpper": {
+   "bBoxNE": [
+    0.56, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.176, 
+    0.0
+   ]
+  }, 
+  "functionKLower": {
+   "bBoxNE": [
+    1.876, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionKUpper": {
+   "bBoxNE": [
+    2.392, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.088, 
+    0.0
+   ]
+  }, 
+  "functionLLower": {
+   "bBoxNE": [
+    0.608, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.264, 
+    0.0
+   ]
+  }, 
+  "functionLUpper": {
+   "bBoxNE": [
+    1.916, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.088, 
+    0.0
+   ]
+  }, 
+  "functionLessThan": {
+   "bBoxNE": [
+    2.084, 
+    2.296
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.3
+   ]
+  }, 
+  "functionMinus": {
+   "bBoxNE": [
+    1.044, 
+    1.252
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.964
+   ]
+  }, 
+  "functionNLower": {
+   "bBoxNE": [
+    1.752, 
+    2.18
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionNUpper": {
+   "bBoxNE": [
+    2.376, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionNine": {
+   "bBoxNE": [
+    1.956, 
+    2.852
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.06
+   ]
+  }, 
+  "functionOne": {
+   "bBoxNE": [
+    1.064, 
+    2.856
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionPLower": {
+   "bBoxNE": [
+    1.96, 
+    2.164
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.856
+   ]
+  }, 
+  "functionPUpper": {
+   "bBoxNE": [
+    2.196, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionParensLeft": {
+   "bBoxNE": [
+    0.868, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.8
+   ]
+  }, 
+  "functionParensRight": {
+   "bBoxNE": [
+    0.868, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.8
+   ]
+  }, 
+  "functionPlus": {
+   "bBoxNE": [
+    1.488, 
+    3.028
+   ], 
+   "bBoxSW": [
+    0.08, 
+    1.62
+   ]
+  }, 
+  "functionRepetition1": {
+   "bBoxNE": [
+    1.78, 
+    0.496
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionRepetition2": {
+   "bBoxNE": [
+    2.084, 
+    3.136
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionRing": {
+   "bBoxNE": [
+    1.456, 
+    3.016
+   ], 
+   "bBoxSW": [
+    0.08, 
+    1.64
+   ]
+  }, 
+  "functionSLower": {
+   "bBoxNE": [
+    1.792, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.06
+   ]
+  }, 
+  "functionSSLower": {
+   "bBoxNE": [
+    2.352, 
+    2.224
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.888
+   ]
+  }, 
+  "functionSSUpper": {
+   "bBoxNE": [
+    3.164, 
+    3.044
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -1.076
+   ]
+  }, 
+  "functionSUpper": {
+   "bBoxNE": [
+    2.364, 
+    3.004
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.04
+   ]
+  }, 
+  "functionSeven": {
+   "bBoxNE": [
+    1.956, 
+    2.776
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionSix": {
+   "bBoxNE": [
+    1.952, 
+    2.852
+   ], 
+   "bBoxSW": [
+    0.076, 
+    -0.06
+   ]
+  }, 
+  "functionSlashedDD": {
+   "bBoxNE": [
+    3.24, 
+    3.204
+   ], 
+   "bBoxSW": [
+    -0.14, 
+    -1.0
+   ]
+  }, 
+  "functionTLower": {
+   "bBoxNE": [
+    1.044, 
+    2.676
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionTUpper": {
+   "bBoxNE": [
+    2.38, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionThree": {
+   "bBoxNE": [
+    1.964, 
+    2.852
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.052
+   ]
+  }, 
+  "functionTwo": {
+   "bBoxNE": [
+    1.968, 
+    2.852
+   ], 
+   "bBoxSW": [
+    0.072, 
+    0.0
+   ]
+  }, 
+  "functionVLower": {
+   "bBoxNE": [
+    1.92, 
+    2.096
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionVUpper": {
+   "bBoxNE": [
+    2.592, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "functionZero": {
+   "bBoxNE": [
+    1.948, 
+    2.852
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.06
+   ]
+  }, 
+  "gClef": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef0Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef10Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef11Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef12Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.772
+   ]
+  }, 
+  "gClef13Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef14Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    -0.052, 
+    -2.76
+   ]
+  }, 
+  "gClef15Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef15ma": {
+   "bBoxNE": [
+    2.732, 
+    5.72
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.748
+   ]
+  }, 
+  "gClef15mb": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.864
+   ]
+  }, 
+  "gClef16Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef17Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef2Above": {
+   "bBoxNE": [
+    3.172, 
+    4.904
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef2Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.772
+   ]
+  }, 
+  "gClef3Above": {
+   "bBoxNE": [
+    3.096, 
+    4.832
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef3Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef4Above": {
+   "bBoxNE": [
+    2.98, 
+    4.784
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef4Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef5Above": {
+   "bBoxNE": [
+    3.084, 
+    4.812
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef5Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef6Above": {
+   "bBoxNE": [
+    3.1, 
+    4.772
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef6Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef7Above": {
+   "bBoxNE": [
+    3.18, 
+    4.844
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef7Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.764
+   ]
+  }, 
+  "gClef8Above": {
+   "bBoxNE": [
+    3.172, 
+    4.824
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef8Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef8va": {
+   "bBoxNE": [
+    2.732, 
+    5.828
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef8vb": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.916
+   ]
+  }, 
+  "gClef8vbCClef": {
+   "bBoxNE": [
+    3.348, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef8vbOld": {
+   "bBoxNE": [
+    4.284, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef8vbParens": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.004
+   ]
+  }, 
+  "gClef9Above": {
+   "bBoxNE": [
+    3.132, 
+    4.784
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClef9Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefArrowDown": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.584
+   ]
+  }, 
+  "gClefArrowUp": {
+   "bBoxNE": [
+    2.732, 
+    4.76
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefChange": {
+   "bBoxNE": [
+    2.052, 
+    3.576
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.052
+   ]
+  }, 
+  "gClefFlat10Below": {
+   "bBoxNE": [
+    2.844, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat11Below": {
+   "bBoxNE": [
+    2.896, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat13Below": {
+   "bBoxNE": [
+    2.844, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat14Below": {
+   "bBoxNE": [
+    2.844, 
+    4.68
+   ], 
+   "bBoxSW": [
+    -0.052, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat15Below": {
+   "bBoxNE": [
+    2.844, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat16Below": {
+   "bBoxNE": [
+    2.844, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat1Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    -0.052, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat2Above": {
+   "bBoxNE": [
+    3.784, 
+    4.904
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat2Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.788
+   ]
+  }, 
+  "gClefFlat3Above": {
+   "bBoxNE": [
+    3.784, 
+    4.832
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat3Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.788
+   ]
+  }, 
+  "gClefFlat4Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    -0.068, 
+    -2.788
+   ]
+  }, 
+  "gClefFlat5Above": {
+   "bBoxNE": [
+    3.784, 
+    4.812
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat6Above": {
+   "bBoxNE": [
+    3.784, 
+    4.772
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat6Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.788
+   ]
+  }, 
+  "gClefFlat7Above": {
+   "bBoxNE": [
+    3.796, 
+    4.844
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat7Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.788
+   ]
+  }, 
+  "gClefFlat8Above": {
+   "bBoxNE": [
+    3.852, 
+    4.824
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat9Above": {
+   "bBoxNE": [
+    3.784, 
+    4.784
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefFlat9Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.788
+   ]
+  }, 
+  "gClefLigatedNumberAbove": {
+   "bBoxNE": [
+    2.732, 
+    4.7
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefLigatedNumberBelow": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefNat2Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.912
+   ]
+  }, 
+  "gClefNatural10Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.912
+   ]
+  }, 
+  "gClefNatural13Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.912
+   ]
+  }, 
+  "gClefNatural17Below": {
+   "bBoxNE": [
+    2.74, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.912
+   ]
+  }, 
+  "gClefNatural2Above": {
+   "bBoxNE": [
+    3.696, 
+    5.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefNatural3Above": {
+   "bBoxNE": [
+    3.668, 
+    4.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefNatural3Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.948
+   ]
+  }, 
+  "gClefNatural6Above": {
+   "bBoxNE": [
+    3.668, 
+    4.92
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefNatural6Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.06
+   ]
+  }, 
+  "gClefNatural7Above": {
+   "bBoxNE": [
+    3.668, 
+    4.92
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefNatural9Above": {
+   "bBoxNE": [
+    3.68, 
+    4.92
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefNatural9Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.992
+   ]
+  }, 
+  "gClefReversed": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefSharp12Below": {
+   "bBoxNE": [
+    2.82, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.908
+   ]
+  }, 
+  "gClefSharp1Above": {
+   "bBoxNE": [
+    3.544, 
+    4.976
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefSharp4Above": {
+   "bBoxNE": [
+    3.712, 
+    4.968
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefSharp5Below": {
+   "bBoxNE": [
+    2.732, 
+    4.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.948
+   ]
+  }, 
+  "gClefSmall": {
+   "bBoxNE": [
+    2.728, 
+    4.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.76
+   ]
+  }, 
+  "gClefTurned": {
+   "bBoxNE": [
+    2.732, 
+    4.772
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.668
+   ]
+  }, 
+  "glissandoDown": {
+   "bBoxNE": [
+    3.972, 
+    4.116
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.048
+   ]
+  }, 
+  "glissandoUp": {
+   "bBoxNE": [
+    3.972, 
+    4.116
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.048
+   ]
+  }, 
+  "graceNoteAcciaccaturaStemDown": {
+   "bBoxNE": [
+    0.98, 
+    0.372
+   ], 
+   "bBoxSW": [
+    -0.392, 
+    -2.34
+   ]
+  }, 
+  "graceNoteAcciaccaturaStemUp": {
+   "bBoxNE": [
+    1.712, 
+    2.316
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.36
+   ]
+  }, 
+  "graceNoteAppoggiaturaStemDown": {
+   "bBoxNE": [
+    0.788, 
+    0.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.34
+   ]
+  }, 
+  "graceNoteAppoggiaturaStemUp": {
+   "bBoxNE": [
+    1.48, 
+    2.328
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.356
+   ]
+  }, 
+  "graceNoteSlashStemDown": {
+   "bBoxNE": [
+    2.056, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.312
+   ]
+  }, 
+  "graceNoteSlashStemUp": {
+   "bBoxNE": [
+    2.412, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarBarreFull": {
+   "bBoxNE": [
+    1.468, 
+    1.924
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "guitarBarreHalf": {
+   "bBoxNE": [
+    3.228, 
+    1.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "guitarClosePedal": {
+   "bBoxNE": [
+    1.032, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarFadeIn": {
+   "bBoxNE": [
+    1.56, 
+    1.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarFadeOut": {
+   "bBoxNE": [
+    1.56, 
+    1.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarGolpe": {
+   "bBoxNE": [
+    1.084, 
+    1.1
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarGolpeFlamenco": {
+   "bBoxNE": [
+    1.596, 
+    1.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarHalfOpenPedal": {
+   "bBoxNE": [
+    1.032, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarLeftHandTapping": {
+   "bBoxNE": [
+    1.516, 
+    1.252
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.264
+   ]
+  }, 
+  "guitarOpenPedal": {
+   "bBoxNE": [
+    1.032, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarRightHandTapping": {
+   "bBoxNE": [
+    0.692, 
+    0.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarShake": {
+   "bBoxNE": [
+    4.508, 
+    1.468
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString0": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString1": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString2": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString3": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString4": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString5": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString6": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString7": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString8": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarString9": {
+   "bBoxNE": [
+    1.796, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarStrumDown": {
+   "bBoxNE": [
+    0.88, 
+    1.876
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarStrumUp": {
+   "bBoxNE": [
+    0.88, 
+    1.876
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarVibratoBarDip": {
+   "bBoxNE": [
+    2.14, 
+    2.052
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarVibratoBarScoop": {
+   "bBoxNE": [
+    1.928, 
+    2.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarVibratoStroke": {
+   "bBoxNE": [
+    0.66, 
+    0.508
+   ], 
+   "bBoxSW": [
+    -0.08, 
+    0.0
+   ]
+  }, 
+  "guitarVolumeSwell": {
+   "bBoxNE": [
+    3.044, 
+    1.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "guitarWideVibratoStroke": {
+   "bBoxNE": [
+    1.024, 
+    0.888
+   ], 
+   "bBoxSW": [
+    -0.104, 
+    0.0
+   ]
+  }, 
+  "handbellsBelltree": {
+   "bBoxNE": [
+    2.192, 
+    3.624
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsDamp3": {
+   "bBoxNE": [
+    2.428, 
+    2.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsEcho1": {
+   "bBoxNE": [
+    1.772, 
+    3.348
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsEcho2": {
+   "bBoxNE": [
+    0.76, 
+    2.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsGyro": {
+   "bBoxNE": [
+    2.06, 
+    2.348
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsHandMartellato": {
+   "bBoxNE": [
+    1.088, 
+    1.316
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "handbellsMalletBellOnTable": {
+   "bBoxNE": [
+    1.208, 
+    1.804
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsMalletBellSuspended": {
+   "bBoxNE": [
+    1.208, 
+    1.804
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.596
+   ]
+  }, 
+  "handbellsMalletLft": {
+   "bBoxNE": [
+    1.856, 
+    2.464
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsMartellato": {
+   "bBoxNE": [
+    1.08, 
+    0.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsMartellatoLift": {
+   "bBoxNE": [
+    1.824, 
+    2.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsMutedMartellato": {
+   "bBoxNE": [
+    1.68, 
+    1.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsPluckLift": {
+   "bBoxNE": [
+    1.316, 
+    2.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsSwing": {
+   "bBoxNE": [
+    1.536, 
+    2.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsSwingDown": {
+   "bBoxNE": [
+    0.76, 
+    2.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsSwingUp": {
+   "bBoxNE": [
+    0.76, 
+    2.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "handbellsTablePairBells": {
+   "bBoxNE": [
+    1.692, 
+    2.488
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "handbellsTableSingleBell": {
+   "bBoxNE": [
+    1.436, 
+    2.392
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpMetalRod": {
+   "bBoxNE": [
+    2.84, 
+    2.292
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpMetalRodAlt": {
+   "bBoxNE": [
+    4.296, 
+    1.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "harpPedalCentered": {
+   "bBoxNE": [
+    2.424, 
+    3.156
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    1.468
+   ]
+  }, 
+  "harpPedalDivider": {
+   "bBoxNE": [
+    2.424, 
+    4.48
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    0.12
+   ]
+  }, 
+  "harpPedalLowered": {
+   "bBoxNE": [
+    2.424, 
+    2.432
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    0.0
+   ]
+  }, 
+  "harpPedalRaised": {
+   "bBoxNE": [
+    2.424, 
+    4.624
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    2.192
+   ]
+  }, 
+  "harpSalzedoAeolianAscending": {
+   "bBoxNE": [
+    2.252, 
+    6.744
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoAeolianDescending": {
+   "bBoxNE": [
+    2.252, 
+    6.752
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "harpSalzedoDampAbove": {
+   "bBoxNE": [
+    1.256, 
+    1.252
+   ], 
+   "bBoxSW": [
+    -0.24, 
+    -0.74
+   ]
+  }, 
+  "harpSalzedoDampBelow": {
+   "bBoxNE": [
+    1.256, 
+    1.252
+   ], 
+   "bBoxSW": [
+    -0.24, 
+    -0.74
+   ]
+  }, 
+  "harpSalzedoDampBothHands": {
+   "bBoxNE": [
+    2.496, 
+    1.256
+   ], 
+   "bBoxSW": [
+    -0.244, 
+    -0.24
+   ]
+  }, 
+  "harpSalzedoDampLowStrings": {
+   "bBoxNE": [
+    1.256, 
+    2.496
+   ], 
+   "bBoxSW": [
+    -0.24, 
+    -0.244
+   ]
+  }, 
+  "harpSalzedoFluidicSoundsLeft": {
+   "bBoxNE": [
+    0.896, 
+    1.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoFluidicSoundsRight": {
+   "bBoxNE": [
+    1.352, 
+    0.964
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "harpSalzedoIsolatedSounds": {
+   "bBoxNE": [
+    2.12, 
+    2.12
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoMetallicSounds": {
+   "bBoxNE": [
+    2.26, 
+    2.3
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.308
+   ]
+  }, 
+  "harpSalzedoMetallicSoundsOneString": {
+   "bBoxNE": [
+    1.78, 
+    2.3
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.308
+   ]
+  }, 
+  "harpSalzedoMuffleTotally": {
+   "bBoxNE": [
+    2.132, 
+    2.132
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoOboicFlux": {
+   "bBoxNE": [
+    5.536, 
+    0.952
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoPlayUpperEnd": {
+   "bBoxNE": [
+    3.368, 
+    2.508
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoSlideWithSuppleness": {
+   "bBoxNE": [
+    2.224, 
+    3.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoSnareDrum": {
+   "bBoxNE": [
+    2.0, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoTamTamSounds": {
+   "bBoxNE": [
+    2.268, 
+    2.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoThunderEffect": {
+   "bBoxNE": [
+    3.744, 
+    2.648
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "harpSalzedoTimpanicSounds": {
+   "bBoxNE": [
+    2.268, 
+    2.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpSalzedoWhistlingSounds": {
+   "bBoxNE": [
+    2.2, 
+    3.12
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpStringNoiseStem": {
+   "bBoxNE": [
+    0.784, 
+    1.416
+   ], 
+   "bBoxSW": [
+    -0.784, 
+    -1.416
+   ]
+  }, 
+  "harpTuningKey": {
+   "bBoxNE": [
+    2.56, 
+    2.628
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpTuningKeyAlt": {
+   "bBoxNE": [
+    3.948, 
+    2.66
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "harpTuningKeyGlissando": {
+   "bBoxNE": [
+    3.3, 
+    4.164
+   ], 
+   "bBoxSW": [
+    0.008, 
+    0.008
+   ]
+  }, 
+  "harpTuningKeyHandle": {
+   "bBoxNE": [
+    3.86, 
+    2.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.124
+   ]
+  }, 
+  "harpTuningKeyShank": {
+   "bBoxNE": [
+    2.892, 
+    2.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.016
+   ]
+  }, 
+  "keyboardBebung2DotsAbove": {
+   "bBoxNE": [
+    1.836, 
+    0.992
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardBebung2DotsBelow": {
+   "bBoxNE": [
+    1.836, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.008
+   ]
+  }, 
+  "keyboardBebung3DotsAbove": {
+   "bBoxNE": [
+    2.072, 
+    1.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.008
+   ]
+  }, 
+  "keyboardBebung3DotsBelow": {
+   "bBoxNE": [
+    2.072, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardBebung4DotsAbove": {
+   "bBoxNE": [
+    2.668, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardBebung4DotsBelow": {
+   "bBoxNE": [
+    2.668, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardLeftPedalPictogram": {
+   "bBoxNE": [
+    1.488, 
+    2.068
+   ], 
+   "bBoxSW": [
+    -0.04, 
+    -0.08
+   ]
+  }, 
+  "keyboardMiddlePedalPictogram": {
+   "bBoxNE": [
+    1.388, 
+    2.064
+   ], 
+   "bBoxSW": [
+    -0.028, 
+    -0.124
+   ]
+  }, 
+  "keyboardPedalD": {
+   "bBoxNE": [
+    0.812, 
+    1.38
+   ], 
+   "bBoxSW": [
+    -0.484, 
+    -0.02
+   ]
+  }, 
+  "keyboardPedalDot": {
+   "bBoxNE": [
+    0.216, 
+    0.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalE": {
+   "bBoxNE": [
+    0.9, 
+    1.024
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.02
+   ]
+  }, 
+  "keyboardPedalHalf": {
+   "bBoxNE": [
+    2.84, 
+    1.808
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalHalf2": {
+   "bBoxNE": [
+    1.728, 
+    0.888
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalHalf3": {
+   "bBoxNE": [
+    1.728, 
+    1.744
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.856
+   ]
+  }, 
+  "keyboardPedalHeel1": {
+   "bBoxNE": [
+    1.496, 
+    1.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalHeel2": {
+   "bBoxNE": [
+    1.496, 
+    1.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalHeel3": {
+   "bBoxNE": [
+    1.528, 
+    1.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalHeelToToe": {
+   "bBoxNE": [
+    3.056, 
+    2.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "keyboardPedalHeelToe": {
+   "bBoxNE": [
+    1.496, 
+    3.116
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalHookEnd": {
+   "bBoxNE": [
+    0.816, 
+    2.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalHookStart": {
+   "bBoxNE": [
+    0.816, 
+    2.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalHyphen": {
+   "bBoxNE": [
+    1.188, 
+    1.224
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.776
+   ]
+  }, 
+  "keyboardPedalP": {
+   "bBoxNE": [
+    1.556, 
+    2.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "keyboardPedalParensLeft": {
+   "bBoxNE": [
+    0.524, 
+    2.12
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.16
+   ]
+  }, 
+  "keyboardPedalParensRight": {
+   "bBoxNE": [
+    0.524, 
+    2.12
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.16
+   ]
+  }, 
+  "keyboardPedalPed": {
+   "bBoxNE": [
+    3.212, 
+    2.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "keyboardPedalPedNoDot": {
+   "bBoxNE": [
+    2.944, 
+    2.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.016
+   ]
+  }, 
+  "keyboardPedalS": {
+   "bBoxNE": [
+    1.48, 
+    2.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.02
+   ]
+  }, 
+  "keyboardPedalSost": {
+   "bBoxNE": [
+    4.116, 
+    2.084
+   ], 
+   "bBoxSW": [
+    -0.044, 
+    -0.02
+   ]
+  }, 
+  "keyboardPedalSostNoDot": {
+   "bBoxNE": [
+    3.808, 
+    2.068
+   ], 
+   "bBoxSW": [
+    -0.044, 
+    -0.036
+   ]
+  }, 
+  "keyboardPedalToe1": {
+   "bBoxNE": [
+    1.456, 
+    1.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalToe2": {
+   "bBoxNE": [
+    1.456, 
+    1.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "keyboardPedalToeToHeel": {
+   "bBoxNE": [
+    3.096, 
+    2.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "keyboardPedalUp": {
+   "bBoxNE": [
+    1.74, 
+    1.744
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalUpNotch": {
+   "bBoxNE": [
+    1.092, 
+    1.808
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPedalUpSpecial": {
+   "bBoxNE": [
+    1.7, 
+    1.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.092
+   ]
+  }, 
+  "keyboardPlayWithLH": {
+   "bBoxNE": [
+    1.444, 
+    4.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPlayWithLHEnd": {
+   "bBoxNE": [
+    1.444, 
+    4.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPlayWithRH": {
+   "bBoxNE": [
+    1.444, 
+    4.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPlayWithRHEnd": {
+   "bBoxNE": [
+    1.444, 
+    4.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "keyboardPluckInside": {
+   "bBoxNE": [
+    1.908, 
+    1.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.02
+   ]
+  }, 
+  "keyboardRightPedalPictogram": {
+   "bBoxNE": [
+    1.488, 
+    2.068
+   ], 
+   "bBoxSW": [
+    -0.04, 
+    -0.08
+   ]
+  }, 
+  "kodalyHandDo": {
+   "bBoxNE": [
+    4.196, 
+    2.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "kodalyHandFa": {
+   "bBoxNE": [
+    3.368, 
+    2.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.384
+   ]
+  }, 
+  "kodalyHandLa": {
+   "bBoxNE": [
+    3.904, 
+    1.916
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.644
+   ]
+  }, 
+  "kodalyHandMi": {
+   "bBoxNE": [
+    5.4, 
+    1.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "kodalyHandRe": {
+   "bBoxNE": [
+    3.86, 
+    4.18
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.224
+   ]
+  }, 
+  "kodalyHandSo": {
+   "bBoxNE": [
+    5.232, 
+    2.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.028
+   ]
+  }, 
+  "kodalyHandTi": {
+   "bBoxNE": [
+    3.908, 
+    4.74
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.112
+   ]
+  }, 
+  "leftRepeatSmall": {
+   "bBoxNE": [
+    1.752, 
+    3.512
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.5
+   ]
+  }, 
+  "legerLine": {
+   "bBoxNE": [
+    1.524, 
+    0.044
+   ], 
+   "bBoxSW": [
+    -0.252, 
+    -0.044
+   ]
+  }, 
+  "legerLineNarrow": {
+   "bBoxNE": [
+    0.816, 
+    0.044
+   ], 
+   "bBoxSW": [
+    -0.252, 
+    -0.044
+   ]
+  }, 
+  "legerLineWide": {
+   "bBoxNE": [
+    2.28, 
+    0.044
+   ], 
+   "bBoxSW": [
+    -0.252, 
+    -0.044
+   ]
+  }, 
+  "luteGermanALower": {
+   "bBoxNE": [
+    1.06, 
+    1.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.032
+   ]
+  }, 
+  "luteGermanAUpper": {
+   "bBoxNE": [
+    1.692, 
+    2.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.064
+   ]
+  }, 
+  "luteGermanBLower": {
+   "bBoxNE": [
+    0.964, 
+    1.88
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.048
+   ]
+  }, 
+  "luteGermanBUpper": {
+   "bBoxNE": [
+    2.116, 
+    2.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.052
+   ]
+  }, 
+  "luteGermanCLower": {
+   "bBoxNE": [
+    0.744, 
+    1.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "luteGermanCUpper": {
+   "bBoxNE": [
+    1.72, 
+    2.068
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.072
+   ]
+  }, 
+  "luteGermanDLower": {
+   "bBoxNE": [
+    1.016, 
+    1.852
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.024
+   ]
+  }, 
+  "luteGermanDUpper": {
+   "bBoxNE": [
+    2.0, 
+    2.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.06
+   ]
+  }, 
+  "luteGermanELower": {
+   "bBoxNE": [
+    0.856, 
+    1.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.032
+   ]
+  }, 
+  "luteGermanEUpper": {
+   "bBoxNE": [
+    1.58, 
+    2.076
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "luteGermanFLower": {
+   "bBoxNE": [
+    0.744, 
+    1.956
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.4
+   ]
+  }, 
+  "luteGermanFUpper": {
+   "bBoxNE": [
+    1.412, 
+    2.072
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.356
+   ]
+  }, 
+  "luteGermanGLower": {
+   "bBoxNE": [
+    1.032, 
+    1.352
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.464
+   ]
+  }, 
+  "luteGermanGUpper": {
+   "bBoxNE": [
+    2.06, 
+    2.064
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "luteGermanHLower": {
+   "bBoxNE": [
+    1.012, 
+    1.96
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.284
+   ]
+  }, 
+  "luteGermanHUpper": {
+   "bBoxNE": [
+    1.716, 
+    2.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.38
+   ]
+  }, 
+  "luteGermanILower": {
+   "bBoxNE": [
+    0.496, 
+    1.864
+   ], 
+   "bBoxSW": [
+    -0.092, 
+    -0.344
+   ]
+  }, 
+  "luteGermanIUpper": {
+   "bBoxNE": [
+    1.768, 
+    2.076
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.404
+   ]
+  }, 
+  "luteGermanKLower": {
+   "bBoxNE": [
+    0.896, 
+    2.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.032
+   ]
+  }, 
+  "luteGermanKUpper": {
+   "bBoxNE": [
+    1.628, 
+    2.052
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.048
+   ]
+  }, 
+  "luteGermanLLower": {
+   "bBoxNE": [
+    0.564, 
+    1.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.068
+   ]
+  }, 
+  "luteGermanLUpper": {
+   "bBoxNE": [
+    1.58, 
+    2.044
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.064
+   ]
+  }, 
+  "luteGermanMLower": {
+   "bBoxNE": [
+    1.7, 
+    1.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "luteGermanMUpper": {
+   "bBoxNE": [
+    2.652, 
+    2.048
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.112
+   ]
+  }, 
+  "luteGermanNLower": {
+   "bBoxNE": [
+    1.128, 
+    1.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.02
+   ]
+  }, 
+  "luteGermanNUpper": {
+   "bBoxNE": [
+    2.048, 
+    2.052
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.072
+   ]
+  }, 
+  "luteGermanOLower": {
+   "bBoxNE": [
+    1.016, 
+    1.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.02
+   ]
+  }, 
+  "luteGermanPLower": {
+   "bBoxNE": [
+    1.228, 
+    1.336
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "luteGermanQLower": {
+   "bBoxNE": [
+    1.028, 
+    1.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.468
+   ]
+  }, 
+  "luteGermanRLower": {
+   "bBoxNE": [
+    0.884, 
+    1.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "luteGermanSLower": {
+   "bBoxNE": [
+    0.912, 
+    1.96
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.392
+   ]
+  }, 
+  "luteGermanTLower": {
+   "bBoxNE": [
+    0.708, 
+    1.74
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "luteGermanVLower": {
+   "bBoxNE": [
+    1.036, 
+    1.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.02
+   ]
+  }, 
+  "luteGermanXLower": {
+   "bBoxNE": [
+    1.04, 
+    1.44
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.252
+   ]
+  }, 
+  "luteGermanYLower": {
+   "bBoxNE": [
+    1.124, 
+    1.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.412
+   ]
+  }, 
+  "luteGermanZLower": {
+   "bBoxNE": [
+    0.82, 
+    1.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "lyricsElision": {
+   "bBoxNE": [
+    1.64, 
+    -0.168
+   ], 
+   "bBoxSW": [
+    -0.232, 
+    -0.596
+   ]
+  }, 
+  "lyricsElisionNarrow": {
+   "bBoxNE": [
+    1.24, 
+    -0.168
+   ], 
+   "bBoxSW": [
+    -0.232, 
+    -0.596
+   ]
+  }, 
+  "lyricsElisionWide": {
+   "bBoxNE": [
+    2.28, 
+    -0.168
+   ], 
+   "bBoxSW": [
+    -0.232, 
+    -0.596
+   ]
+  }, 
+  "lyricsHyphenBaseline": {
+   "bBoxNE": [
+    1.144, 
+    0.144
+   ], 
+   "bBoxSW": [
+    0.132, 
+    -0.148
+   ]
+  }, 
+  "lyricsHyphenBaselineNonBreaking": {
+   "bBoxNE": [
+    1.144, 
+    0.144
+   ], 
+   "bBoxSW": [
+    0.132, 
+    -0.148
+   ]
+  }, 
+  "lyricsTextRepeat": {
+   "bBoxNE": [
+    1.608, 
+    1.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "medRenFlatHardB": {
+   "bBoxNE": [
+    0.696, 
+    1.656
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "medRenFlatSoftB": {
+   "bBoxNE": [
+    0.852, 
+    1.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.612
+   ]
+  }, 
+  "medRenFlatWithDot": {
+   "bBoxNE": [
+    0.88, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.632
+   ]
+  }, 
+  "medRenGClefCMN": {
+   "bBoxNE": [
+    1.52, 
+    2.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "medRenLiquescenceCMN": {
+   "bBoxNE": [
+    1.324, 
+    0.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.544
+   ]
+  }, 
+  "medRenLiquescentAscCMN": {
+   "bBoxNE": [
+    1.096, 
+    1.28
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.508
+   ]
+  }, 
+  "medRenLiquescentDescCMN": {
+   "bBoxNE": [
+    1.096, 
+    0.508
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.28
+   ]
+  }, 
+  "medRenNatural": {
+   "bBoxNE": [
+    0.48, 
+    1.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "medRenNaturalWithCross": {
+   "bBoxNE": [
+    0.624, 
+    1.336
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.344
+   ]
+  }, 
+  "medRenOriscusCMN": {
+   "bBoxNE": [
+    1.268, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "medRenPlicaCMN": {
+   "bBoxNE": [
+    0.6, 
+    0.384
+   ], 
+   "bBoxSW": [
+    -0.6, 
+    -0.384
+   ]
+  }, 
+  "medRenPunctumCMN": {
+   "bBoxNE": [
+    1.096, 
+    0.508
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.508
+   ]
+  }, 
+  "medRenQuilismaCMN": {
+   "bBoxNE": [
+    1.612, 
+    0.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "medRenSharpCroix": {
+   "bBoxNE": [
+    1.264, 
+    0.468
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.476
+   ]
+  }, 
+  "medRenStrophicusCMN": {
+   "bBoxNE": [
+    0.712, 
+    0.548
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "mensuralAlterationSign": {
+   "bBoxNE": [
+    1.192, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralBlackBrevis": {
+   "bBoxNE": [
+    1.328, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralBlackBrevisVoid": {
+   "bBoxNE": [
+    1.328, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralBlackDragma": {
+   "bBoxNE": [
+    1.136, 
+    2.576
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.576
+   ]
+  }, 
+  "mensuralBlackLonga": {
+   "bBoxNE": [
+    1.328, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.564
+   ]
+  }, 
+  "mensuralBlackMaxima": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.564
+   ]
+  }, 
+  "mensuralBlackMinima": {
+   "bBoxNE": [
+    1.136, 
+    2.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "mensuralBlackMinimaVoid": {
+   "bBoxNE": [
+    1.136, 
+    2.648
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "mensuralBlackSemibrevis": {
+   "bBoxNE": [
+    1.136, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "mensuralBlackSemibrevisCaudata": {
+   "bBoxNE": [
+    1.136, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.576
+   ]
+  }, 
+  "mensuralBlackSemibrevisOblique": {
+   "bBoxNE": [
+    2.044, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.984
+   ]
+  }, 
+  "mensuralBlackSemibrevisVoid": {
+   "bBoxNE": [
+    1.136, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "mensuralBlackSemiminima": {
+   "bBoxNE": [
+    1.316, 
+    2.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "mensuralCclef": {
+   "bBoxNE": [
+    2.584, 
+    1.992
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.984
+   ]
+  }, 
+  "mensuralCclefPetrucciPosHigh": {
+   "bBoxNE": [
+    0.976, 
+    2.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.16
+   ]
+  }, 
+  "mensuralCclefPetrucciPosHighest": {
+   "bBoxNE": [
+    0.976, 
+    1.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.164
+   ]
+  }, 
+  "mensuralCclefPetrucciPosLow": {
+   "bBoxNE": [
+    0.976, 
+    3.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.368
+   ]
+  }, 
+  "mensuralCclefPetrucciPosLowest": {
+   "bBoxNE": [
+    0.976, 
+    3.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.396
+   ]
+  }, 
+  "mensuralCclefPetrucciPosMiddle": {
+   "bBoxNE": [
+    0.976, 
+    3.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.164
+   ]
+  }, 
+  "mensuralColorationEndRound": {
+   "bBoxNE": [
+    0.732, 
+    0.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralColorationEndSquare": {
+   "bBoxNE": [
+    0.732, 
+    0.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralColorationStartRound": {
+   "bBoxNE": [
+    0.732, 
+    0.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralColorationStartSquare": {
+   "bBoxNE": [
+    0.732, 
+    0.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralCombStemDiagonal": {
+   "bBoxNE": [
+    0.776, 
+    0.772
+   ], 
+   "bBoxSW": [
+    -0.776, 
+    -0.776
+   ]
+  }, 
+  "mensuralCombStemDown": {
+   "bBoxNE": [
+    0.128, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.128
+   ]
+  }, 
+  "mensuralCombStemDownFlagExtended": {
+   "bBoxNE": [
+    0.844, 
+    0.0
+   ], 
+   "bBoxSW": [
+    -0.492, 
+    -3.128
+   ]
+  }, 
+  "mensuralCombStemDownFlagFlared": {
+   "bBoxNE": [
+    0.844, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.128
+   ]
+  }, 
+  "mensuralCombStemDownFlagFusa": {
+   "bBoxNE": [
+    0.856, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.128
+   ]
+  }, 
+  "mensuralCombStemDownFlagLeft": {
+   "bBoxNE": [
+    0.128, 
+    0.0
+   ], 
+   "bBoxSW": [
+    -0.716, 
+    -3.128
+   ]
+  }, 
+  "mensuralCombStemDownFlagRight": {
+   "bBoxNE": [
+    0.844, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.128
+   ]
+  }, 
+  "mensuralCombStemDownFlagSemiminima": {
+   "bBoxNE": [
+    0.856, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.128
+   ]
+  }, 
+  "mensuralCombStemUp": {
+   "bBoxNE": [
+    0.128, 
+    3.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralCombStemUpFlagExtended": {
+   "bBoxNE": [
+    0.844, 
+    3.128
+   ], 
+   "bBoxSW": [
+    -0.492, 
+    0.0
+   ]
+  }, 
+  "mensuralCombStemUpFlagFlared": {
+   "bBoxNE": [
+    0.844, 
+    3.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralCombStemUpFlagFusa": {
+   "bBoxNE": [
+    0.856, 
+    3.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralCombStemUpFlagLeft": {
+   "bBoxNE": [
+    0.128, 
+    3.128
+   ], 
+   "bBoxSW": [
+    -0.716, 
+    0.0
+   ]
+  }, 
+  "mensuralCombStemUpFlagRight": {
+   "bBoxNE": [
+    0.844, 
+    3.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralCombStemUpFlagSemiminima": {
+   "bBoxNE": [
+    0.856, 
+    3.128
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralCustosCheckmark": {
+   "bBoxNE": [
+    2.196, 
+    1.852
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "mensuralCustosDown": {
+   "bBoxNE": [
+    2.456, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.504
+   ]
+  }, 
+  "mensuralCustosTurn": {
+   "bBoxNE": [
+    1.868, 
+    0.932
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralCustosUp": {
+   "bBoxNE": [
+    2.456, 
+    1.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "mensuralFclef": {
+   "bBoxNE": [
+    1.268, 
+    0.76
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.76
+   ]
+  }, 
+  "mensuralFclefPetrucci": {
+   "bBoxNE": [
+    2.272, 
+    2.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.284
+   ]
+  }, 
+  "mensuralGclef": {
+   "bBoxNE": [
+    1.436, 
+    0.98
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.884
+   ]
+  }, 
+  "mensuralGclefPetrucci": {
+   "bBoxNE": [
+    1.236, 
+    3.772
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.652
+   ]
+  }, 
+  "mensuralModusImperfectumVert": {
+   "bBoxNE": [
+    4.192, 
+    1.344
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.344
+   ]
+  }, 
+  "mensuralModusPerfectumVert": {
+   "bBoxNE": [
+    4.192, 
+    1.344
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.344
+   ]
+  }, 
+  "mensuralNoteheadLongaBlack": {
+   "bBoxNE": [
+    1.328, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralNoteheadLongaBlackVoid": {
+   "bBoxNE": [
+    1.328, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralNoteheadLongaVoid": {
+   "bBoxNE": [
+    1.328, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralNoteheadLongaWhite": {
+   "bBoxNE": [
+    1.28, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.708
+   ]
+  }, 
+  "mensuralNoteheadMaximaBlack": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralNoteheadMaximaBlackVoid": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralNoteheadMaximaVoid": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralNoteheadMaximaWhite": {
+   "bBoxNE": [
+    2.44, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.708
+   ]
+  }, 
+  "mensuralNoteheadMinimaWhite": {
+   "bBoxNE": [
+    1.272, 
+    0.736
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.736
+   ]
+  }, 
+  "mensuralNoteheadSemibrevisBlack": {
+   "bBoxNE": [
+    1.136, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "mensuralNoteheadSemibrevisBlackVoid": {
+   "bBoxNE": [
+    1.128, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralNoteheadSemibrevisBlackVoidTurned": {
+   "bBoxNE": [
+    1.128, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralNoteheadSemibrevisVoid": {
+   "bBoxNE": [
+    1.136, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "mensuralNoteheadSemiminimaWhite": {
+   "bBoxNE": [
+    1.272, 
+    0.736
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.736
+   ]
+  }, 
+  "mensuralObliqueAsc2ndBlack": {
+   "bBoxNE": [
+    3.08, 
+    1.064
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc2ndBlackVoid": {
+   "bBoxNE": [
+    3.08, 
+    1.064
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc2ndVoid": {
+   "bBoxNE": [
+    3.08, 
+    1.064
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc2ndWhite": {
+   "bBoxNE": [
+    3.08, 
+    1.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.708
+   ]
+  }, 
+  "mensuralObliqueAsc3rdBlack": {
+   "bBoxNE": [
+    3.08, 
+    1.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc3rdBlackVoid": {
+   "bBoxNE": [
+    3.08, 
+    1.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc3rdVoid": {
+   "bBoxNE": [
+    3.08, 
+    1.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc3rdWhite": {
+   "bBoxNE": [
+    3.08, 
+    1.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.708
+   ]
+  }, 
+  "mensuralObliqueAsc4thBlack": {
+   "bBoxNE": [
+    3.08, 
+    2.064
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc4thBlackVoid": {
+   "bBoxNE": [
+    3.128, 
+    2.1
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "mensuralObliqueAsc4thVoid": {
+   "bBoxNE": [
+    3.08, 
+    2.064
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc4thWhite": {
+   "bBoxNE": [
+    3.08, 
+    2.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.708
+   ]
+  }, 
+  "mensuralObliqueAsc5thBlack": {
+   "bBoxNE": [
+    3.08, 
+    2.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc5thBlackVoid": {
+   "bBoxNE": [
+    3.08, 
+    2.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc5thVoid": {
+   "bBoxNE": [
+    3.08, 
+    2.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "mensuralObliqueAsc5thWhite": {
+   "bBoxNE": [
+    3.08, 
+    2.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.708
+   ]
+  }, 
+  "mensuralObliqueDesc2ndBlack": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.064
+   ]
+  }, 
+  "mensuralObliqueDesc2ndBlackVoid": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.064
+   ]
+  }, 
+  "mensuralObliqueDesc2ndVoid": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.064
+   ]
+  }, 
+  "mensuralObliqueDesc2ndWhite": {
+   "bBoxNE": [
+    3.08, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.208
+   ]
+  }, 
+  "mensuralObliqueDesc3rdBlack": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.564
+   ]
+  }, 
+  "mensuralObliqueDesc3rdBlackVoid": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.564
+   ]
+  }, 
+  "mensuralObliqueDesc3rdVoid": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.564
+   ]
+  }, 
+  "mensuralObliqueDesc3rdWhite": {
+   "bBoxNE": [
+    3.08, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.708
+   ]
+  }, 
+  "mensuralObliqueDesc4thBlack": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.064
+   ]
+  }, 
+  "mensuralObliqueDesc4thBlackVoid": {
+   "bBoxNE": [
+    3.128, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.1
+   ]
+  }, 
+  "mensuralObliqueDesc4thVoid": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.064
+   ]
+  }, 
+  "mensuralObliqueDesc4thWhite": {
+   "bBoxNE": [
+    3.08, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.208
+   ]
+  }, 
+  "mensuralObliqueDesc5thBlack": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.564
+   ]
+  }, 
+  "mensuralObliqueDesc5thBlackVoid": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.564
+   ]
+  }, 
+  "mensuralObliqueDesc5thVoid": {
+   "bBoxNE": [
+    3.08, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.564
+   ]
+  }, 
+  "mensuralObliqueDesc5thWhite": {
+   "bBoxNE": [
+    3.08, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.708
+   ]
+  }, 
+  "mensuralProlation1": {
+   "bBoxNE": [
+    1.856, 
+    0.928
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.928
+   ]
+  }, 
+  "mensuralProlation10": {
+   "bBoxNE": [
+    1.74, 
+    1.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.4
+   ]
+  }, 
+  "mensuralProlation11": {
+   "bBoxNE": [
+    1.74, 
+    0.928
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.928
+   ]
+  }, 
+  "mensuralProlation2": {
+   "bBoxNE": [
+    1.856, 
+    0.928
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.928
+   ]
+  }, 
+  "mensuralProlation3": {
+   "bBoxNE": [
+    1.856, 
+    1.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.4
+   ]
+  }, 
+  "mensuralProlation4": {
+   "bBoxNE": [
+    1.856, 
+    1.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.4
+   ]
+  }, 
+  "mensuralProlation5": {
+   "bBoxNE": [
+    1.74, 
+    0.928
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.928
+   ]
+  }, 
+  "mensuralProlation6": {
+   "bBoxNE": [
+    1.74, 
+    0.928
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.928
+   ]
+  }, 
+  "mensuralProlation7": {
+   "bBoxNE": [
+    1.74, 
+    0.928
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.928
+   ]
+  }, 
+  "mensuralProlation8": {
+   "bBoxNE": [
+    1.74, 
+    1.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.4
+   ]
+  }, 
+  "mensuralProlation9": {
+   "bBoxNE": [
+    1.74, 
+    1.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.4
+   ]
+  }, 
+  "mensuralProlationCombiningDot": {
+   "bBoxNE": [
+    0.492, 
+    0.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.244
+   ]
+  }, 
+  "mensuralProlationCombiningDotVoid": {
+   "bBoxNE": [
+    1.284, 
+    0.644
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.64
+   ]
+  }, 
+  "mensuralProlationCombiningStroke": {
+   "bBoxNE": [
+    0.176, 
+    1.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.48
+   ]
+  }, 
+  "mensuralProlationCombiningThreeDots": {
+   "bBoxNE": [
+    1.456, 
+    0.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.208
+   ]
+  }, 
+  "mensuralProlationCombiningThreeDotsTri": {
+   "bBoxNE": [
+    1.064, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "mensuralProlationCombiningTwoDots": {
+   "bBoxNE": [
+    1.076, 
+    0.224
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.22
+   ]
+  }, 
+  "mensuralProportion1": {
+   "bBoxNE": [
+    0.836, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.0
+   ]
+  }, 
+  "mensuralProportion2": {
+   "bBoxNE": [
+    1.256, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.0
+   ]
+  }, 
+  "mensuralProportion3": {
+   "bBoxNE": [
+    0.968, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.008
+   ]
+  }, 
+  "mensuralProportion4": {
+   "bBoxNE": [
+    1.276, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.0
+   ]
+  }, 
+  "mensuralProportion4Old": {
+   "bBoxNE": [
+    1.764, 
+    0.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.004
+   ]
+  }, 
+  "mensuralProportionMajor": {
+   "bBoxNE": [
+    0.892, 
+    1.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.496
+   ]
+  }, 
+  "mensuralProportionMinor": {
+   "bBoxNE": [
+    0.892, 
+    1.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.496
+   ]
+  }, 
+  "mensuralProportionProportioDupla1": {
+   "bBoxNE": [
+    2.72, 
+    0.928
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.928
+   ]
+  }, 
+  "mensuralProportionProportioDupla2": {
+   "bBoxNE": [
+    1.944, 
+    0.972
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.972
+   ]
+  }, 
+  "mensuralProportionProportioQuadrupla": {
+   "bBoxNE": [
+    1.944, 
+    0.972
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.972
+   ]
+  }, 
+  "mensuralProportionProportioTripla": {
+   "bBoxNE": [
+    1.944, 
+    0.972
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.972
+   ]
+  }, 
+  "mensuralProportionTempusPerfectum": {
+   "bBoxNE": [
+    1.944, 
+    0.972
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.972
+   ]
+  }, 
+  "mensuralRestBrevis": {
+   "bBoxNE": [
+    0.208, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralRestFusa": {
+   "bBoxNE": [
+    0.56, 
+    0.66
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralRestLongaImperfecta": {
+   "bBoxNE": [
+    0.208, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.0
+   ]
+  }, 
+  "mensuralRestLongaPerfecta": {
+   "bBoxNE": [
+    0.208, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.0
+   ]
+  }, 
+  "mensuralRestMaxima": {
+   "bBoxNE": [
+    0.608, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.0
+   ]
+  }, 
+  "mensuralRestMinima": {
+   "bBoxNE": [
+    0.208, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralRestSemibrevis": {
+   "bBoxNE": [
+    0.208, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.5
+   ]
+  }, 
+  "mensuralRestSemifusa": {
+   "bBoxNE": [
+    0.56, 
+    0.66
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralRestSemiminima": {
+   "bBoxNE": [
+    0.56, 
+    0.66
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralSignumDown": {
+   "bBoxNE": [
+    1.292, 
+    1.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralSignumUp": {
+   "bBoxNE": [
+    1.292, 
+    1.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "mensuralTempusImperfectumHoriz": {
+   "bBoxNE": [
+    4.192, 
+    1.344
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.344
+   ]
+  }, 
+  "mensuralTempusPerfectumHoriz": {
+   "bBoxNE": [
+    4.192, 
+    1.344
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.344
+   ]
+  }, 
+  "mensuralWhiteBrevis": {
+   "bBoxNE": [
+    1.28, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.708
+   ]
+  }, 
+  "mensuralWhiteFusa": {
+   "bBoxNE": [
+    1.368, 
+    3.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.736
+   ]
+  }, 
+  "mensuralWhiteLonga": {
+   "bBoxNE": [
+    1.28, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.528
+   ]
+  }, 
+  "mensuralWhiteMaxima": {
+   "bBoxNE": [
+    2.44, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.524
+   ]
+  }, 
+  "mensuralWhiteMinima": {
+   "bBoxNE": [
+    1.272, 
+    0.736
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.736
+   ]
+  }, 
+  "mensuralWhiteSemiminima": {
+   "bBoxNE": [
+    1.272, 
+    3.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.736
+   ]
+  }, 
+  "metAugmentationDot": {
+   "bBoxNE": [
+    0.404, 
+    0.204
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.2
+   ]
+  }, 
+  "metNote1024thDown": {
+   "bBoxNE": [
+    1.32, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -7.788
+   ]
+  }, 
+  "metNote1024thUp": {
+   "bBoxNE": [
+    2.376, 
+    7.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metNote128thDown": {
+   "bBoxNE": [
+    1.32, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -5.476
+   ]
+  }, 
+  "metNote128thUp": {
+   "bBoxNE": [
+    2.376, 
+    5.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metNote16thDown": {
+   "bBoxNE": [
+    1.32, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.084
+   ]
+  }, 
+  "metNote16thUp": {
+   "bBoxNE": [
+    2.376, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metNote256thDown": {
+   "bBoxNE": [
+    1.32, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -6.24
+   ]
+  }, 
+  "metNote256thUp": {
+   "bBoxNE": [
+    2.376, 
+    6.148
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metNote32ndDown": {
+   "bBoxNE": [
+    1.32, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.884
+   ]
+  }, 
+  "metNote32ndUp": {
+   "bBoxNE": [
+    2.376, 
+    3.816
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metNote512thDown": {
+   "bBoxNE": [
+    1.32, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -7.02
+   ]
+  }, 
+  "metNote512thUp": {
+   "bBoxNE": [
+    2.376, 
+    6.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metNote64thDown": {
+   "bBoxNE": [
+    1.32, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.66
+   ]
+  }, 
+  "metNote64thUp": {
+   "bBoxNE": [
+    2.376, 
+    4.604
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metNote8thDown": {
+   "bBoxNE": [
+    1.32, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.056
+   ]
+  }, 
+  "metNote8thUp": {
+   "bBoxNE": [
+    2.264, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metNoteDoubleWhole": {
+   "bBoxNE": [
+    2.472, 
+    0.632
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.604
+   ]
+  }, 
+  "metNoteDoubleWholeSquare": {
+   "bBoxNE": [
+    2.108, 
+    1.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.056
+   ]
+  }, 
+  "metNoteHalfDown": {
+   "bBoxNE": [
+    1.368, 
+    0.548
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.044
+   ]
+  }, 
+  "metNoteHalfUp": {
+   "bBoxNE": [
+    1.368, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.556
+   ]
+  }, 
+  "metNoteQuarterDown": {
+   "bBoxNE": [
+    1.32, 
+    0.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.06
+   ]
+  }, 
+  "metNoteQuarterUp": {
+   "bBoxNE": [
+    1.32, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metNoteWhole": {
+   "bBoxNE": [
+    1.744, 
+    0.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "metricModulationArrowLeft": {
+   "bBoxNE": [
+    2.904, 
+    1.784
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.872
+   ]
+  }, 
+  "metricModulationArrowRight": {
+   "bBoxNE": [
+    2.904, 
+    1.784
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.872
+   ]
+  }, 
+  "miscDoNotCopy": {
+   "bBoxNE": [
+    5.552, 
+    3.912
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.64
+   ]
+  }, 
+  "miscDoNotPhotocopy": {
+   "bBoxNE": [
+    5.552, 
+    3.912
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.64
+   ]
+  }, 
+  "miscEyeglasses": {
+   "bBoxNE": [
+    4.216, 
+    2.784
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "note1024thDown": {
+   "bBoxNE": [
+    1.296, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -6.784
+   ]
+  }, 
+  "note1024thUp": {
+   "bBoxNE": [
+    2.38, 
+    7.28
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "note128thDown": {
+   "bBoxNE": [
+    1.292, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.976
+   ]
+  }, 
+  "note128thUp": {
+   "bBoxNE": [
+    2.38, 
+    5.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "note16thDown": {
+   "bBoxNE": [
+    1.284, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.688
+   ]
+  }, 
+  "note16thUp": {
+   "bBoxNE": [
+    2.376, 
+    3.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "note256thDown": {
+   "bBoxNE": [
+    1.296, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -5.576
+   ]
+  }, 
+  "note256thUp": {
+   "bBoxNE": [
+    2.38, 
+    5.944
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "note32ndDown": {
+   "bBoxNE": [
+    1.292, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.448
+   ]
+  }, 
+  "note32ndUp": {
+   "bBoxNE": [
+    2.38, 
+    4.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "note512thDown": {
+   "bBoxNE": [
+    1.296, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -6.176
+   ]
+  }, 
+  "note512thUp": {
+   "bBoxNE": [
+    2.38, 
+    6.604
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "note64thDown": {
+   "bBoxNE": [
+    1.292, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.544
+   ]
+  }, 
+  "note64thUp": {
+   "bBoxNE": [
+    2.38, 
+    4.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "note8thDown": {
+   "bBoxNE": [
+    1.272, 
+    0.508
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.568
+   ]
+  }, 
+  "note8thUp": {
+   "bBoxNE": [
+    2.248, 
+    3.576
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteABlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteAFlatBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteAFlatHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteAFlatWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteAHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteASharpBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteASharpHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteASharpWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteAWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteBBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteBFlatBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteBFlatHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteBFlatWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteBHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteBSharpBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteBSharpHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteBSharpWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteBWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteCBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteCFlatBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteCFlatHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteCFlatWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteCHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteCSharpBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteCSharpHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteCSharpWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteCWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteDBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteDFlatBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteDFlatHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteDFlatWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteDHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteDSharpBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteDSharpHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteDSharpWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteDWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteDoBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteDoHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteDoWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteDoubleWhole": {
+   "bBoxNE": [
+    2.38, 
+    0.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.98
+   ]
+  }, 
+  "noteDoubleWholeSquare": {
+   "bBoxNE": [
+    2.028, 
+    1.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "noteEBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteEFlatBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteEFlatHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteEFlatWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteEHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteESharpBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteESharpHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteESharpWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteEWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteEmptyBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteEmptyHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteEmptyWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteFBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteFFlatBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteFFlatHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteFFlatWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteFHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteFSharpBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteFSharpHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteFSharpWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteFWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteFaBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteFaHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteFaWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteGBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteGFlatBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteGFlatHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteGFlatWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteGHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteGSharpBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteGSharpHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteGSharpWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteGWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteHBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteHHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteHSharpBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteHSharpHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteHSharpWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteHWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteHalfDown": {
+   "bBoxNE": [
+    1.312, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.6
+   ]
+  }, 
+  "noteHalfUp": {
+   "bBoxNE": [
+    1.312, 
+    3.6
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "noteLaBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteLaHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteLaWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteMiBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteMiHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteMiWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteQuarterDown": {
+   "bBoxNE": [
+    1.272, 
+    0.508
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.576
+   ]
+  }, 
+  "noteQuarterUp": {
+   "bBoxNE": [
+    1.272, 
+    3.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteReBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteReHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteReWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteShapeArrowheadLeftBlack": {
+   "bBoxNE": [
+    1.296, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "noteShapeArrowheadLeftWhite": {
+   "bBoxNE": [
+    1.296, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "noteShapeDiamondBlack": {
+   "bBoxNE": [
+    1.532, 
+    0.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.544
+   ]
+  }, 
+  "noteShapeDiamondWhite": {
+   "bBoxNE": [
+    1.532, 
+    0.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.544
+   ]
+  }, 
+  "noteShapeIsoscelesTriangleBlack": {
+   "bBoxNE": [
+    1.272, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "noteShapeIsoscelesTriangleWhite": {
+   "bBoxNE": [
+    1.272, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "noteShapeKeystoneBlack": {
+   "bBoxNE": [
+    1.412, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.508
+   ]
+  }, 
+  "noteShapeKeystoneWhite": {
+   "bBoxNE": [
+    1.412, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.508
+   ]
+  }, 
+  "noteShapeMoonBlack": {
+   "bBoxNE": [
+    1.532, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteShapeMoonLeftBlack": {
+   "bBoxNE": [
+    1.124, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteShapeMoonLeftWhite": {
+   "bBoxNE": [
+    1.124, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteShapeMoonWhite": {
+   "bBoxNE": [
+    1.532, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteShapeQuarterMoonBlack": {
+   "bBoxNE": [
+    1.12, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteShapeQuarterMoonWhite": {
+   "bBoxNE": [
+    1.12, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteShapeRoundBlack": {
+   "bBoxNE": [
+    1.276, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.004, 
+    -0.528
+   ]
+  }, 
+  "noteShapeRoundWhite": {
+   "bBoxNE": [
+    1.312, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "noteShapeSquareBlack": {
+   "bBoxNE": [
+    1.532, 
+    0.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "noteShapeSquareWhite": {
+   "bBoxNE": [
+    1.532, 
+    0.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "noteShapeTriangleLeftBlack": {
+   "bBoxNE": [
+    1.532, 
+    0.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "noteShapeTriangleLeftWhite": {
+   "bBoxNE": [
+    1.532, 
+    0.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "noteShapeTriangleRightBlack": {
+   "bBoxNE": [
+    1.532, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "noteShapeTriangleRightWhite": {
+   "bBoxNE": [
+    1.532, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "noteShapeTriangleRoundBlack": {
+   "bBoxNE": [
+    1.532, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.544
+   ]
+  }, 
+  "noteShapeTriangleRoundLeftBlack": {
+   "bBoxNE": [
+    1.396, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "noteShapeTriangleRoundLeftWhite": {
+   "bBoxNE": [
+    1.396, 
+    0.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.564
+   ]
+  }, 
+  "noteShapeTriangleRoundWhite": {
+   "bBoxNE": [
+    1.532, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.544
+   ]
+  }, 
+  "noteShapeTriangleUpBlack": {
+   "bBoxNE": [
+    1.532, 
+    0.552
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "noteShapeTriangleUpWhite": {
+   "bBoxNE": [
+    1.532, 
+    0.552
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "noteSiBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteSiHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteSiWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteSoBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteSoHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteSoWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteTiBlack": {
+   "bBoxNE": [
+    1.4, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteTiHalf": {
+   "bBoxNE": [
+    1.452, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteTiWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteWhole": {
+   "bBoxNE": [
+    1.68, 
+    0.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteheadBlack": {
+   "bBoxNE": [
+    1.272, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteheadBlackParens": {
+   "bBoxNE": [
+    2.276, 
+    0.748
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.696
+   ]
+  }, 
+  "noteheadCircleSlash": {
+   "bBoxNE": [
+    1.032, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteheadCircleX": {
+   "bBoxNE": [
+    1.088, 
+    0.552
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteheadCircleXDoubleWhole": {
+   "bBoxNE": [
+    1.852, 
+    0.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadCircleXHalf": {
+   "bBoxNE": [
+    1.088, 
+    0.552
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteheadCircleXWhole": {
+   "bBoxNE": [
+    1.088, 
+    0.552
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteheadCircledBlack": {
+   "bBoxNE": [
+    1.3, 
+    0.696
+   ], 
+   "bBoxSW": [
+    -0.092, 
+    -0.696
+   ]
+  }, 
+  "noteheadCircledBlackLarge": {
+   "bBoxNE": [
+    1.404, 
+    0.8
+   ], 
+   "bBoxSW": [
+    -0.192, 
+    -0.8
+   ]
+  }, 
+  "noteheadCircledDoubleWhole": {
+   "bBoxNE": [
+    2.52, 
+    0.888
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.888
+   ]
+  }, 
+  "noteheadCircledDoubleWholeLarge": {
+   "bBoxNE": [
+    2.336, 
+    0.84
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.844
+   ]
+  }, 
+  "noteheadCircledHalf": {
+   "bBoxNE": [
+    1.288, 
+    0.696
+   ], 
+   "bBoxSW": [
+    -0.104, 
+    -0.696
+   ]
+  }, 
+  "noteheadCircledHalfLarge": {
+   "bBoxNE": [
+    1.392, 
+    0.8
+   ], 
+   "bBoxSW": [
+    -0.204, 
+    -0.8
+   ]
+  }, 
+  "noteheadCircledWhole": {
+   "bBoxNE": [
+    1.776, 
+    0.888
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.888
+   ]
+  }, 
+  "noteheadCircledWholeLarge": {
+   "bBoxNE": [
+    2.224, 
+    0.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.804
+   ]
+  }, 
+  "noteheadCircledXLarge": {
+   "bBoxNE": [
+    1.596, 
+    0.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.8
+   ]
+  }, 
+  "noteheadClusterDoubleWhole2nd": {
+   "bBoxNE": [
+    2.52, 
+    1.132
+   ], 
+   "bBoxSW": [
+    0.004, 
+    -0.592
+   ]
+  }, 
+  "noteheadClusterDoubleWhole3rd": {
+   "bBoxNE": [
+    2.516, 
+    1.62
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.596
+   ]
+  }, 
+  "noteheadClusterDoubleWholeBottom": {
+   "bBoxNE": [
+    2.376, 
+    0.772
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadClusterDoubleWholeMiddle": {
+   "bBoxNE": [
+    2.376, 
+    0.384
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.384
+   ]
+  }, 
+  "noteheadClusterDoubleWholeTop": {
+   "bBoxNE": [
+    2.376, 
+    0.604
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.776
+   ]
+  }, 
+  "noteheadClusterHalf2nd": {
+   "bBoxNE": [
+    1.312, 
+    1.024
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "noteheadClusterHalf3rd": {
+   "bBoxNE": [
+    1.312, 
+    1.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "noteheadClusterHalfBottom": {
+   "bBoxNE": [
+    1.312, 
+    0.768
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "noteheadClusterHalfMiddle": {
+   "bBoxNE": [
+    1.1, 
+    0.384
+   ], 
+   "bBoxSW": [
+    0.232, 
+    -0.384
+   ]
+  }, 
+  "noteheadClusterHalfTop": {
+   "bBoxNE": [
+    1.312, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.768
+   ]
+  }, 
+  "noteheadClusterQuarter2nd": {
+   "bBoxNE": [
+    1.272, 
+    1.06
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "noteheadClusterQuarter3rd": {
+   "bBoxNE": [
+    1.272, 
+    1.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "noteheadClusterQuarterBottom": {
+   "bBoxNE": [
+    1.272, 
+    0.776
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteheadClusterQuarterMiddle": {
+   "bBoxNE": [
+    0.972, 
+    0.42
+   ], 
+   "bBoxSW": [
+    0.3, 
+    -0.42
+   ]
+  }, 
+  "noteheadClusterQuarterTop": {
+   "bBoxNE": [
+    1.272, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.78
+   ]
+  }, 
+  "noteheadClusterRoundBlack": {
+   "bBoxNE": [
+    1.312, 
+    2.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "noteheadClusterRoundWhite": {
+   "bBoxNE": [
+    1.312, 
+    2.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "noteheadClusterSquareBlack": {
+   "bBoxNE": [
+    1.208, 
+    2.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "noteheadClusterSquareWhite": {
+   "bBoxNE": [
+    1.208, 
+    2.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "noteheadClusterWhole2nd": {
+   "bBoxNE": [
+    1.68, 
+    1.068
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "noteheadClusterWhole3rd": {
+   "bBoxNE": [
+    1.688, 
+    1.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteheadClusterWholeBottom": {
+   "bBoxNE": [
+    1.68, 
+    0.768
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteheadClusterWholeMiddle": {
+   "bBoxNE": [
+    1.308, 
+    0.384
+   ], 
+   "bBoxSW": [
+    0.392, 
+    -0.384
+   ]
+  }, 
+  "noteheadClusterWholeTop": {
+   "bBoxNE": [
+    1.68, 
+    0.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.776
+   ]
+  }, 
+  "noteheadDiamondBlack": {
+   "bBoxNE": [
+    1.132, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "noteheadDiamondBlackOld": {
+   "bBoxNE": [
+    1.2, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadDiamondBlackWide": {
+   "bBoxNE": [
+    1.496, 
+    0.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "noteheadDiamondClusterBlack2nd": {
+   "bBoxNE": [
+    1.392, 
+    1.204
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteheadDiamondClusterBlack3rd": {
+   "bBoxNE": [
+    1.392, 
+    1.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteheadDiamondClusterBlackBottom": {
+   "bBoxNE": [
+    1.392, 
+    0.712
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteheadDiamondClusterBlackMiddle": {
+   "bBoxNE": [
+    1.108, 
+    0.384
+   ], 
+   "bBoxSW": [
+    0.284, 
+    -0.384
+   ]
+  }, 
+  "noteheadDiamondClusterBlackTop": {
+   "bBoxNE": [
+    1.392, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.76
+   ]
+  }, 
+  "noteheadDiamondClusterWhite2nd": {
+   "bBoxNE": [
+    1.392, 
+    1.208
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteheadDiamondClusterWhite3rd": {
+   "bBoxNE": [
+    1.392, 
+    1.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.552
+   ]
+  }, 
+  "noteheadDiamondClusterWhiteBottom": {
+   "bBoxNE": [
+    1.392, 
+    0.584
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.676
+   ]
+  }, 
+  "noteheadDiamondClusterWhiteMiddle": {
+   "bBoxNE": [
+    1.108, 
+    0.384
+   ], 
+   "bBoxSW": [
+    0.284, 
+    -0.384
+   ]
+  }, 
+  "noteheadDiamondClusterWhiteTop": {
+   "bBoxNE": [
+    1.392, 
+    0.676
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.584
+   ]
+  }, 
+  "noteheadDiamondDoubleWhole": {
+   "bBoxNE": [
+    2.056, 
+    0.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.604
+   ]
+  }, 
+  "noteheadDiamondDoubleWholeOld": {
+   "bBoxNE": [
+    2.064, 
+    0.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadDiamondHalf": {
+   "bBoxNE": [
+    1.132, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "noteheadDiamondHalfFilled": {
+   "bBoxNE": [
+    1.2, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadDiamondHalfOld": {
+   "bBoxNE": [
+    1.2, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadDiamondHalfWide": {
+   "bBoxNE": [
+    1.496, 
+    0.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "noteheadDiamondOpen": {
+   "bBoxNE": [
+    1.2, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadDiamondWhite": {
+   "bBoxNE": [
+    1.132, 
+    0.568
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.568
+   ]
+  }, 
+  "noteheadDiamondWhiteWide": {
+   "bBoxNE": [
+    1.496, 
+    0.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "noteheadDiamondWhole": {
+   "bBoxNE": [
+    1.308, 
+    0.588
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.604
+   ]
+  }, 
+  "noteheadDiamondWholeOld": {
+   "bBoxNE": [
+    1.2, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadDoubleWhole": {
+   "bBoxNE": [
+    2.376, 
+    0.608
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadDoubleWholeAlt": {
+   "bBoxNE": [
+    1.78, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "noteheadDoubleWholeParens": {
+   "bBoxNE": [
+    3.448, 
+    0.748
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.696
+   ]
+  }, 
+  "noteheadDoubleWholeSquare": {
+   "bBoxNE": [
+    2.028, 
+    1.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "noteheadDoubleWholeWithX": {
+   "bBoxNE": [
+    2.38, 
+    0.6
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadHalf": {
+   "bBoxNE": [
+    1.312, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "noteheadHalfFilled": {
+   "bBoxNE": [
+    1.312, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "noteheadHalfParens": {
+   "bBoxNE": [
+    2.276, 
+    0.748
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.696
+   ]
+  }, 
+  "noteheadHalfWithX": {
+   "bBoxNE": [
+    1.312, 
+    0.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.536
+   ]
+  }, 
+  "noteheadHeavyX": {
+   "bBoxNE": [
+    1.736, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteheadHeavyXHat": {
+   "bBoxNE": [
+    1.984, 
+    1.144
+   ], 
+   "bBoxSW": [
+    -0.248, 
+    -0.516
+   ]
+  }, 
+  "noteheadLargeArrowDownBlack": {
+   "bBoxNE": [
+    1.26, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.0
+   ]
+  }, 
+  "noteheadLargeArrowDownDoubleWhole": {
+   "bBoxNE": [
+    2.228, 
+    0.58
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.036
+   ]
+  }, 
+  "noteheadLargeArrowDownHalf": {
+   "bBoxNE": [
+    1.26, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.0
+   ]
+  }, 
+  "noteheadLargeArrowDownWhole": {
+   "bBoxNE": [
+    1.324, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.0
+   ]
+  }, 
+  "noteheadLargeArrowUpBlack": {
+   "bBoxNE": [
+    1.26, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "noteheadLargeArrowUpDoubleWhole": {
+   "bBoxNE": [
+    2.228, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadLargeArrowUpHalf": {
+   "bBoxNE": [
+    1.26, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "noteheadLargeArrowUpWhole": {
+   "bBoxNE": [
+    1.324, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.5
+   ]
+  }, 
+  "noteheadMoonBlack": {
+   "bBoxNE": [
+    1.26, 
+    0.468
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.468
+   ]
+  }, 
+  "noteheadMoonWhite": {
+   "bBoxNE": [
+    1.26, 
+    0.468
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.468
+   ]
+  }, 
+  "noteheadParenthesis": {
+   "bBoxNE": [
+    1.556, 
+    0.74
+   ], 
+   "bBoxSW": [
+    -0.284, 
+    -0.736
+   ]
+  }, 
+  "noteheadParenthesisLeft": {
+   "bBoxNE": [
+    0.376, 
+    0.72
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.724
+   ]
+  }, 
+  "noteheadParenthesisRight": {
+   "bBoxNE": [
+    0.288, 
+    0.724
+   ], 
+   "bBoxSW": [
+    -0.084, 
+    -0.72
+   ]
+  }, 
+  "noteheadPlusBlack": {
+   "bBoxNE": [
+    1.012, 
+    0.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadPlusDoubleWhole": {
+   "bBoxNE": [
+    2.216, 
+    0.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadPlusHalf": {
+   "bBoxNE": [
+    1.068, 
+    0.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.544
+   ]
+  }, 
+  "noteheadPlusWhole": {
+   "bBoxNE": [
+    1.236, 
+    0.532
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.544
+   ]
+  }, 
+  "noteheadRectangularClusterBlackBottom": {
+   "bBoxNE": [
+    1.208, 
+    0.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.556
+   ]
+  }, 
+  "noteheadRectangularClusterBlackMiddle": {
+   "bBoxNE": [
+    1.208, 
+    0.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.556
+   ]
+  }, 
+  "noteheadRectangularClusterBlackTop": {
+   "bBoxNE": [
+    1.208, 
+    0.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.556
+   ]
+  }, 
+  "noteheadRectangularClusterWhiteBottom": {
+   "bBoxNE": [
+    1.208, 
+    0.56
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.556
+   ]
+  }, 
+  "noteheadRectangularClusterWhiteMiddle": {
+   "bBoxNE": [
+    1.208, 
+    0.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.556
+   ]
+  }, 
+  "noteheadRectangularClusterWhiteTop": {
+   "bBoxNE": [
+    1.208, 
+    0.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.56
+   ]
+  }, 
+  "noteheadRoundBlack": {
+   "bBoxNE": [
+    1.032, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteheadRoundBlackDoubleSlashed": {
+   "bBoxNE": [
+    1.244, 
+    0.724
+   ], 
+   "bBoxSW": [
+    -0.212, 
+    -0.732
+   ]
+  }, 
+  "noteheadRoundBlackLarge": {
+   "bBoxNE": [
+    1.996, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.996
+   ]
+  }, 
+  "noteheadRoundBlackSlashed": {
+   "bBoxNE": [
+    2.508, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -1.496, 
+    -2.0
+   ]
+  }, 
+  "noteheadRoundBlackSlashedLarge": {
+   "bBoxNE": [
+    3.0, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -1.004, 
+    -2.0
+   ]
+  }, 
+  "noteheadRoundWhite": {
+   "bBoxNE": [
+    1.032, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteheadRoundWhiteDoubleSlashed": {
+   "bBoxNE": [
+    1.244, 
+    0.724
+   ], 
+   "bBoxSW": [
+    -0.212, 
+    -0.732
+   ]
+  }, 
+  "noteheadRoundWhiteLarge": {
+   "bBoxNE": [
+    1.996, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.996
+   ]
+  }, 
+  "noteheadRoundWhiteSlashed": {
+   "bBoxNE": [
+    2.504, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -1.5, 
+    -2.0
+   ]
+  }, 
+  "noteheadRoundWhiteSlashedLarge": {
+   "bBoxNE": [
+    3.0, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -1.004, 
+    -2.0
+   ]
+  }, 
+  "noteheadRoundWhiteWithDot": {
+   "bBoxNE": [
+    1.032, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteheadRoundWhiteWithDotLarge": {
+   "bBoxNE": [
+    1.996, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.996
+   ]
+  }, 
+  "noteheadSlashDiamondWhite": {
+   "bBoxNE": [
+    2.028, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "noteheadSlashHorizontalEnds": {
+   "bBoxNE": [
+    2.56, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "noteheadSlashHorizontalEndsMuted": {
+   "bBoxNE": [
+    2.536, 
+    1.068
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.068
+   ]
+  }, 
+  "noteheadSlashVerticalEnds": {
+   "bBoxNE": [
+    1.324, 
+    0.864
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.864
+   ]
+  }, 
+  "noteheadSlashVerticalEndsMuted": {
+   "bBoxNE": [
+    1.744, 
+    1.068
+   ], 
+   "bBoxSW": [
+    -0.092, 
+    -1.068
+   ]
+  }, 
+  "noteheadSlashVerticalEndsSmall": {
+   "bBoxNE": [
+    0.756, 
+    0.508
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.504
+   ]
+  }, 
+  "noteheadSlashWhiteDoubleWhole": {
+   "bBoxNE": [
+    4.876, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "noteheadSlashWhiteHalf": {
+   "bBoxNE": [
+    3.424, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "noteheadSlashWhiteMuted": {
+   "bBoxNE": [
+    3.304, 
+    1.068
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.068
+   ]
+  }, 
+  "noteheadSlashWhiteWhole": {
+   "bBoxNE": [
+    4.344, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "noteheadSlashX": {
+   "bBoxNE": [
+    2.076, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "noteheadSlashedBlack1": {
+   "bBoxNE": [
+    1.576, 
+    0.548
+   ], 
+   "bBoxSW": [
+    -0.276, 
+    -0.584
+   ]
+  }, 
+  "noteheadSlashedBlack2": {
+   "bBoxNE": [
+    1.38, 
+    0.784
+   ], 
+   "bBoxSW": [
+    -0.168, 
+    -0.764
+   ]
+  }, 
+  "noteheadSlashedDoubleWhole1": {
+   "bBoxNE": [
+    2.38, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.7
+   ]
+  }, 
+  "noteheadSlashedDoubleWhole2": {
+   "bBoxNE": [
+    2.38, 
+    0.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.7
+   ]
+  }, 
+  "noteheadSlashedHalf1": {
+   "bBoxNE": [
+    1.576, 
+    0.548
+   ], 
+   "bBoxSW": [
+    -0.276, 
+    -0.584
+   ]
+  }, 
+  "noteheadSlashedHalf2": {
+   "bBoxNE": [
+    1.44, 
+    0.796
+   ], 
+   "bBoxSW": [
+    -0.108, 
+    -0.748
+   ]
+  }, 
+  "noteheadSlashedWhole1": {
+   "bBoxNE": [
+    1.948, 
+    0.652
+   ], 
+   "bBoxSW": [
+    -0.176, 
+    -0.64
+   ]
+  }, 
+  "noteheadSlashedWhole2": {
+   "bBoxNE": [
+    1.76, 
+    0.596
+   ], 
+   "bBoxSW": [
+    -0.056, 
+    -0.564
+   ]
+  }, 
+  "noteheadSquareBlack": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "noteheadSquareBlackLarge": {
+   "bBoxNE": [
+    1.996, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.996
+   ]
+  }, 
+  "noteheadSquareBlackWhite": {
+   "bBoxNE": [
+    1.996, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.996
+   ]
+  }, 
+  "noteheadSquareWhite": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "noteheadTriangleDownBlack": {
+   "bBoxNE": [
+    1.26, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadTriangleDownDoubleWhole": {
+   "bBoxNE": [
+    2.228, 
+    0.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadTriangleDownHalf": {
+   "bBoxNE": [
+    1.26, 
+    0.512
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteheadTriangleDownWhite": {
+   "bBoxNE": [
+    1.26, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadTriangleDownWhole": {
+   "bBoxNE": [
+    1.26, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadTriangleLeftBlack": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "noteheadTriangleLeftWhite": {
+   "bBoxNE": [
+    1.148, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.496
+   ]
+  }, 
+  "noteheadTriangleRightBlack": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "noteheadTriangleRightWhite": {
+   "bBoxNE": [
+    1.148, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.532
+   ]
+  }, 
+  "noteheadTriangleRoundDownBlack": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "noteheadTriangleRoundDownWhite": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "noteheadTriangleUpBlack": {
+   "bBoxNE": [
+    1.26, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadTriangleUpDoubleWhole": {
+   "bBoxNE": [
+    2.228, 
+    0.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadTriangleUpHalf": {
+   "bBoxNE": [
+    1.26, 
+    0.512
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.516
+   ]
+  }, 
+  "noteheadTriangleUpRightBlack": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "noteheadTriangleUpRightWhite": {
+   "bBoxNE": [
+    1.26, 
+    0.472
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.472
+   ]
+  }, 
+  "noteheadTriangleUpWhite": {
+   "bBoxNE": [
+    1.26, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadTriangleUpWhole": {
+   "bBoxNE": [
+    1.26, 
+    0.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadVoidWithX": {
+   "bBoxNE": [
+    1.272, 
+    0.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteheadWhole": {
+   "bBoxNE": [
+    1.68, 
+    0.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteheadWholeFilled": {
+   "bBoxNE": [
+    1.68, 
+    0.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteheadWholeParens": {
+   "bBoxNE": [
+    2.744, 
+    0.748
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.696
+   ]
+  }, 
+  "noteheadWholeWithX": {
+   "bBoxNE": [
+    1.68, 
+    0.536
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "noteheadXBlack": {
+   "bBoxNE": [
+    1.076, 
+    0.62
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.62
+   ]
+  }, 
+  "noteheadXDoubleWhole": {
+   "bBoxNE": [
+    2.492, 
+    0.596
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.58
+   ]
+  }, 
+  "noteheadXHalf": {
+   "bBoxNE": [
+    1.592, 
+    0.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "noteheadXOrnate": {
+   "bBoxNE": [
+    1.008, 
+    0.512
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.512
+   ]
+  }, 
+  "noteheadXOrnateEllipse": {
+   "bBoxNE": [
+    1.532, 
+    0.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.768
+   ]
+  }, 
+  "noteheadXWhole": {
+   "bBoxNE": [
+    1.768, 
+    0.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.548
+   ]
+  }, 
+  "octaveBaselineA": {
+   "bBoxNE": [
+    0.752, 
+    0.752
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.024
+   ]
+  }, 
+  "octaveBaselineB": {
+   "bBoxNE": [
+    0.724, 
+    1.216
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "octaveBaselineM": {
+   "bBoxNE": [
+    1.144, 
+    0.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.024
+   ]
+  }, 
+  "octaveBaselineV": {
+   "bBoxNE": [
+    0.692, 
+    0.788
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.024
+   ]
+  }, 
+  "octaveBassa": {
+   "bBoxNE": [
+    3.716, 
+    1.24
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.016
+   ]
+  }, 
+  "octaveLoco": {
+   "bBoxNE": [
+    2.616, 
+    1.24
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.044
+   ]
+  }, 
+  "octaveParensLeft": {
+   "bBoxNE": [
+    0.496, 
+    1.868
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.176
+   ]
+  }, 
+  "octaveParensRight": {
+   "bBoxNE": [
+    0.496, 
+    1.868
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.176
+   ]
+  }, 
+  "octaveSuperscriptA": {
+   "bBoxNE": [
+    0.752, 
+    1.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.956
+   ]
+  }, 
+  "octaveSuperscriptB": {
+   "bBoxNE": [
+    0.724, 
+    2.172
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.928
+   ]
+  }, 
+  "octaveSuperscriptM": {
+   "bBoxNE": [
+    1.144, 
+    1.72
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.932
+   ]
+  }, 
+  "octaveSuperscriptV": {
+   "bBoxNE": [
+    0.692, 
+    1.748
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.936
+   ]
+  }, 
+  "oneHandedRollStevens": {
+   "bBoxNE": [
+    1.044, 
+    0.78
+   ], 
+   "bBoxSW": [
+    -1.044, 
+    -0.004
+   ]
+  }, 
+  "ornamentBottomLeftConcaveStroke": {
+   "bBoxNE": [
+    1.316, 
+    0.78
+   ], 
+   "bBoxSW": [
+    -0.068, 
+    -1.404
+   ]
+  }, 
+  "ornamentBottomLeftConcaveStrokeLarge": {
+   "bBoxNE": [
+    1.7, 
+    0.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.396
+   ]
+  }, 
+  "ornamentBottomLeftConvexStroke": {
+   "bBoxNE": [
+    2.248, 
+    0.828
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.808
+   ]
+  }, 
+  "ornamentBottomRightConcaveStroke": {
+   "bBoxNE": [
+    1.036, 
+    0.972
+   ], 
+   "bBoxSW": [
+    -0.188, 
+    -0.856
+   ]
+  }, 
+  "ornamentBottomRightConvexStroke": {
+   "bBoxNE": [
+    2.128, 
+    0.992
+   ], 
+   "bBoxSW": [
+    -0.16, 
+    -0.636
+   ]
+  }, 
+  "ornamentComma": {
+   "bBoxNE": [
+    0.572, 
+    1.06
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentDoubleObliqueLinesAfterNote": {
+   "bBoxNE": [
+    2.004, 
+    1.98
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentDoubleObliqueLinesBeforeNote": {
+   "bBoxNE": [
+    2.004, 
+    1.98
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentDownCurve": {
+   "bBoxNE": [
+    1.56, 
+    0.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentHaydn": {
+   "bBoxNE": [
+    2.0, 
+    0.86
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.156
+   ]
+  }, 
+  "ornamentHighLeftConcaveStroke": {
+   "bBoxNE": [
+    1.42, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.2
+   ]
+  }, 
+  "ornamentHighLeftConvexStroke": {
+   "bBoxNE": [
+    1.196, 
+    1.276
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentHighRightConcaveStroke": {
+   "bBoxNE": [
+    2.016, 
+    1.148
+   ], 
+   "bBoxSW": [
+    -0.264, 
+    0.156
+   ]
+  }, 
+  "ornamentHighRightConvexStroke": {
+   "bBoxNE": [
+    1.504, 
+    1.272
+   ], 
+   "bBoxSW": [
+    -0.1, 
+    0.0
+   ]
+  }, 
+  "ornamentHookAfterNote": {
+   "bBoxNE": [
+    1.86, 
+    1.24
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentHookBeforeNote": {
+   "bBoxNE": [
+    1.46, 
+    1.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentLeftFacingHalfCircle": {
+   "bBoxNE": [
+    0.648, 
+    1.884
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentLeftFacingHook": {
+   "bBoxNE": [
+    0.884, 
+    1.944
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentLeftPlus": {
+   "bBoxNE": [
+    2.576, 
+    1.836
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    -0.196
+   ]
+  }, 
+  "ornamentLeftShakeT": {
+   "bBoxNE": [
+    1.096, 
+    1.928
+   ], 
+   "bBoxSW": [
+    -0.044, 
+    -0.012
+   ]
+  }, 
+  "ornamentLeftVerticalStroke": {
+   "bBoxNE": [
+    0.84, 
+    1.916
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    0.0
+   ]
+  }, 
+  "ornamentLeftVerticalStrokeWithCross": {
+   "bBoxNE": [
+    1.176, 
+    1.932
+   ], 
+   "bBoxSW": [
+    -0.088, 
+    0.0
+   ]
+  }, 
+  "ornamentLowLeftConcaveStroke": {
+   "bBoxNE": [
+    1.388, 
+    1.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "ornamentLowLeftConvexStroke": {
+   "bBoxNE": [
+    1.46, 
+    0.86
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentLowRightConcaveStroke": {
+   "bBoxNE": [
+    1.248, 
+    0.968
+   ], 
+   "bBoxSW": [
+    -0.212, 
+    -0.072
+   ]
+  }, 
+  "ornamentLowRightConvexStroke": {
+   "bBoxNE": [
+    1.804, 
+    0.992
+   ], 
+   "bBoxSW": [
+    -0.112, 
+    -0.108
+   ]
+  }, 
+  "ornamentMiddleVerticalStroke": {
+   "bBoxNE": [
+    0.06, 
+    1.356
+   ], 
+   "bBoxSW": [
+    -0.056, 
+    -0.336
+   ]
+  }, 
+  "ornamentMordent": {
+   "bBoxNE": [
+    2.428, 
+    1.32
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.372
+   ]
+  }, 
+  "ornamentObliqueLineAfterNote": {
+   "bBoxNE": [
+    1.26, 
+    1.98
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentObliqueLineBeforeNote": {
+   "bBoxNE": [
+    1.26, 
+    1.98
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentObliqueLineHorizAfterNote": {
+   "bBoxNE": [
+    1.92, 
+    0.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentObliqueLineHorizBeforeNote": {
+   "bBoxNE": [
+    1.92, 
+    0.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentOriscus": {
+   "bBoxNE": [
+    2.0, 
+    0.744
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentPinceCouperin": {
+   "bBoxNE": [
+    2.284, 
+    1.892
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentPortDeVoixV": {
+   "bBoxNE": [
+    1.712, 
+    1.844
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentPrecompAppoggTrill": {
+   "bBoxNE": [
+    3.916, 
+    1.88
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.02
+   ]
+  }, 
+  "ornamentPrecompAppoggTrillSuffix": {
+   "bBoxNE": [
+    3.4, 
+    2.492
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentPrecompCadence": {
+   "bBoxNE": [
+    3.712, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.028
+   ]
+  }, 
+  "ornamentPrecompCadenceUpperPrefix": {
+   "bBoxNE": [
+    3.604, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.028
+   ]
+  }, 
+  "ornamentPrecompCadenceUpperPrefixTurn": {
+   "bBoxNE": [
+    3.604, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.316
+   ]
+  }, 
+  "ornamentPrecompCadenceWithTurn": {
+   "bBoxNE": [
+    3.712, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.316
+   ]
+  }, 
+  "ornamentPrecompDescendingSlide": {
+   "bBoxNE": [
+    4.276, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.656
+   ]
+  }, 
+  "ornamentPrecompDoubleCadenceLowerPrefix": {
+   "bBoxNE": [
+    4.644, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "ornamentPrecompDoubleCadenceUpperPrefix": {
+   "bBoxNE": [
+    4.424, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.012
+   ]
+  }, 
+  "ornamentPrecompDoubleCadenceUpperPrefixTurn": {
+   "bBoxNE": [
+    4.424, 
+    1.368
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.32
+   ]
+  }, 
+  "ornamentPrecompInvertedMordentUpperPrefix": {
+   "bBoxNE": [
+    4.456, 
+    1.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.316
+   ]
+  }, 
+  "ornamentPrecompMordentRelease": {
+   "bBoxNE": [
+    2.604, 
+    1.312
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "ornamentPrecompMordentUpperPrefix": {
+   "bBoxNE": [
+    4.456, 
+    1.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "ornamentPrecompPortDeVoixMordent": {
+   "bBoxNE": [
+    4.652, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.316
+   ]
+  }, 
+  "ornamentPrecompSlide": {
+   "bBoxNE": [
+    4.288, 
+    1.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "ornamentPrecompSlideTrillBach": {
+   "bBoxNE": [
+    4.076, 
+    1.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.396
+   ]
+  }, 
+  "ornamentPrecompSlideTrillDAnglebert": {
+   "bBoxNE": [
+    3.884, 
+    0.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.396
+   ]
+  }, 
+  "ornamentPrecompSlideTrillMarpurg": {
+   "bBoxNE": [
+    4.076, 
+    1.288
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.4
+   ]
+  }, 
+  "ornamentPrecompSlideTrillMuffat": {
+   "bBoxNE": [
+    5.56, 
+    1.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.808
+   ]
+  }, 
+  "ornamentPrecompSlideTrillSuffixMuffat": {
+   "bBoxNE": [
+    4.284, 
+    1.292
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.792
+   ]
+  }, 
+  "ornamentPrecompTrillLowerSuffix": {
+   "bBoxNE": [
+    3.184, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.856
+   ]
+  }, 
+  "ornamentPrecompTrillSuffixDandrieu": {
+   "bBoxNE": [
+    3.596, 
+    1.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentPrecompTrillWithMordent": {
+   "bBoxNE": [
+    3.412, 
+    1.352
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.34
+   ]
+  }, 
+  "ornamentPrecompTurnTrillBach": {
+   "bBoxNE": [
+    5.256, 
+    1.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.356
+   ]
+  }, 
+  "ornamentPrecompTurnTrillDAnglebert": {
+   "bBoxNE": [
+    5.82, 
+    1.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.016
+   ]
+  }, 
+  "ornamentQuilisma": {
+   "bBoxNE": [
+    1.568, 
+    1.196
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentRightFacingHalfCircle": {
+   "bBoxNE": [
+    0.648, 
+    1.884
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentRightFacingHook": {
+   "bBoxNE": [
+    0.884, 
+    1.948
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "ornamentRightVerticalStroke": {
+   "bBoxNE": [
+    0.552, 
+    2.48
+   ], 
+   "bBoxSW": [
+    -0.216, 
+    0.208
+   ]
+  }, 
+  "ornamentSchleifer": {
+   "bBoxNE": [
+    4.548, 
+    2.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "ornamentShake3": {
+   "bBoxNE": [
+    1.0, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentShakeMuffat1": {
+   "bBoxNE": [
+    0.812, 
+    1.86
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.264
+   ]
+  }, 
+  "ornamentShortObliqueLineAfterNote": {
+   "bBoxNE": [
+    0.784, 
+    1.196
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentShortObliqueLineBeforeNote": {
+   "bBoxNE": [
+    0.784, 
+    1.196
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentShortTrill": {
+   "bBoxNE": [
+    2.428, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "ornamentTopLeftConcaveStroke": {
+   "bBoxNE": [
+    1.424, 
+    1.604
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.2
+   ]
+  }, 
+  "ornamentTopLeftConvexStroke": {
+   "bBoxNE": [
+    1.084, 
+    1.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.2
+   ]
+  }, 
+  "ornamentTopRightConcaveStroke": {
+   "bBoxNE": [
+    1.98, 
+    1.756
+   ], 
+   "bBoxSW": [
+    -0.164, 
+    0.256
+   ]
+  }, 
+  "ornamentTopRightConvexStroke": {
+   "bBoxNE": [
+    0.3, 
+    1.5
+   ], 
+   "bBoxSW": [
+    -0.416, 
+    0.196
+   ]
+  }, 
+  "ornamentTremblement": {
+   "bBoxNE": [
+    3.412, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentTremblementCouperin": {
+   "bBoxNE": [
+    2.432, 
+    0.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentTrill": {
+   "bBoxNE": [
+    1.936, 
+    1.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.012
+   ]
+  }, 
+  "ornamentTrillFlatAbove": {
+   "bBoxNE": [
+    1.936, 
+    3.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "ornamentTrillNaturalAbove": {
+   "bBoxNE": [
+    1.936, 
+    3.432
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.012
+   ]
+  }, 
+  "ornamentTrillSharpAbove": {
+   "bBoxNE": [
+    1.936, 
+    3.552
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "ornamentTurn": {
+   "bBoxNE": [
+    2.524, 
+    1.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "ornamentTurnFlatAbove": {
+   "bBoxNE": [
+    2.288, 
+    2.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "ornamentTurnFlatAboveSharpBelow": {
+   "bBoxNE": [
+    2.288, 
+    2.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.168
+   ]
+  }, 
+  "ornamentTurnFlatBelow": {
+   "bBoxNE": [
+    2.288, 
+    1.076
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.872
+   ]
+  }, 
+  "ornamentTurnInverted": {
+   "bBoxNE": [
+    2.524, 
+    1.192
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentTurnNaturalAbove": {
+   "bBoxNE": [
+    2.288, 
+    3.236
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "ornamentTurnNaturalBelow": {
+   "bBoxNE": [
+    2.288, 
+    1.076
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.072
+   ]
+  }, 
+  "ornamentTurnSharpAbove": {
+   "bBoxNE": [
+    2.288, 
+    3.232
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "ornamentTurnSharpAboveFlatBelow": {
+   "bBoxNE": [
+    2.288, 
+    3.232
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.872
+   ]
+  }, 
+  "ornamentTurnSharpBelow": {
+   "bBoxNE": [
+    2.288, 
+    1.076
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.168
+   ]
+  }, 
+  "ornamentTurnSlash": {
+   "bBoxNE": [
+    2.524, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.256
+   ]
+  }, 
+  "ornamentTurnUp": {
+   "bBoxNE": [
+    1.192, 
+    2.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentTurnUpS": {
+   "bBoxNE": [
+    1.192, 
+    2.524
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentUpCurve": {
+   "bBoxNE": [
+    1.56, 
+    0.496
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ornamentVerticalLine": {
+   "bBoxNE": [
+    0.088, 
+    1.556
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.46
+   ]
+  }, 
+  "ornamentZigZagLineNoRightEnd": {
+   "bBoxNE": [
+    1.08, 
+    0.992
+   ], 
+   "bBoxSW": [
+    -0.1, 
+    0.0
+   ]
+  }, 
+  "ornamentZigZagLineWithRightEnd": {
+   "bBoxNE": [
+    1.26, 
+    0.992
+   ], 
+   "bBoxSW": [
+    -0.148, 
+    0.0
+   ]
+  }, 
+  "ottava": {
+   "bBoxNE": [
+    1.46, 
+    1.828
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "ottavaAlta": {
+   "bBoxNE": [
+    2.896, 
+    1.832
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "ottavaBassa": {
+   "bBoxNE": [
+    2.816, 
+    1.832
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.012
+   ]
+  }, 
+  "ottavaBassaBa": {
+   "bBoxNE": [
+    2.984, 
+    1.832
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "ottavaBassaVb": {
+   "bBoxNE": [
+    2.868, 
+    1.832
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "pendereckiTremolo": {
+   "bBoxNE": [
+    0.528, 
+    0.536
+   ], 
+   "bBoxSW": [
+    -0.528, 
+    -0.54
+   ]
+  }, 
+  "pictAgogo": {
+   "bBoxNE": [
+    1.768, 
+    3.06
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictAlmglocken": {
+   "bBoxNE": [
+    1.832, 
+    2.588
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictAnvil": {
+   "bBoxNE": [
+    4.008, 
+    2.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBambooChimes": {
+   "bBoxNE": [
+    3.924, 
+    3.6
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBambooScraper": {
+   "bBoxNE": [
+    3.256, 
+    1.248
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBassDrum": {
+   "bBoxNE": [
+    1.764, 
+    2.836
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBassDrumOnSide": {
+   "bBoxNE": [
+    2.836, 
+    1.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBassDrumPeinkofer": {
+   "bBoxNE": [
+    3.1, 
+    2.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "pictBeaterBow": {
+   "bBoxNE": [
+    0.344, 
+    2.976
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterBox": {
+   "bBoxNE": [
+    1.596, 
+    3.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.288
+   ]
+  }, 
+  "pictBeaterBrassMalletsDown": {
+   "bBoxNE": [
+    0.792, 
+    2.924
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterBrassMalletsLeft": {
+   "bBoxNE": [
+    1.792, 
+    2.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterBrassMalletsRight": {
+   "bBoxNE": [
+    1.792, 
+    2.692
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterBrassMalletsUp": {
+   "bBoxNE": [
+    0.792, 
+    2.916
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterCombiningDashedCircle": {
+   "bBoxNE": [
+    1.628, 
+    3.28
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.656
+   ]
+  }, 
+  "pictBeaterCombiningParentheses": {
+   "bBoxNE": [
+    1.884, 
+    3.156
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.78
+   ]
+  }, 
+  "pictBeaterDoubleBassDrumDown": {
+   "bBoxNE": [
+    1.072, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterDoubleBassDrumUp": {
+   "bBoxNE": [
+    1.072, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterFinger": {
+   "bBoxNE": [
+    1.848, 
+    2.732
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterFingernails": {
+   "bBoxNE": [
+    1.308, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterFist": {
+   "bBoxNE": [
+    1.784, 
+    1.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterGuiroScraper": {
+   "bBoxNE": [
+    0.856, 
+    2.932
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHammer": {
+   "bBoxNE": [
+    2.308, 
+    2.452
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHammerMetalDown": {
+   "bBoxNE": [
+    2.24, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHammerMetalUp": {
+   "bBoxNE": [
+    2.24, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHammerPlasticDown": {
+   "bBoxNE": [
+    2.24, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHammerPlasticUp": {
+   "bBoxNE": [
+    2.24, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHammerWoodDown": {
+   "bBoxNE": [
+    2.24, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHammerWoodUp": {
+   "bBoxNE": [
+    2.24, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "pictBeaterHand": {
+   "bBoxNE": [
+    2.2, 
+    2.88
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardBassDrumDown": {
+   "bBoxNE": [
+    1.072, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardBassDrumUp": {
+   "bBoxNE": [
+    1.072, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "pictBeaterHardGlockenspielDown": {
+   "bBoxNE": [
+    0.44, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardGlockenspielLeft": {
+   "bBoxNE": [
+    1.612, 
+    2.58
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardGlockenspielRight": {
+   "bBoxNE": [
+    1.612, 
+    2.58
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardGlockenspielUp": {
+   "bBoxNE": [
+    0.44, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardTimpaniDown": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardTimpaniLeft": {
+   "bBoxNE": [
+    1.896, 
+    2.78
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardTimpaniRight": {
+   "bBoxNE": [
+    1.896, 
+    2.78
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardTimpaniUp": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardXylophoneDown": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardXylophoneLeft": {
+   "bBoxNE": [
+    1.732, 
+    2.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardXylophoneRight": {
+   "bBoxNE": [
+    1.724, 
+    2.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardXylophoneUp": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardYarnDown": {
+   "bBoxNE": [
+    1.268, 
+    3.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardYarnLeft": {
+   "bBoxNE": [
+    1.892, 
+    2.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardYarnRight": {
+   "bBoxNE": [
+    1.86, 
+    2.752
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterHardYarnUp": {
+   "bBoxNE": [
+    1.268, 
+    3.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterJazzSticksDown": {
+   "bBoxNE": [
+    0.432, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterJazzSticksUp": {
+   "bBoxNE": [
+    0.432, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterKnittingNeedle": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMallet": {
+   "bBoxNE": [
+    1.528, 
+    3.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "pictBeaterMalletDown": {
+   "bBoxNE": [
+    1.528, 
+    3.024
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumBassDrumDown": {
+   "bBoxNE": [
+    1.072, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumBassDrumUp": {
+   "bBoxNE": [
+    1.072, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumTimpaniDown": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumTimpaniLeft": {
+   "bBoxNE": [
+    1.896, 
+    2.78
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumTimpaniRight": {
+   "bBoxNE": [
+    1.896, 
+    2.78
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumTimpaniUp": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumXylophoneDown": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumXylophoneLeft": {
+   "bBoxNE": [
+    1.732, 
+    2.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumXylophoneRight": {
+   "bBoxNE": [
+    1.724, 
+    2.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumXylophoneUp": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumYarnDown": {
+   "bBoxNE": [
+    1.268, 
+    3.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumYarnLeft": {
+   "bBoxNE": [
+    1.892, 
+    2.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumYarnRight": {
+   "bBoxNE": [
+    1.86, 
+    2.752
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMediumYarnUp": {
+   "bBoxNE": [
+    1.268, 
+    3.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMetalBassDrumDown": {
+   "bBoxNE": [
+    1.072, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMetalBassDrumUp": {
+   "bBoxNE": [
+    1.072, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMetalDown": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMetalHammer": {
+   "bBoxNE": [
+    1.72, 
+    3.024
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMetalLeft": {
+   "bBoxNE": [
+    1.724, 
+    2.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMetalRight": {
+   "bBoxNE": [
+    1.724, 
+    2.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterMetalUp": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSnareSticksDown": {
+   "bBoxNE": [
+    0.432, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSnareSticksUp": {
+   "bBoxNE": [
+    0.432, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftBassDrumDown": {
+   "bBoxNE": [
+    1.072, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftBassDrumUp": {
+   "bBoxNE": [
+    1.072, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftGlockenspielDown": {
+   "bBoxNE": [
+    0.568, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftGlockenspielLeft": {
+   "bBoxNE": [
+    1.64, 
+    2.588
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftGlockenspielRight": {
+   "bBoxNE": [
+    1.64, 
+    2.588
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftGlockenspielUp": {
+   "bBoxNE": [
+    0.568, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftTimpaniDown": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftTimpaniLeft": {
+   "bBoxNE": [
+    1.896, 
+    2.78
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftTimpaniRight": {
+   "bBoxNE": [
+    1.896, 
+    2.78
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftTimpaniUp": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftXylophone": {
+   "bBoxNE": [
+    2.256, 
+    2.628
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftXylophoneDown": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftXylophoneLeft": {
+   "bBoxNE": [
+    1.732, 
+    2.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftXylophoneRight": {
+   "bBoxNE": [
+    1.724, 
+    2.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftXylophoneUp": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftYarnDown": {
+   "bBoxNE": [
+    1.268, 
+    3.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftYarnLeft": {
+   "bBoxNE": [
+    1.892, 
+    2.728
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftYarnRight": {
+   "bBoxNE": [
+    1.86, 
+    2.752
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSoftYarnUp": {
+   "bBoxNE": [
+    1.268, 
+    3.056
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSpoonWoodenMallet": {
+   "bBoxNE": [
+    2.468, 
+    3.076
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSuperballDown": {
+   "bBoxNE": [
+    0.924, 
+    2.56
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSuperballLeft": {
+   "bBoxNE": [
+    1.54, 
+    2.288
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSuperballRight": {
+   "bBoxNE": [
+    1.54, 
+    2.288
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterSuperballUp": {
+   "bBoxNE": [
+    0.924, 
+    2.56
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterTriangleDown": {
+   "bBoxNE": [
+    1.24, 
+    2.924
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterTrianglePlain": {
+   "bBoxNE": [
+    1.512, 
+    2.528
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterTriangleUp": {
+   "bBoxNE": [
+    1.24, 
+    2.924
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWireBrushesDown": {
+   "bBoxNE": [
+    1.636, 
+    2.92
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWireBrushesUp": {
+   "bBoxNE": [
+    1.636, 
+    2.92
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWoodTimpaniDown": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWoodTimpaniLeft": {
+   "bBoxNE": [
+    1.896, 
+    2.78
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWoodTimpaniRight": {
+   "bBoxNE": [
+    1.896, 
+    2.78
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWoodTimpaniUp": {
+   "bBoxNE": [
+    0.92, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWoodXylophoneDown": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWoodXylophoneLeft": {
+   "bBoxNE": [
+    1.732, 
+    2.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWoodXylophoneRight": {
+   "bBoxNE": [
+    1.724, 
+    2.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBeaterWoodXylophoneUp": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBell": {
+   "bBoxNE": [
+    2.668, 
+    2.964
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBellOfCymbal": {
+   "bBoxNE": [
+    3.648, 
+    2.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBellPlate": {
+   "bBoxNE": [
+    3.004, 
+    2.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBellTree": {
+   "bBoxNE": [
+    1.932, 
+    2.98
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBirdWhistle": {
+   "bBoxNE": [
+    2.036, 
+    2.088
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBoardClapper": {
+   "bBoxNE": [
+    3.4, 
+    2.62
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBongos": {
+   "bBoxNE": [
+    4.86, 
+    2.38
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBongosPeinkofer": {
+   "bBoxNE": [
+    3.576, 
+    1.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictBrakeDrum": {
+   "bBoxNE": [
+    2.636, 
+    2.636
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCabasa": {
+   "bBoxNE": [
+    2.056, 
+    3.32
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCannon": {
+   "bBoxNE": [
+    3.62, 
+    3.024
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCarHorn": {
+   "bBoxNE": [
+    3.208, 
+    1.448
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCastanets": {
+   "bBoxNE": [
+    1.804, 
+    1.632
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCastanetsSmithBrindle": {
+   "bBoxNE": [
+    1.056, 
+    3.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCastanetsWithHandle": {
+   "bBoxNE": [
+    1.188, 
+    2.88
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCelesta": {
+   "bBoxNE": [
+    5.228, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCencerro": {
+   "bBoxNE": [
+    0.968, 
+    3.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCenter1": {
+   "bBoxNE": [
+    1.848, 
+    1.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCenter2": {
+   "bBoxNE": [
+    1.848, 
+    1.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCenter3": {
+   "bBoxNE": [
+    1.42, 
+    1.42
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictChainRattle": {
+   "bBoxNE": [
+    4.256, 
+    1.724
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "pictChimes": {
+   "bBoxNE": [
+    3.768, 
+    2.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictChineseCymbal": {
+   "bBoxNE": [
+    3.42, 
+    0.724
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictChokeCymbal": {
+   "bBoxNE": [
+    0.572, 
+    1.06
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictClaves": {
+   "bBoxNE": [
+    2.24, 
+    2.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCoins": {
+   "bBoxNE": [
+    3.596, 
+    2.14
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictConga": {
+   "bBoxNE": [
+    1.752, 
+    2.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCongaPeinkofer": {
+   "bBoxNE": [
+    1.552, 
+    3.176
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCowBell": {
+   "bBoxNE": [
+    2.06, 
+    2.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCowBellBerio": {
+   "bBoxNE": [
+    2.792, 
+    2.304
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCrashCymbals": {
+   "bBoxNE": [
+    1.164, 
+    3.24
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCrotales": {
+   "bBoxNE": [
+    3.612, 
+    1.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCrushStem": {
+   "bBoxNE": [
+    0.988, 
+    0.22
+   ], 
+   "bBoxSW": [
+    -0.992, 
+    -0.492
+   ]
+  }, 
+  "pictCuica": {
+   "bBoxNE": [
+    2.692, 
+    2.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictCymbalTongs": {
+   "bBoxNE": [
+    4.42, 
+    1.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictDamp1": {
+   "bBoxNE": [
+    1.376, 
+    1.372
+   ], 
+   "bBoxSW": [
+    -0.36, 
+    -0.364
+   ]
+  }, 
+  "pictDamp2": {
+   "bBoxNE": [
+    2.376, 
+    2.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictDamp3": {
+   "bBoxNE": [
+    2.376, 
+    2.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictDamp4": {
+   "bBoxNE": [
+    2.396, 
+    2.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictDeadNoteStem": {
+   "bBoxNE": [
+    0.584, 
+    0.584
+   ], 
+   "bBoxSW": [
+    -0.58, 
+    -0.58
+   ]
+  }, 
+  "pictDrumStick": {
+   "bBoxNE": [
+    0.18, 
+    2.648
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictDuckCall": {
+   "bBoxNE": [
+    3.944, 
+    1.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictEdgeOfCymbal": {
+   "bBoxNE": [
+    4.96, 
+    2.084
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictEmptyTrap": {
+   "bBoxNE": [
+    5.228, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictFingerCymbals": {
+   "bBoxNE": [
+    1.176, 
+    2.428
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictFlexatone": {
+   "bBoxNE": [
+    2.256, 
+    3.468
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictFlexatonePeinkofer": {
+   "bBoxNE": [
+    3.112, 
+    2.132
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.016
+   ]
+  }, 
+  "pictFootballRatchet": {
+   "bBoxNE": [
+    4.904, 
+    2.748
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGlassHarmonica": {
+   "bBoxNE": [
+    3.52, 
+    2.068
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGlassHarp": {
+   "bBoxNE": [
+    2.664, 
+    1.636
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGlassPlateChimes": {
+   "bBoxNE": [
+    3.924, 
+    3.628
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGlassTubeChimes": {
+   "bBoxNE": [
+    3.924, 
+    3.604
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGlsp": {
+   "bBoxNE": [
+    5.592, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGlspPeinkofer": {
+   "bBoxNE": [
+    4.868, 
+    3.088
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGlspSmithBrindle": {
+   "bBoxNE": [
+    5.348, 
+    2.308
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGobletDrum": {
+   "bBoxNE": [
+    2.356, 
+    2.444
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGong": {
+   "bBoxNE": [
+    2.692, 
+    3.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGongWithButton": {
+   "bBoxNE": [
+    2.692, 
+    3.204
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGuiro": {
+   "bBoxNE": [
+    3.952, 
+    1.516
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGuiroPeinkofer": {
+   "bBoxNE": [
+    5.436, 
+    1.992
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.008
+   ]
+  }, 
+  "pictGuiroSevsay": {
+   "bBoxNE": [
+    4.328, 
+    1.64
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumHardDown": {
+   "bBoxNE": [
+    1.072, 
+    3.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumHardLeft": {
+   "bBoxNE": [
+    1.976, 
+    2.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumHardRight": {
+   "bBoxNE": [
+    1.976, 
+    2.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumHardUp": {
+   "bBoxNE": [
+    1.072, 
+    3.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumMediumDown": {
+   "bBoxNE": [
+    1.072, 
+    3.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumMediumLeft": {
+   "bBoxNE": [
+    1.98, 
+    2.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumMediumRight": {
+   "bBoxNE": [
+    1.98, 
+    2.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumMediumUp": {
+   "bBoxNE": [
+    1.072, 
+    3.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumSoftDown": {
+   "bBoxNE": [
+    1.072, 
+    3.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumSoftLeft": {
+   "bBoxNE": [
+    1.98, 
+    2.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumSoftRight": {
+   "bBoxNE": [
+    1.98, 
+    2.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictGumSoftUp": {
+   "bBoxNE": [
+    1.072, 
+    3.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictHalfOpen1": {
+   "bBoxNE": [
+    1.032, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictHalfOpen2": {
+   "bBoxNE": [
+    1.032, 
+    1.388
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.364
+   ]
+  }, 
+  "pictHandbell": {
+   "bBoxNE": [
+    2.5, 
+    3.272
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictHiHat": {
+   "bBoxNE": [
+    3.24, 
+    1.412
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictHiHatOnStand": {
+   "bBoxNE": [
+    2.276, 
+    2.876
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictJawHarp": {
+   "bBoxNE": [
+    2.008, 
+    2.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictJingleBells": {
+   "bBoxNE": [
+    3.656, 
+    2.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "pictKlaxonHorn": {
+   "bBoxNE": [
+    3.208, 
+    2.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictLeftHandCircle": {
+   "bBoxNE": [
+    0.428, 
+    0.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.288
+   ]
+  }, 
+  "pictLionsRoar": {
+   "bBoxNE": [
+    3.396, 
+    2.896
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictLithophone": {
+   "bBoxNE": [
+    4.492, 
+    3.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictLithophonePeinkofer": {
+   "bBoxNE": [
+    4.54, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictLogDrum": {
+   "bBoxNE": [
+    4.096, 
+    1.62
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictLotusFlute": {
+   "bBoxNE": [
+    3.476, 
+    1.072
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictLotusFlutePeinkofer": {
+   "bBoxNE": [
+    4.676, 
+    0.704
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictMar": {
+   "bBoxNE": [
+    5.592, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictMarPeinkofer": {
+   "bBoxNE": [
+    4.868, 
+    3.088
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictMarSmithBrindle": {
+   "bBoxNE": [
+    6.004, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "pictMaraca": {
+   "bBoxNE": [
+    2.056, 
+    3.32
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictMaracaSmithBrindle": {
+   "bBoxNE": [
+    1.32, 
+    3.172
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictMaracas": {
+   "bBoxNE": [
+    2.864, 
+    2.292
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictMegaphone": {
+   "bBoxNE": [
+    4.096, 
+    3.1
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictMetalPlateChimes": {
+   "bBoxNE": [
+    3.924, 
+    3.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictMetalTubeChimes": {
+   "bBoxNE": [
+    3.924, 
+    3.588
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictMusicalSaw": {
+   "bBoxNE": [
+    3.72, 
+    1.284
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    -0.888
+   ]
+  }, 
+  "pictMusicalSawPeinkofer": {
+   "bBoxNE": [
+    4.848, 
+    1.836
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.524
+   ]
+  }, 
+  "pictNormalPosition": {
+   "bBoxNE": [
+    1.42, 
+    1.42
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictOnRim": {
+   "bBoxNE": [
+    1.848, 
+    1.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictOpen": {
+   "bBoxNE": [
+    1.032, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictOpenRimShot": {
+   "bBoxNE": [
+    1.044, 
+    1.044
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictPistolShot": {
+   "bBoxNE": [
+    5.224, 
+    2.34
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictPoliceWhistle": {
+   "bBoxNE": [
+    3.6, 
+    2.108
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictQuijada": {
+   "bBoxNE": [
+    4.096, 
+    1.296
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictRainstick": {
+   "bBoxNE": [
+    1.032, 
+    3.956
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictRatchet": {
+   "bBoxNE": [
+    2.284, 
+    2.836
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictRecoReco": {
+   "bBoxNE": [
+    3.7, 
+    0.636
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictRightHandSquare": {
+   "bBoxNE": [
+    1.004, 
+    1.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictRim1": {
+   "bBoxNE": [
+    2.18, 
+    1.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictRim2": {
+   "bBoxNE": [
+    1.848, 
+    1.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictRim3": {
+   "bBoxNE": [
+    1.42, 
+    1.42
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictRimShotOnStem": {
+   "bBoxNE": [
+    0.504, 
+    0.508
+   ], 
+   "bBoxSW": [
+    -0.504, 
+    -0.516
+   ]
+  }, 
+  "pictSandpaperBlocks": {
+   "bBoxNE": [
+    3.076, 
+    2.612
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictScrapeAroundRim": {
+   "bBoxNE": [
+    2.908, 
+    2.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictScrapeAroundRimClockwise": {
+   "bBoxNE": [
+    2.908, 
+    2.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictScrapeCenterToEdge": {
+   "bBoxNE": [
+    2.9, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictScrapeEdgeToCenter": {
+   "bBoxNE": [
+    2.9, 
+    2.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictShellBells": {
+   "bBoxNE": [
+    2.016, 
+    2.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictShellChimes": {
+   "bBoxNE": [
+    3.932, 
+    3.64
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSiren": {
+   "bBoxNE": [
+    2.58, 
+    2.66
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSistrum": {
+   "bBoxNE": [
+    2.648, 
+    3.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSizzleCymbal": {
+   "bBoxNE": [
+    3.272, 
+    0.712
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSleighBell": {
+   "bBoxNE": [
+    5.256, 
+    1.944
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSleighBellSmithBrindle": {
+   "bBoxNE": [
+    3.288, 
+    2.32
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSlideBrushOnGong": {
+   "bBoxNE": [
+    3.344, 
+    0.968
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSlideWhistle": {
+   "bBoxNE": [
+    2.668, 
+    3.424
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSlitDrum": {
+   "bBoxNE": [
+    4.492, 
+    1.58
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSnareDrum": {
+   "bBoxNE": [
+    3.88, 
+    1.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSnareDrumMilitary": {
+   "bBoxNE": [
+    1.848, 
+    3.88
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSnareDrumSnaresOff": {
+   "bBoxNE": [
+    3.88, 
+    1.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSteelDrums": {
+   "bBoxNE": [
+    4.084, 
+    2.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictStickShot": {
+   "bBoxNE": [
+    1.74, 
+    1.744
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSuperball": {
+   "bBoxNE": [
+    0.924, 
+    0.924
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSuspendedCymbal": {
+   "bBoxNE": [
+    3.24, 
+    0.572
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictSwishStem": {
+   "bBoxNE": [
+    1.02, 
+    0.916
+   ], 
+   "bBoxSW": [
+    -0.848, 
+    -0.776
+   ]
+  }, 
+  "pictTabla": {
+   "bBoxNE": [
+    3.064, 
+    2.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTamTam": {
+   "bBoxNE": [
+    4.264, 
+    3.224
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTamTamWithBeater": {
+   "bBoxNE": [
+    3.884, 
+    2.912
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "pictTambourine": {
+   "bBoxNE": [
+    2.984, 
+    2.98
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTambourineStockhausen": {
+   "bBoxNE": [
+    4.196, 
+    1.12
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTempleBlocks": {
+   "bBoxNE": [
+    2.924, 
+    1.788
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTenorDrum": {
+   "bBoxNE": [
+    1.848, 
+    3.88
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictThundersheet": {
+   "bBoxNE": [
+    4.684, 
+    3.224
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTimbales": {
+   "bBoxNE": [
+    4.612, 
+    2.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTimbalesPeinkofer": {
+   "bBoxNE": [
+    3.576, 
+    1.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTimpani": {
+   "bBoxNE": [
+    2.968, 
+    3.216
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTimpaniPeinkofer": {
+   "bBoxNE": [
+    2.476, 
+    1.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTomTom": {
+   "bBoxNE": [
+    2.288, 
+    2.288
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTomTomChinese": {
+   "bBoxNE": [
+    4.908, 
+    2.148
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTomTomChinesePeinkofer": {
+   "bBoxNE": [
+    3.032, 
+    2.048
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.048
+   ]
+  }, 
+  "pictTomTomIndoAmerican": {
+   "bBoxNE": [
+    4.908, 
+    2.148
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTomTomJapanese": {
+   "bBoxNE": [
+    4.908, 
+    2.148
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTomTomPeinkofer": {
+   "bBoxNE": [
+    5.748, 
+    1.664
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTriangle": {
+   "bBoxNE": [
+    2.484, 
+    2.4
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTubaphone": {
+   "bBoxNE": [
+    5.592, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTubaphonePeinkofer": {
+   "bBoxNE": [
+    4.868, 
+    3.088
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTubularBells": {
+   "bBoxNE": [
+    3.316, 
+    3.108
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictTurnLeftStem": {
+   "bBoxNE": [
+    1.76, 
+    0.492
+   ], 
+   "bBoxSW": [
+    -1.632, 
+    -0.5
+   ]
+  }, 
+  "pictTurnRightLeftStem": {
+   "bBoxNE": [
+    1.624, 
+    0.328
+   ], 
+   "bBoxSW": [
+    -1.624, 
+    -0.536
+   ]
+  }, 
+  "pictTurnRightStem": {
+   "bBoxNE": [
+    1.632, 
+    0.492
+   ], 
+   "bBoxSW": [
+    -1.76, 
+    -0.5
+   ]
+  }, 
+  "pictVib": {
+   "bBoxNE": [
+    5.228, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictVibMotorOff": {
+   "bBoxNE": [
+    5.228, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictVibMotorOffPeinkofer": {
+   "bBoxNE": [
+    4.868, 
+    3.088
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictVibPeinkofer": {
+   "bBoxNE": [
+    4.868, 
+    3.088
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictVibSmithBrindle": {
+   "bBoxNE": [
+    5.644, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictVibraslap": {
+   "bBoxNE": [
+    2.824, 
+    1.964
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictVietnameseHat": {
+   "bBoxNE": [
+    3.248, 
+    1.796
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWhip": {
+   "bBoxNE": [
+    2.772, 
+    2.756
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWindChimesGlass": {
+   "bBoxNE": [
+    2.96, 
+    3.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "pictWindMachine": {
+   "bBoxNE": [
+    4.156, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWindWhistle": {
+   "bBoxNE": [
+    4.888, 
+    1.876
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWoodBlock": {
+   "bBoxNE": [
+    2.768, 
+    1.58
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWoundHardDown": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWoundHardLeft": {
+   "bBoxNE": [
+    1.724, 
+    2.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWoundHardRight": {
+   "bBoxNE": [
+    1.724, 
+    2.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWoundHardUp": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWoundSoftDown": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWoundSoftLeft": {
+   "bBoxNE": [
+    1.724, 
+    2.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWoundSoftRight": {
+   "bBoxNE": [
+    1.724, 
+    2.616
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictWoundSoftUp": {
+   "bBoxNE": [
+    0.92, 
+    2.94
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictXyl": {
+   "bBoxNE": [
+    5.592, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictXylBass": {
+   "bBoxNE": [
+    5.592, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictXylBassPeinkofer": {
+   "bBoxNE": [
+    3.588, 
+    3.088
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictXylPeinkofer": {
+   "bBoxNE": [
+    4.868, 
+    3.088
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictXylSmithBrindle": {
+   "bBoxNE": [
+    5.756, 
+    2.188
+   ], 
+   "bBoxSW": [
+    0.024, 
+    0.0
+   ]
+  }, 
+  "pictXylTenor": {
+   "bBoxNE": [
+    5.592, 
+    3.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictXylTenorPeinkofer": {
+   "bBoxNE": [
+    3.224, 
+    1.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictXylTenorTrough": {
+   "bBoxNE": [
+    5.596, 
+    3.232
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pictXylTrough": {
+   "bBoxNE": [
+    5.596, 
+    3.232
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedBuzzPizzicato": {
+   "bBoxNE": [
+    1.248, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedDamp": {
+   "bBoxNE": [
+    1.236, 
+    1.236
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedDampAll": {
+   "bBoxNE": [
+    1.404, 
+    1.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedDampOnStem": {
+   "bBoxNE": [
+    0.816, 
+    0.512
+   ], 
+   "bBoxSW": [
+    -0.812, 
+    -0.508
+   ]
+  }, 
+  "pluckedFingernailFlick": {
+   "bBoxNE": [
+    0.692, 
+    1.308
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedLeftHandPizzicato": {
+   "bBoxNE": [
+    1.08, 
+    1.076
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.004
+   ]
+  }, 
+  "pluckedPlectrum": {
+   "bBoxNE": [
+    1.624, 
+    1.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedSnapPizzicatoAbove": {
+   "bBoxNE": [
+    0.908, 
+    1.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedSnapPizzicatoAboveGerman": {
+   "bBoxNE": [
+    0.8, 
+    1.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedSnapPizzicatoBelow": {
+   "bBoxNE": [
+    0.908, 
+    1.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedSnapPizzicatoBelowGerman": {
+   "bBoxNE": [
+    0.8, 
+    1.16
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "pluckedWithFingernails": {
+   "bBoxNE": [
+    1.308, 
+    0.688
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "quindicesima": {
+   "bBoxNE": [
+    2.404, 
+    1.844
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "quindicesimaAlta": {
+   "bBoxNE": [
+    4.268, 
+    1.84
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.04
+   ]
+  }, 
+  "quindicesimaBassa": {
+   "bBoxNE": [
+    4.164, 
+    1.844
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "quindicesimaBassaMb": {
+   "bBoxNE": [
+    4.128, 
+    1.844
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "repeat1Bar": {
+   "bBoxNE": [
+    2.536, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "repeat2Bars": {
+   "bBoxNE": [
+    3.38, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.012
+   ]
+  }, 
+  "repeat4Bars": {
+   "bBoxNE": [
+    5.056, 
+    1.016
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.008
+   ]
+  }, 
+  "repeatBarLowerDot": {
+   "bBoxNE": [
+    0.456, 
+    -0.296
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.752
+   ]
+  }, 
+  "repeatBarSlash": {
+   "bBoxNE": [
+    2.536, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.016
+   ]
+  }, 
+  "repeatBarUpperDot": {
+   "bBoxNE": [
+    0.456, 
+    0.752
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.296
+   ]
+  }, 
+  "repeatDot": {
+   "bBoxNE": [
+    0.416, 
+    0.2
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.204
+   ]
+  }, 
+  "repeatDots": {
+   "bBoxNE": [
+    0.416, 
+    2.704
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.296
+   ]
+  }, 
+  "repeatLeft": {
+   "bBoxNE": [
+    1.752, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "repeatRight": {
+   "bBoxNE": [
+    1.752, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "repeatRightLeft": {
+   "bBoxNE": [
+    2.864, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "repeatRightLeftThick": {
+   "bBoxNE": [
+    2.784, 
+    4.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "rest1024th": {
+   "bBoxNE": [
+    2.912, 
+    4.92
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.02
+   ]
+  }, 
+  "rest128th": {
+   "bBoxNE": [
+    2.132, 
+    2.872
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.048
+   ]
+  }, 
+  "rest16th": {
+   "bBoxNE": [
+    1.328, 
+    0.856
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.04
+   ]
+  }, 
+  "rest256th": {
+   "bBoxNE": [
+    2.4, 
+    2.924
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.996
+   ]
+  }, 
+  "rest32nd": {
+   "bBoxNE": [
+    1.592, 
+    1.868
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.024
+   ]
+  }, 
+  "rest512th": {
+   "bBoxNE": [
+    2.648, 
+    3.9
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -4.02
+   ]
+  }, 
+  "rest64th": {
+   "bBoxNE": [
+    1.864, 
+    1.856
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.04
+   ]
+  }, 
+  "rest8th": {
+   "bBoxNE": [
+    1.06, 
+    0.864
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.992
+   ]
+  }, 
+  "restDoubleWhole": {
+   "bBoxNE": [
+    0.82, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "restDoubleWholeLegerLine": {
+   "bBoxNE": [
+    1.292, 
+    1.048
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.048
+   ]
+  }, 
+  "restHBar": {
+   "bBoxNE": [
+    4.208, 
+    1.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.028
+   ]
+  }, 
+  "restHBarLeft": {
+   "bBoxNE": [
+    2.692, 
+    1.028
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.028
+   ]
+  }, 
+  "restHBarMiddle": {
+   "bBoxNE": [
+    2.012, 
+    0.36
+   ], 
+   "bBoxSW": [
+    -0.204, 
+    -0.36
+   ]
+  }, 
+  "restHBarRight": {
+   "bBoxNE": [
+    2.832, 
+    1.028
+   ], 
+   "bBoxSW": [
+    0.14, 
+    -1.028
+   ]
+  }, 
+  "restHalf": {
+   "bBoxNE": [
+    1.272, 
+    0.512
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "restHalfLegerLine": {
+   "bBoxNE": [
+    1.748, 
+    0.488
+   ], 
+   "bBoxSW": [
+    0.004, 
+    -0.048
+   ]
+  }, 
+  "restLonga": {
+   "bBoxNE": [
+    0.82, 
+    1.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.008
+   ]
+  }, 
+  "restMaxima": {
+   "bBoxNE": [
+    2.252, 
+    1.008
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.008
+   ]
+  }, 
+  "restQuarter": {
+   "bBoxNE": [
+    1.004, 
+    1.548
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.436
+   ]
+  }, 
+  "restQuarterOld": {
+   "bBoxNE": [
+    1.06, 
+    0.864
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.992
+   ]
+  }, 
+  "restQuarterZ": {
+   "bBoxNE": [
+    1.264, 
+    0.864
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.864
+   ]
+  }, 
+  "restWhole": {
+   "bBoxNE": [
+    1.272, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.576
+   ]
+  }, 
+  "restWholeLegerLine": {
+   "bBoxNE": [
+    1.744, 
+    0.048
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.488
+   ]
+  }, 
+  "reversedBrace": {
+   "bBoxNE": [
+    0.492, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "reversedBracketBottom": {
+   "bBoxNE": [
+    1.74, 
+    0.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.672
+   ]
+  }, 
+  "reversedBracketTop": {
+   "bBoxNE": [
+    1.74, 
+    0.672
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "rightRepeatSmall": {
+   "bBoxNE": [
+    1.752, 
+    3.512
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.5
+   ]
+  }, 
+  "schaefferClef": {
+   "bBoxNE": [
+    1.34, 
+    0.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.008
+   ]
+  }, 
+  "schaefferFClefToGClef": {
+   "bBoxNE": [
+    2.68, 
+    3.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.996
+   ]
+  }, 
+  "schaefferGClefToFClef": {
+   "bBoxNE": [
+    2.68, 
+    0.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -3.012
+   ]
+  }, 
+  "schaefferPreviousClef": {
+   "bBoxNE": [
+    1.34, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.004
+   ]
+  }, 
+  "segno": {
+   "bBoxNE": [
+    2.108, 
+    2.736
+   ], 
+   "bBoxSW": [
+    0.032, 
+    -0.04
+   ]
+  }, 
+  "segnoJapanese": {
+   "bBoxNE": [
+    2.324, 
+    2.74
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.012
+   ]
+  }, 
+  "segnoSerpent1": {
+   "bBoxNE": [
+    1.82, 
+    4.348
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.356
+   ]
+  }, 
+  "segnoSerpent2": {
+   "bBoxNE": [
+    1.82, 
+    4.348
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.356
+   ]
+  }, 
+  "semipitchedPercussionClef1": {
+   "bBoxNE": [
+    0.924, 
+    2.564
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.564
+   ]
+  }, 
+  "semipitchedPercussionClef2": {
+   "bBoxNE": [
+    1.72, 
+    0.776
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.78
+   ]
+  }, 
+  "smnFlat": {
+   "bBoxNE": [
+    1.528, 
+    0.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "smnFlatWhite": {
+   "bBoxNE": [
+    1.528, 
+    0.52
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.52
+   ]
+  }, 
+  "smnHistoryDoubleFlat": {
+   "bBoxNE": [
+    1.744, 
+    0.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.396
+   ]
+  }, 
+  "smnHistoryDoubleSharp": {
+   "bBoxNE": [
+    1.748, 
+    0.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.436
+   ]
+  }, 
+  "smnHistoryFlat": {
+   "bBoxNE": [
+    1.744, 
+    0.372
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.396
+   ]
+  }, 
+  "smnHistorySharp": {
+   "bBoxNE": [
+    1.248, 
+    0.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.436
+   ]
+  }, 
+  "smnNatural": {
+   "bBoxNE": [
+    0.848, 
+    0.416
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.416
+   ]
+  }, 
+  "smnSharp": {
+   "bBoxNE": [
+    1.352, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "smnSharpDown": {
+   "bBoxNE": [
+    1.352, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "smnSharpWhite": {
+   "bBoxNE": [
+    1.352, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "smnSharpWhiteDown": {
+   "bBoxNE": [
+    1.352, 
+    0.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "splitBarDivider": {
+   "bBoxNE": [
+    0.616, 
+    2.136
+   ], 
+   "bBoxSW": [
+    -0.624, 
+    0.5
+   ]
+  }, 
+  "staff1Line": {
+   "bBoxNE": [
+    2.136, 
+    2.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.96
+   ]
+  }, 
+  "staff1LineNarrow": {
+   "bBoxNE": [
+    1.128, 
+    2.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.96
+   ]
+  }, 
+  "staff1LineWide": {
+   "bBoxNE": [
+    4.0, 
+    2.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.96
+   ]
+  }, 
+  "staff2Lines": {
+   "bBoxNE": [
+    2.136, 
+    2.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.46
+   ]
+  }, 
+  "staff2LinesNarrow": {
+   "bBoxNE": [
+    1.132, 
+    2.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.46
+   ]
+  }, 
+  "staff2LinesWide": {
+   "bBoxNE": [
+    4.016, 
+    2.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.46
+   ]
+  }, 
+  "staff3Lines": {
+   "bBoxNE": [
+    2.144, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.96
+   ]
+  }, 
+  "staff3LinesNarrow": {
+   "bBoxNE": [
+    1.128, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.96
+   ]
+  }, 
+  "staff3LinesWide": {
+   "bBoxNE": [
+    4.0, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.96
+   ]
+  }, 
+  "staff4Lines": {
+   "bBoxNE": [
+    2.136, 
+    3.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.46
+   ]
+  }, 
+  "staff4LinesNarrow": {
+   "bBoxNE": [
+    1.132, 
+    3.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.46
+   ]
+  }, 
+  "staff4LinesWide": {
+   "bBoxNE": [
+    4.016, 
+    3.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.46
+   ]
+  }, 
+  "staff5Lines": {
+   "bBoxNE": [
+    2.144, 
+    4.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.04
+   ]
+  }, 
+  "staff5LinesNarrow": {
+   "bBoxNE": [
+    1.128, 
+    4.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.04
+   ]
+  }, 
+  "staff5LinesWide": {
+   "bBoxNE": [
+    4.0, 
+    4.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.04
+   ]
+  }, 
+  "staff6Lines": {
+   "bBoxNE": [
+    2.136, 
+    4.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "staff6LinesNarrow": {
+   "bBoxNE": [
+    1.132, 
+    4.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "staff6LinesWide": {
+   "bBoxNE": [
+    4.016, 
+    4.54
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.54
+   ]
+  }, 
+  "staffDivideArrowDown": {
+   "bBoxNE": [
+    1.456, 
+    2.052
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "staffDivideArrowUp": {
+   "bBoxNE": [
+    1.456, 
+    3.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.94
+   ]
+  }, 
+  "staffDivideArrowUpDown": {
+   "bBoxNE": [
+    1.44, 
+    3.976
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.028
+   ]
+  }, 
+  "stem": {
+   "bBoxNE": [
+    0.04, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.04, 
+    0.0
+   ]
+  }, 
+  "stemBowOnBridge": {
+   "bBoxNE": [
+    0.816, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.82, 
+    0.0
+   ]
+  }, 
+  "stemBowOnTailpiece": {
+   "bBoxNE": [
+    0.736, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.8, 
+    0.0
+   ]
+  }, 
+  "stemBuzzRoll": {
+   "bBoxNE": [
+    0.468, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.496, 
+    0.0
+   ]
+  }, 
+  "stemDamp": {
+   "bBoxNE": [
+    0.868, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.868, 
+    0.0
+   ]
+  }, 
+  "stemHarpStringNoise": {
+   "bBoxNE": [
+    0.784, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.784, 
+    0.0
+   ]
+  }, 
+  "stemMultiphonicsBlack": {
+   "bBoxNE": [
+    1.1, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -1.1, 
+    0.0
+   ]
+  }, 
+  "stemMultiphonicsBlackWhite": {
+   "bBoxNE": [
+    1.224, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -1.232, 
+    0.0
+   ]
+  }, 
+  "stemMultiphonicsWhite": {
+   "bBoxNE": [
+    1.224, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -1.232, 
+    0.0
+   ]
+  }, 
+  "stemPendereckiTremolo": {
+   "bBoxNE": [
+    0.508, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.548, 
+    0.0
+   ]
+  }, 
+  "stemRimShot": {
+   "bBoxNE": [
+    0.504, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.504, 
+    0.0
+   ]
+  }, 
+  "stemSprechgesang": {
+   "bBoxNE": [
+    0.596, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.568, 
+    0.0
+   ]
+  }, 
+  "stemSulPonticello": {
+   "bBoxNE": [
+    0.892, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.884, 
+    0.0
+   ]
+  }, 
+  "stemSussurando": {
+   "bBoxNE": [
+    0.492, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.524, 
+    0.0
+   ]
+  }, 
+  "stemSwished": {
+   "bBoxNE": [
+    1.044, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -0.824, 
+    0.0
+   ]
+  }, 
+  "stemVibratoPulse": {
+   "bBoxNE": [
+    1.06, 
+    4.0
+   ], 
+   "bBoxSW": [
+    -1.056, 
+    0.0
+   ]
+  }, 
+  "stockhausenTremolo": {
+   "bBoxNE": [
+    1.644, 
+    0.556
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -0.576
+   ]
+  }, 
+  "stringsBowBehindBridge": {
+   "bBoxNE": [
+    0.888, 
+    0.88
+   ], 
+   "bBoxSW": [
+    -0.888, 
+    -0.004
+   ]
+  }, 
+  "stringsBowBehindBridgeFourStrings": {
+   "bBoxNE": [
+    0.888, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -0.888, 
+    0.0
+   ]
+  }, 
+  "stringsBowBehindBridgeOneString": {
+   "bBoxNE": [
+    0.888, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -0.888, 
+    0.0
+   ]
+  }, 
+  "stringsBowBehindBridgeThreeStrings": {
+   "bBoxNE": [
+    0.888, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -0.888, 
+    0.0
+   ]
+  }, 
+  "stringsBowBehindBridgeTwoStrings": {
+   "bBoxNE": [
+    0.888, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -0.888, 
+    0.0
+   ]
+  }, 
+  "stringsBowOnBridge": {
+   "bBoxNE": [
+    0.82, 
+    0.204
+   ], 
+   "bBoxSW": [
+    -0.816, 
+    -0.204
+   ]
+  }, 
+  "stringsBowOnTailpiece": {
+   "bBoxNE": [
+    0.768, 
+    0.288
+   ], 
+   "bBoxSW": [
+    -0.768, 
+    -0.288
+   ]
+  }, 
+  "stringsChangeBowDirection": {
+   "bBoxNE": [
+    3.644, 
+    1.752
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.22
+   ]
+  }, 
+  "stringsChangeBowDirectionImposed": {
+   "bBoxNE": [
+    1.488, 
+    1.876
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "stringsChangeBowDirectionLiga": {
+   "bBoxNE": [
+    2.012, 
+    1.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "stringsDownBow": {
+   "bBoxNE": [
+    1.32, 
+    1.42
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsDownBowTurned": {
+   "bBoxNE": [
+    1.32, 
+    1.42
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsFouette": {
+   "bBoxNE": [
+    0.58, 
+    1.544
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsHalfHarmonic": {
+   "bBoxNE": [
+    0.828, 
+    0.828
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsHarmonic": {
+   "bBoxNE": [
+    0.828, 
+    0.828
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsJeteAbove": {
+   "bBoxNE": [
+    2.668, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsJeteBelow": {
+   "bBoxNE": [
+    2.668, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsMuteOff": {
+   "bBoxNE": [
+    2.532, 
+    1.476
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.016
+   ]
+  }, 
+  "stringsMuteOn": {
+   "bBoxNE": [
+    2.532, 
+    1.492
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsOverpressureDownBow": {
+   "bBoxNE": [
+    1.32, 
+    1.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsOverpressureNoDirection": {
+   "bBoxNE": [
+    1.196, 
+    0.856
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsOverpressurePossibileDownBow": {
+   "bBoxNE": [
+    1.32, 
+    1.396
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsOverpressurePossibileUpBow": {
+   "bBoxNE": [
+    0.9, 
+    1.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsOverpressureUpBow": {
+   "bBoxNE": [
+    0.9, 
+    1.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsThumbPosition": {
+   "bBoxNE": [
+    0.66, 
+    1.184
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsThumbPositionTurned": {
+   "bBoxNE": [
+    0.66, 
+    1.184
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsUpBow": {
+   "bBoxNE": [
+    0.9, 
+    1.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsUpBowTurned": {
+   "bBoxNE": [
+    0.9, 
+    1.716
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "stringsVibratoPulse": {
+   "bBoxNE": [
+    1.06, 
+    1.16
+   ], 
+   "bBoxSW": [
+    -1.056, 
+    -1.16
+   ]
+  }, 
+  "systemDivider": {
+   "bBoxNE": [
+    4.244, 
+    4.708
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.284
+   ]
+  }, 
+  "systemDividerExtraLong": {
+   "bBoxNE": [
+    9.26, 
+    5.876
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.328
+   ]
+  }, 
+  "systemDividerLong": {
+   "bBoxNE": [
+    6.244, 
+    4.936
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.288
+   ]
+  }, 
+  "textAugmentationDot": {
+   "bBoxNE": [
+    0.416, 
+    0.304
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.1
+   ]
+  }, 
+  "textBlackNoteFrac16thLongStem": {
+   "bBoxNE": [
+    1.416, 
+    3.804
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "textBlackNoteFrac16thShortStem": {
+   "bBoxNE": [
+    1.352, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "textBlackNoteFrac32ndLongStem": {
+   "bBoxNE": [
+    1.416, 
+    3.804
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "textBlackNoteFrac8thLongStem": {
+   "bBoxNE": [
+    1.352, 
+    3.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "textBlackNoteFrac8thShortStem": {
+   "bBoxNE": [
+    1.332, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "textBlackNoteLongStem": {
+   "bBoxNE": [
+    1.272, 
+    3.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "textBlackNoteShortStem": {
+   "bBoxNE": [
+    1.272, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.528
+   ]
+  }, 
+  "textCont16thBeamLongStem": {
+   "bBoxNE": [
+    1.352, 
+    3.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    2.54
+   ]
+  }, 
+  "textCont16thBeamShortStem": {
+   "bBoxNE": [
+    1.352, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.78
+   ]
+  }, 
+  "textCont32ndBeamLongStem": {
+   "bBoxNE": [
+    1.352, 
+    3.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    1.78
+   ]
+  }, 
+  "textCont8thBeamLongStem": {
+   "bBoxNE": [
+    1.352, 
+    3.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    3.3
+   ]
+  }, 
+  "textCont8thBeamShortStem": {
+   "bBoxNE": [
+    1.352, 
+    3.04
+   ], 
+   "bBoxSW": [
+    0.0, 
+    2.54
+   ]
+  }, 
+  "textTie": {
+   "bBoxNE": [
+    1.528, 
+    -0.664
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.12
+   ]
+  }, 
+  "textTuplet3LongStem": {
+   "bBoxNE": [
+    1.052, 
+    5.608
+   ], 
+   "bBoxSW": [
+    0.3, 
+    4.228
+   ]
+  }, 
+  "textTuplet3ShortStem": {
+   "bBoxNE": [
+    0.752, 
+    4.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    3.42
+   ]
+  }, 
+  "textTupletBracketEndLongStem": {
+   "bBoxNE": [
+    1.404, 
+    4.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    4.232
+   ]
+  }, 
+  "textTupletBracketEndShortStem": {
+   "bBoxNE": [
+    1.404, 
+    4.172
+   ], 
+   "bBoxSW": [
+    0.0, 
+    3.408
+   ]
+  }, 
+  "textTupletBracketStartLongStem": {
+   "bBoxNE": [
+    1.404, 
+    4.996
+   ], 
+   "bBoxSW": [
+    0.0, 
+    4.232
+   ]
+  }, 
+  "textTupletBracketStartShortStem": {
+   "bBoxNE": [
+    1.404, 
+    4.172
+   ], 
+   "bBoxSW": [
+    0.0, 
+    3.408
+   ]
+  }, 
+  "timeSig0": {
+   "bBoxNE": [
+    1.644, 
+    0.992
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.968
+   ]
+  }, 
+  "timeSig0Large": {
+   "bBoxNE": [
+    0.528, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.036
+   ]
+  }, 
+  "timeSig1": {
+   "bBoxNE": [
+    1.144, 
+    0.972
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.972
+   ]
+  }, 
+  "timeSig1Large": {
+   "bBoxNE": [
+    0.348, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.032
+   ]
+  }, 
+  "timeSig2": {
+   "bBoxNE": [
+    1.64, 
+    0.996
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.988
+   ]
+  }, 
+  "timeSig2Large": {
+   "bBoxNE": [
+    0.528, 
+    1.044
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.036
+   ]
+  }, 
+  "timeSig3": {
+   "bBoxNE": [
+    1.576, 
+    0.984
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.984
+   ]
+  }, 
+  "timeSig3Large": {
+   "bBoxNE": [
+    0.5, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.036
+   ]
+  }, 
+  "timeSig4": {
+   "bBoxNE": [
+    1.668, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.964
+   ]
+  }, 
+  "timeSig4Large": {
+   "bBoxNE": [
+    0.508, 
+    1.032
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.032
+   ]
+  }, 
+  "timeSig5": {
+   "bBoxNE": [
+    1.448, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.988
+   ]
+  }, 
+  "timeSig5Large": {
+   "bBoxNE": [
+    0.52, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.028
+   ]
+  }, 
+  "timeSig6": {
+   "bBoxNE": [
+    1.588, 
+    0.948
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -1.02
+   ]
+  }, 
+  "timeSig6Large": {
+   "bBoxNE": [
+    0.536, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.032
+   ]
+  }, 
+  "timeSig7": {
+   "bBoxNE": [
+    1.712, 
+    1.008
+   ], 
+   "bBoxSW": [
+    0.076, 
+    -1.012
+   ]
+  }, 
+  "timeSig7Large": {
+   "bBoxNE": [
+    0.56, 
+    1.036
+   ], 
+   "bBoxSW": [
+    -0.012, 
+    -1.032
+   ]
+  }, 
+  "timeSig8": {
+   "bBoxNE": [
+    1.58, 
+    0.98
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -1.0
+   ]
+  }, 
+  "timeSig8Large": {
+   "bBoxNE": [
+    0.544, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.052
+   ]
+  }, 
+  "timeSig9": {
+   "bBoxNE": [
+    1.588, 
+    0.948
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -1.02
+   ]
+  }, 
+  "timeSig9Large": {
+   "bBoxNE": [
+    0.54, 
+    1.036
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.032
+   ]
+  }, 
+  "timeSigBracketLeft": {
+   "bBoxNE": [
+    0.54, 
+    2.464
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.464
+   ]
+  }, 
+  "timeSigBracketLeftSmall": {
+   "bBoxNE": [
+    0.54, 
+    1.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.456
+   ]
+  }, 
+  "timeSigBracketRight": {
+   "bBoxNE": [
+    0.54, 
+    2.464
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.464
+   ]
+  }, 
+  "timeSigBracketRightSmall": {
+   "bBoxNE": [
+    0.54, 
+    1.456
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.456
+   ]
+  }, 
+  "timeSigComma": {
+   "bBoxNE": [
+    0.612, 
+    0.508
+   ], 
+   "bBoxSW": [
+    0.04, 
+    -0.552
+   ]
+  }, 
+  "timeSigCommon": {
+   "bBoxNE": [
+    1.656, 
+    0.988
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.996
+   ]
+  }, 
+  "timeSigCommonLarge": {
+   "bBoxNE": [
+    0.516, 
+    1.044
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.04
+   ]
+  }, 
+  "timeSigCut2": {
+   "bBoxNE": [
+    1.64, 
+    1.4
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -1.412
+   ]
+  }, 
+  "timeSigCut3": {
+   "bBoxNE": [
+    1.576, 
+    1.4
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -1.412
+   ]
+  }, 
+  "timeSigCutCommon": {
+   "bBoxNE": [
+    1.656, 
+    1.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.648
+   ]
+  }, 
+  "timeSigCutCommonLarge": {
+   "bBoxNE": [
+    0.516, 
+    1.208
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -1.212
+   ]
+  }, 
+  "timeSigEquals": {
+   "bBoxNE": [
+    1.468, 
+    0.48
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.48
+   ]
+  }, 
+  "timeSigFractionHalf": {
+   "bBoxNE": [
+    1.612, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.972
+   ]
+  }, 
+  "timeSigFractionOneThird": {
+   "bBoxNE": [
+    1.696, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.996
+   ]
+  }, 
+  "timeSigFractionQuarter": {
+   "bBoxNE": [
+    1.548, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.964
+   ]
+  }, 
+  "timeSigFractionThreeQuarters": {
+   "bBoxNE": [
+    1.648, 
+    1.0
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.964
+   ]
+  }, 
+  "timeSigFractionTwoThirds": {
+   "bBoxNE": [
+    1.728, 
+    0.988
+   ], 
+   "bBoxSW": [
+    0.08, 
+    -0.996
+   ]
+  }, 
+  "timeSigFractionalSlash": {
+   "bBoxNE": [
+    1.596, 
+    0.808
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.812
+   ]
+  }, 
+  "timeSigMinus": {
+   "bBoxNE": [
+    1.468, 
+    0.116
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.112
+   ]
+  }, 
+  "timeSigMultiply": {
+   "bBoxNE": [
+    1.62, 
+    0.812
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.808
+   ]
+  }, 
+  "timeSigOpenPenderecki": {
+   "bBoxNE": [
+    3.376, 
+    0.984
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.996
+   ]
+  }, 
+  "timeSigParensLeft": {
+   "bBoxNE": [
+    0.876, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.0
+   ]
+  }, 
+  "timeSigParensLeftSmall": {
+   "bBoxNE": [
+    0.588, 
+    1.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.004
+   ]
+  }, 
+  "timeSigParensRight": {
+   "bBoxNE": [
+    0.716, 
+    2.0
+   ], 
+   "bBoxSW": [
+    -0.16, 
+    -2.0
+   ]
+  }, 
+  "timeSigParensRightSmall": {
+   "bBoxNE": [
+    0.588, 
+    1.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.004
+   ]
+  }, 
+  "timeSigPlus": {
+   "bBoxNE": [
+    1.656, 
+    0.824
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.832
+   ]
+  }, 
+  "timeSigPlusLarge": {
+   "bBoxNE": [
+    0.728, 
+    0.816
+   ], 
+   "bBoxSW": [
+    0.02, 
+    -0.816
+   ]
+  }, 
+  "timeSigPlusSmall": {
+   "bBoxNE": [
+    1.184, 
+    0.592
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.592
+   ]
+  }, 
+  "timeSigSlash": {
+   "bBoxNE": [
+    1.464, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -2.0
+   ]
+  }, 
+  "timeSigX": {
+   "bBoxNE": [
+    1.524, 
+    1.504
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.5
+   ]
+  }, 
+  "tremolo1": {
+   "bBoxNE": [
+    0.56, 
+    0.556
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -0.552
+   ]
+  }, 
+  "tremolo2": {
+   "bBoxNE": [
+    0.56, 
+    0.912
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -0.908
+   ]
+  }, 
+  "tremolo3": {
+   "bBoxNE": [
+    0.56, 
+    1.268
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -1.268
+   ]
+  }, 
+  "tremolo4": {
+   "bBoxNE": [
+    0.56, 
+    1.628
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -1.624
+   ]
+  }, 
+  "tremolo5": {
+   "bBoxNE": [
+    0.56, 
+    1.988
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -1.984
+   ]
+  }, 
+  "tremoloDivisiDots2": {
+   "bBoxNE": [
+    1.016, 
+    0.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "tremoloDivisiDots3": {
+   "bBoxNE": [
+    1.524, 
+    0.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "tremoloDivisiDots4": {
+   "bBoxNE": [
+    2.076, 
+    0.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "tremoloDivisiDots6": {
+   "bBoxNE": [
+    1.528, 
+    1.004
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "tremoloFingered1": {
+   "bBoxNE": [
+    0.56, 
+    0.556
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -0.552
+   ]
+  }, 
+  "tremoloFingered2": {
+   "bBoxNE": [
+    0.56, 
+    0.912
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -0.908
+   ]
+  }, 
+  "tremoloFingered3": {
+   "bBoxNE": [
+    0.56, 
+    1.268
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -1.268
+   ]
+  }, 
+  "tremoloFingered4": {
+   "bBoxNE": [
+    0.56, 
+    1.624
+   ], 
+   "bBoxSW": [
+    -0.556, 
+    -1.628
+   ]
+  }, 
+  "tremoloFingered5": {
+   "bBoxNE": [
+    0.556, 
+    1.988
+   ], 
+   "bBoxSW": [
+    -0.56, 
+    -1.984
+   ]
+  }, 
+  "tripleTongueAbove": {
+   "bBoxNE": [
+    2.072, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "tripleTongueAboveNoSlur": {
+   "bBoxNE": [
+    1.792, 
+    0.404
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "tripleTongueBelow": {
+   "bBoxNE": [
+    2.072, 
+    1.012
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "tripleTongueBelowNoSlur": {
+   "bBoxNE": [
+    1.792, 
+    0.408
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.004
+   ]
+  }, 
+  "tuplet0": {
+   "bBoxNE": [
+    1.024, 
+    1.248
+   ], 
+   "bBoxSW": [
+    0.012, 
+    -0.02
+   ]
+  }, 
+  "tuplet1": {
+   "bBoxNE": [
+    0.696, 
+    1.256
+   ], 
+   "bBoxSW": [
+    -0.084, 
+    0.0
+   ]
+  }, 
+  "tuplet2": {
+   "bBoxNE": [
+    1.06, 
+    1.276
+   ], 
+   "bBoxSW": [
+    -0.088, 
+    -0.024
+   ]
+  }, 
+  "tuplet3": {
+   "bBoxNE": [
+    1.012, 
+    1.264
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "tuplet4": {
+   "bBoxNE": [
+    1.012, 
+    1.296
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "tuplet5": {
+   "bBoxNE": [
+    1.052, 
+    1.268
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "tuplet6": {
+   "bBoxNE": [
+    1.052, 
+    1.28
+   ], 
+   "bBoxSW": [
+    0.048, 
+    -0.02
+   ]
+  }, 
+  "tuplet7": {
+   "bBoxNE": [
+    1.136, 
+    1.264
+   ], 
+   "bBoxSW": [
+    0.08, 
+    0.0
+   ]
+  }, 
+  "tuplet8": {
+   "bBoxNE": [
+    1.108, 
+    1.264
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    -0.024
+   ]
+  }, 
+  "tuplet9": {
+   "bBoxNE": [
+    1.008, 
+    1.268
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    -0.028
+   ]
+  }, 
+  "tupletColon": {
+   "bBoxNE": [
+    0.584, 
+    1.044
+   ], 
+   "bBoxSW": [
+    0.148, 
+    0.164
+   ]
+  }, 
+  "unmeasuredTremolo": {
+   "bBoxNE": [
+    0.592, 
+    1.296
+   ], 
+   "bBoxSW": [
+    -0.592, 
+    -1.296
+   ]
+  }, 
+  "unmeasuredTremoloSimple": {
+   "bBoxNE": [
+    0.652, 
+    1.064
+   ], 
+   "bBoxSW": [
+    -0.652, 
+    -1.068
+   ]
+  }, 
+  "unpitchedPercussionClef1": {
+   "bBoxNE": [
+    1.292, 
+    1.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.02
+   ]
+  }, 
+  "unpitchedPercussionClef1Alt": {
+   "bBoxNE": [
+    1.052, 
+    3.02
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.98
+   ]
+  }, 
+  "unpitchedPercussionClef2": {
+   "bBoxNE": [
+    1.016, 
+    1.776
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -1.776
+   ]
+  }, 
+  "ventiduesima": {
+   "bBoxNE": [
+    3.068, 
+    1.808
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.028
+   ]
+  }, 
+  "ventiduesimaAlta": {
+   "bBoxNE": [
+    5.176, 
+    1.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "ventiduesimaBassa": {
+   "bBoxNE": [
+    4.976, 
+    1.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "ventiduesimaBassaMb": {
+   "bBoxNE": [
+    4.904, 
+    1.8
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.036
+   ]
+  }, 
+  "vocalFingerClickStockhausen": {
+   "bBoxNE": [
+    2.004, 
+    1.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "vocalHalbGesungen": {
+   "bBoxNE": [
+    0.312, 
+    0.416
+   ], 
+   "bBoxSW": [
+    -0.312, 
+    0.0
+   ]
+  }, 
+  "vocalMouthClosed": {
+   "bBoxNE": [
+    1.428, 
+    0.376
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "vocalMouthOpen": {
+   "bBoxNE": [
+    1.428, 
+    0.896
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "vocalMouthPursed": {
+   "bBoxNE": [
+    0.988, 
+    0.896
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "vocalMouthSlightlyOpen": {
+   "bBoxNE": [
+    1.428, 
+    0.696
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "vocalMouthWideOpen": {
+   "bBoxNE": [
+    1.428, 
+    1.296
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "vocalNasalVoice": {
+   "bBoxNE": [
+    1.216, 
+    2.0
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "vocalSprechgesang": {
+   "bBoxNE": [
+    0.584, 
+    1.164
+   ], 
+   "bBoxSW": [
+    -0.58, 
+    0.0
+   ]
+  }, 
+  "vocalTongueClickStockhausen": {
+   "bBoxNE": [
+    2.0, 
+    1.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "vocalTongueFingerClickStockhausen": {
+   "bBoxNE": [
+    2.004, 
+    1.5
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "vocalsSussurando": {
+   "bBoxNE": [
+    0.496, 
+    1.576
+   ], 
+   "bBoxSW": [
+    -0.52, 
+    0.0
+   ]
+  }, 
+  "wiggleArpeggiatoDown": {
+   "bBoxNE": [
+    1.24, 
+    0.524
+   ], 
+   "bBoxSW": [
+    -0.176, 
+    0.0
+   ]
+  }, 
+  "wiggleArpeggiatoDownArrow": {
+   "bBoxNE": [
+    1.968, 
+    0.704
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.208
+   ]
+  }, 
+  "wiggleArpeggiatoDownSwash": {
+   "bBoxNE": [
+    1.716, 
+    0.524
+   ], 
+   "bBoxSW": [
+    -0.176, 
+    -0.048
+   ]
+  }, 
+  "wiggleArpeggiatoUp": {
+   "bBoxNE": [
+    1.24, 
+    0.524
+   ], 
+   "bBoxSW": [
+    -0.176, 
+    0.0
+   ]
+  }, 
+  "wiggleArpeggiatoUpArrow": {
+   "bBoxNE": [
+    1.824, 
+    0.596
+   ], 
+   "bBoxSW": [
+    -0.176, 
+    -0.316
+   ]
+  }, 
+  "wiggleArpeggiatoUpSwash": {
+   "bBoxNE": [
+    1.928, 
+    0.524
+   ], 
+   "bBoxSW": [
+    -0.176, 
+    0.0
+   ]
+  }, 
+  "wiggleCircular": {
+   "bBoxNE": [
+    1.48, 
+    1.668
+   ], 
+   "bBoxSW": [
+    -0.504, 
+    0.324
+   ]
+  }, 
+  "wiggleCircularConstant": {
+   "bBoxNE": [
+    0.836, 
+    0.848
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    -0.356
+   ]
+  }, 
+  "wiggleCircularConstantFlipped": {
+   "bBoxNE": [
+    0.836, 
+    1.932
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    0.728
+   ]
+  }, 
+  "wiggleCircularConstantFlippedLarge": {
+   "bBoxNE": [
+    1.204, 
+    2.332
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    0.728
+   ]
+  }, 
+  "wiggleCircularConstantLarge": {
+   "bBoxNE": [
+    1.204, 
+    0.848
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    -0.756
+   ]
+  }, 
+  "wiggleCircularEnd": {
+   "bBoxNE": [
+    0.732, 
+    1.536
+   ], 
+   "bBoxSW": [
+    -0.528, 
+    1.012
+   ]
+  }, 
+  "wiggleCircularLarge": {
+   "bBoxNE": [
+    1.6, 
+    1.708
+   ], 
+   "bBoxSW": [
+    -0.5, 
+    0.184
+   ]
+  }, 
+  "wiggleCircularLarger": {
+   "bBoxNE": [
+    2.248, 
+    1.776
+   ], 
+   "bBoxSW": [
+    -0.484, 
+    0.076
+   ]
+  }, 
+  "wiggleCircularLargerStill": {
+   "bBoxNE": [
+    2.968, 
+    1.936
+   ], 
+   "bBoxSW": [
+    -0.484, 
+    0.036
+   ]
+  }, 
+  "wiggleCircularLargest": {
+   "bBoxNE": [
+    3.964, 
+    2.196
+   ], 
+   "bBoxSW": [
+    -0.532, 
+    -0.008
+   ]
+  }, 
+  "wiggleCircularSmall": {
+   "bBoxNE": [
+    1.1, 
+    1.636
+   ], 
+   "bBoxSW": [
+    -0.536, 
+    0.312
+   ]
+  }, 
+  "wiggleCircularStart": {
+   "bBoxNE": [
+    1.88, 
+    2.124
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.468
+   ]
+  }, 
+  "wiggleGlissando": {
+   "bBoxNE": [
+    1.156, 
+    0.476
+   ], 
+   "bBoxSW": [
+    -0.108, 
+    0.0
+   ]
+  }, 
+  "wiggleGlissandoGroup1": {
+   "bBoxNE": [
+    1.276, 
+    2.456
+   ], 
+   "bBoxSW": [
+    -0.044, 
+    0.0
+   ]
+  }, 
+  "wiggleGlissandoGroup2": {
+   "bBoxNE": [
+    0.608, 
+    3.22
+   ], 
+   "bBoxSW": [
+    -0.052, 
+    0.0
+   ]
+  }, 
+  "wiggleGlissandoGroup3": {
+   "bBoxNE": [
+    0.576, 
+    4.2
+   ], 
+   "bBoxSW": [
+    -0.06, 
+    0.0
+   ]
+  }, 
+  "wiggleRandom1": {
+   "bBoxNE": [
+    7.92, 
+    2.256
+   ], 
+   "bBoxSW": [
+    -0.004, 
+    -1.124
+   ]
+  }, 
+  "wiggleRandom2": {
+   "bBoxNE": [
+    7.624, 
+    2.54
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    -0.668
+   ]
+  }, 
+  "wiggleRandom3": {
+   "bBoxNE": [
+    7.444, 
+    2.544
+   ], 
+   "bBoxSW": [
+    -0.044, 
+    -0.58
+   ]
+  }, 
+  "wiggleRandom4": {
+   "bBoxNE": [
+    7.44, 
+    2.464
+   ], 
+   "bBoxSW": [
+    -0.012, 
+    -1.252
+   ]
+  }, 
+  "wiggleSawtooth": {
+   "bBoxNE": [
+    2.924, 
+    0.848
+   ], 
+   "bBoxSW": [
+    -0.032, 
+    -0.936
+   ]
+  }, 
+  "wiggleSawtoothNarrow": {
+   "bBoxNE": [
+    2.284, 
+    0.848
+   ], 
+   "bBoxSW": [
+    -0.032, 
+    -0.976
+   ]
+  }, 
+  "wiggleSawtoothWide": {
+   "bBoxNE": [
+    3.248, 
+    0.848
+   ], 
+   "bBoxSW": [
+    -0.028, 
+    -0.928
+   ]
+  }, 
+  "wiggleSquareWave": {
+   "bBoxNE": [
+    3.024, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.296
+   ]
+  }, 
+  "wiggleSquareWaveNarrow": {
+   "bBoxNE": [
+    2.064, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.296
+   ]
+  }, 
+  "wiggleSquareWaveWide": {
+   "bBoxNE": [
+    3.984, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.296
+   ]
+  }, 
+  "wiggleTrill": {
+   "bBoxNE": [
+    1.004, 
+    1.152
+   ], 
+   "bBoxSW": [
+    -0.188, 
+    0.564
+   ]
+  }, 
+  "wiggleTrillFast": {
+   "bBoxNE": [
+    0.904, 
+    1.152
+   ], 
+   "bBoxSW": [
+    -0.204, 
+    0.564
+   ]
+  }, 
+  "wiggleTrillFaster": {
+   "bBoxNE": [
+    0.804, 
+    1.152
+   ], 
+   "bBoxSW": [
+    -0.188, 
+    0.564
+   ]
+  }, 
+  "wiggleTrillFasterStill": {
+   "bBoxNE": [
+    0.732, 
+    1.152
+   ], 
+   "bBoxSW": [
+    -0.164, 
+    0.564
+   ]
+  }, 
+  "wiggleTrillFastest": {
+   "bBoxNE": [
+    0.676, 
+    1.152
+   ], 
+   "bBoxSW": [
+    -0.152, 
+    0.564
+   ]
+  }, 
+  "wiggleTrillSlow": {
+   "bBoxNE": [
+    1.332, 
+    1.152
+   ], 
+   "bBoxSW": [
+    -0.216, 
+    0.564
+   ]
+  }, 
+  "wiggleTrillSlower": {
+   "bBoxNE": [
+    1.476, 
+    1.152
+   ], 
+   "bBoxSW": [
+    -0.208, 
+    0.564
+   ]
+  }, 
+  "wiggleTrillSlowerStill": {
+   "bBoxNE": [
+    1.636, 
+    1.152
+   ], 
+   "bBoxSW": [
+    -0.28, 
+    0.564
+   ]
+  }, 
+  "wiggleTrillSlowest": {
+   "bBoxNE": [
+    1.892, 
+    1.152
+   ], 
+   "bBoxSW": [
+    -0.336, 
+    0.564
+   ]
+  }, 
+  "wiggleVIbratoLargestSlower": {
+   "bBoxNE": [
+    3.76, 
+    1.896
+   ], 
+   "bBoxSW": [
+    -0.116, 
+    -1.1
+   ]
+  }, 
+  "wiggleVIbratoMediumSlower": {
+   "bBoxNE": [
+    1.748, 
+    0.784
+   ], 
+   "bBoxSW": [
+    -0.072, 
+    -0.112
+   ]
+  }, 
+  "wiggleVibrato": {
+   "bBoxNE": [
+    0.66, 
+    0.508
+   ], 
+   "bBoxSW": [
+    -0.08, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargeFast": {
+   "bBoxNE": [
+    1.824, 
+    1.284
+   ], 
+   "bBoxSW": [
+    -0.048, 
+    -0.5
+   ]
+  }, 
+  "wiggleVibratoLargeFaster": {
+   "bBoxNE": [
+    1.584, 
+    1.284
+   ], 
+   "bBoxSW": [
+    -0.06, 
+    -0.5
+   ]
+  }, 
+  "wiggleVibratoLargeFasterStill": {
+   "bBoxNE": [
+    1.336, 
+    1.284
+   ], 
+   "bBoxSW": [
+    -0.084, 
+    -0.5
+   ]
+  }, 
+  "wiggleVibratoLargeFastest": {
+   "bBoxNE": [
+    1.148, 
+    1.284
+   ], 
+   "bBoxSW": [
+    -0.072, 
+    -0.5
+   ]
+  }, 
+  "wiggleVibratoLargeSlow": {
+   "bBoxNE": [
+    2.128, 
+    1.284
+   ], 
+   "bBoxSW": [
+    -0.044, 
+    -0.5
+   ]
+  }, 
+  "wiggleVibratoLargeSlower": {
+   "bBoxNE": [
+    2.62, 
+    1.284
+   ], 
+   "bBoxSW": [
+    -0.056, 
+    -0.5
+   ]
+  }, 
+  "wiggleVibratoLargeSlowest": {
+   "bBoxNE": [
+    3.112, 
+    1.284
+   ], 
+   "bBoxSW": [
+    -0.048, 
+    -0.5
+   ]
+  }, 
+  "wiggleVibratoLargestFast": {
+   "bBoxNE": [
+    2.788, 
+    1.896
+   ], 
+   "bBoxSW": [
+    -0.096, 
+    -1.104
+   ]
+  }, 
+  "wiggleVibratoLargestFaster": {
+   "bBoxNE": [
+    2.296, 
+    1.896
+   ], 
+   "bBoxSW": [
+    -0.088, 
+    -1.104
+   ]
+  }, 
+  "wiggleVibratoLargestFasterStill": {
+   "bBoxNE": [
+    1.996, 
+    1.896
+   ], 
+   "bBoxSW": [
+    -0.076, 
+    -1.1
+   ]
+  }, 
+  "wiggleVibratoLargestFastest": {
+   "bBoxNE": [
+    1.692, 
+    1.896
+   ], 
+   "bBoxSW": [
+    -0.084, 
+    -1.1
+   ]
+  }, 
+  "wiggleVibratoLargestSlow": {
+   "bBoxNE": [
+    3.256, 
+    1.896
+   ], 
+   "bBoxSW": [
+    -0.108, 
+    -1.1
+   ]
+  }, 
+  "wiggleVibratoLargestSlowest": {
+   "bBoxNE": [
+    4.52, 
+    1.896
+   ], 
+   "bBoxSW": [
+    -0.116, 
+    -1.112
+   ]
+  }, 
+  "wiggleVibratoMediumFast": {
+   "bBoxNE": [
+    1.276, 
+    0.788
+   ], 
+   "bBoxSW": [
+    -0.092, 
+    -0.104
+   ]
+  }, 
+  "wiggleVibratoMediumFaster": {
+   "bBoxNE": [
+    1.12, 
+    0.796
+   ], 
+   "bBoxSW": [
+    -0.104, 
+    -0.104
+   ]
+  }, 
+  "wiggleVibratoMediumFasterStill": {
+   "bBoxNE": [
+    0.972, 
+    0.796
+   ], 
+   "bBoxSW": [
+    -0.08, 
+    -0.104
+   ]
+  }, 
+  "wiggleVibratoMediumFastest": {
+   "bBoxNE": [
+    0.82, 
+    0.78
+   ], 
+   "bBoxSW": [
+    -0.076, 
+    -0.148
+   ]
+  }, 
+  "wiggleVibratoMediumSlow": {
+   "bBoxNE": [
+    1.536, 
+    0.784
+   ], 
+   "bBoxSW": [
+    -0.076, 
+    -0.112
+   ]
+  }, 
+  "wiggleVibratoMediumSlowest": {
+   "bBoxNE": [
+    2.132, 
+    0.788
+   ], 
+   "bBoxSW": [
+    -0.104, 
+    -0.188
+   ]
+  }, 
+  "wiggleVibratoSmallFast": {
+   "bBoxNE": [
+    0.896, 
+    0.556
+   ], 
+   "bBoxSW": [
+    -0.096, 
+    -0.056
+   ]
+  }, 
+  "wiggleVibratoSmallFaster": {
+   "bBoxNE": [
+    0.812, 
+    0.548
+   ], 
+   "bBoxSW": [
+    -0.064, 
+    -0.064
+   ]
+  }, 
+  "wiggleVibratoSmallFasterStill": {
+   "bBoxNE": [
+    0.72, 
+    0.56
+   ], 
+   "bBoxSW": [
+    -0.064, 
+    -0.064
+   ]
+  }, 
+  "wiggleVibratoSmallFastest": {
+   "bBoxNE": [
+    0.588, 
+    0.556
+   ], 
+   "bBoxSW": [
+    -0.096, 
+    -0.064
+   ]
+  }, 
+  "wiggleVibratoSmallSlow": {
+   "bBoxNE": [
+    1.04, 
+    0.56
+   ], 
+   "bBoxSW": [
+    -0.068, 
+    -0.064
+   ]
+  }, 
+  "wiggleVibratoSmallSlower": {
+   "bBoxNE": [
+    1.272, 
+    0.556
+   ], 
+   "bBoxSW": [
+    -0.1, 
+    -0.06
+   ]
+  }, 
+  "wiggleVibratoSmallSlowest": {
+   "bBoxNE": [
+    1.572, 
+    0.564
+   ], 
+   "bBoxSW": [
+    -0.092, 
+    -0.064
+   ]
+  }, 
+  "wiggleVibratoSmallestFast": {
+   "bBoxNE": [
+    0.744, 
+    0.368
+   ], 
+   "bBoxSW": [
+    -0.12, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestFaster": {
+   "bBoxNE": [
+    0.748, 
+    0.368
+   ], 
+   "bBoxSW": [
+    -0.052, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestFasterStill": {
+   "bBoxNE": [
+    0.636, 
+    0.368
+   ], 
+   "bBoxSW": [
+    -0.048, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestFastest": {
+   "bBoxNE": [
+    0.544, 
+    0.368
+   ], 
+   "bBoxSW": [
+    -0.072, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestSlow": {
+   "bBoxNE": [
+    0.896, 
+    0.368
+   ], 
+   "bBoxSW": [
+    -0.132, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestSlower": {
+   "bBoxNE": [
+    1.032, 
+    0.368
+   ], 
+   "bBoxSW": [
+    -0.124, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestSlowest": {
+   "bBoxNE": [
+    1.256, 
+    0.372
+   ], 
+   "bBoxSW": [
+    -0.092, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoStart": {
+   "bBoxNE": [
+    1.936, 
+    1.284
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoWide": {
+   "bBoxNE": [
+    1.024, 
+    0.888
+   ], 
+   "bBoxSW": [
+    -0.104, 
+    0.0
+   ]
+  }, 
+  "wiggleWavy": {
+   "bBoxNE": [
+    3.192, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.816
+   ]
+  }, 
+  "wiggleWavyNarrow": {
+   "bBoxNE": [
+    2.232, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.816
+   ]
+  }, 
+  "wiggleWavyWide": {
+   "bBoxNE": [
+    4.16, 
+    0.848
+   ], 
+   "bBoxSW": [
+    0.0, 
+    -0.816
+   ]
+  }, 
+  "windClosedHole": {
+   "bBoxNE": [
+    0.908, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windFlatEmbouchure": {
+   "bBoxNE": [
+    1.376, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windHalfClosedHole1": {
+   "bBoxNE": [
+    0.908, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windHalfClosedHole2": {
+   "bBoxNE": [
+    0.908, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windHalfClosedHole3": {
+   "bBoxNE": [
+    0.908, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windLessRelaxedEmbouchure": {
+   "bBoxNE": [
+    1.764, 
+    1.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windLessTightEmbouchure": {
+   "bBoxNE": [
+    1.764, 
+    1.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windMouthpiecePop": {
+   "bBoxNE": [
+    1.632, 
+    2.632
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windMultiphonicsBlackStem": {
+   "bBoxNE": [
+    1.1, 
+    1.208
+   ], 
+   "bBoxSW": [
+    -1.1, 
+    -1.172
+   ]
+  }, 
+  "windMultiphonicsBlackWhiteStem": {
+   "bBoxNE": [
+    1.228, 
+    1.38
+   ], 
+   "bBoxSW": [
+    -1.228, 
+    -1.272
+   ]
+  }, 
+  "windMultiphonicsWhiteStem": {
+   "bBoxNE": [
+    1.228, 
+    1.38
+   ], 
+   "bBoxSW": [
+    -1.228, 
+    -1.272
+   ]
+  }, 
+  "windOpenHole": {
+   "bBoxNE": [
+    0.908, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windReedPositionIn": {
+   "bBoxNE": [
+    0.76, 
+    1.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windReedPositionNormal": {
+   "bBoxNE": [
+    0.76, 
+    1.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windReedPositionOut": {
+   "bBoxNE": [
+    0.76, 
+    1.68
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windRelaxedEmbouchure": {
+   "bBoxNE": [
+    1.764, 
+    1.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windRimOnly": {
+   "bBoxNE": [
+    1.216, 
+    1.212
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windSharpEmbouchure": {
+   "bBoxNE": [
+    1.376, 
+    1.436
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windStrongAirPressure": {
+   "bBoxNE": [
+    1.972, 
+    1.1
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windThreeQuartersClosedHole": {
+   "bBoxNE": [
+    0.908, 
+    0.908
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windTightEmbouchure": {
+   "bBoxNE": [
+    1.608, 
+    1.608
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windTrillKey": {
+   "bBoxNE": [
+    2.848, 
+    1.524
+   ], 
+   "bBoxSW": [
+    -0.008, 
+    -0.012
+   ]
+  }, 
+  "windVeryTightEmbouchure": {
+   "bBoxNE": [
+    1.764, 
+    1.764
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "windWeakAirPressure": {
+   "bBoxNE": [
+    2.212, 
+    1.22
+   ], 
+   "bBoxSW": [
+    0.0, 
+    0.0
+   ]
+  }
+ }, 
+ "glyphsWithAnchors": {
+  "U+F600": {
+   "noteheadOrigin": [
+    0.36, 
+    0.0
+   ]
+  }, 
+  "U+F601": {
+   "noteheadOrigin": [
+    0.056, 
+    0.0
+   ]
+  }, 
+  "U+F603": {
+   "stemDownNW": [
+    0.0, 
+    -0.208
+   ], 
+   "stemUpSE": [
+    1.412, 
+    0.136
+   ]
+  }, 
+  "U+F604": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.372, 
+    0.168
+   ]
+  }, 
+  "U+F611": {
+   "stemDownNW": [
+    0.0, 
+    -0.46
+   ], 
+   "stemUpSE": [
+    1.14, 
+    0.456
+   ]
+  }, 
+  "U+F612": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.536, 
+    0.0
+   ]
+  }, 
+  "U+F613": {
+   "stemDownNW": [
+    0.0, 
+    -0.5
+   ], 
+   "stemUpSE": [
+    1.04, 
+    0.5
+   ]
+  }, 
+  "U+F614": {
+   "stemDownNW": [
+    0.0, 
+    -0.5
+   ], 
+   "stemUpSE": [
+    1.04, 
+    0.5
+   ]
+  }, 
+  "U+F615": {
+   "stemDownNW": [
+    0.0, 
+    -0.5
+   ], 
+   "stemUpSE": [
+    1.04, 
+    0.5
+   ]
+  }, 
+  "U+F616": {
+   "stemDownNW": [
+    0.0, 
+    -0.52
+   ], 
+   "stemUpSE": [
+    1.4, 
+    -0.52
+   ]
+  }, 
+  "U+F617": {
+   "stemDownNW": [
+    0.0, 
+    0.472
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.472
+   ]
+  }, 
+  "U+F618": {
+   "stemDownNW": [
+    0.0, 
+    -0.496
+   ], 
+   "stemUpSE": [
+    1.148, 
+    -0.496
+   ]
+  }, 
+  "U+F619": {
+   "stemDownNW": [
+    0.0, 
+    -0.532
+   ], 
+   "stemUpSE": [
+    1.148, 
+    0.34
+   ]
+  }, 
+  "U+F61A": {
+   "stemDownNW": [
+    0.0, 
+    0.472
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.472
+   ]
+  }, 
+  "U+F61B": {
+   "stemDownNW": [
+    0.0, 
+    0.06
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.06
+   ]
+  }, 
+  "U+F61C": {
+   "stemDownNW": [
+    0.0, 
+    0.184
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.184
+   ]
+  }, 
+  "U+F624": {
+   "stemDownNW": [
+    0.0, 
+    -0.472
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.472
+   ]
+  }, 
+  "U+F625": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.132, 
+    0.0
+   ]
+  }, 
+  "U+F626": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.0
+   ]
+  }, 
+  "U+F627": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.092, 
+    0.0
+   ]
+  }, 
+  "U+F628": {
+   "stemDownNW": [
+    0.0, 
+    -0.524
+   ], 
+   "stemUpSE": [
+    1.324, 
+    0.48
+   ]
+  }, 
+  "U+F629": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    0.952, 
+    0.0
+   ]
+  }, 
+  "U+F690": {
+   "stemDownNW": [
+    0.0, 
+    -0.168
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.132
+   ]
+  }, 
+  "U+F691": {
+   "stemDownNW": [
+    0.0, 
+    -0.176
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "U+F692": {
+   "stemDownNW": [
+    0.0, 
+    -0.18
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.132
+   ]
+  }, 
+  "U+F693": {
+   "stemDownNW": [
+    0.0, 
+    -0.168
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "U+F694": {
+   "stemDownNW": [
+    0.0, 
+    -0.18
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.132
+   ]
+  }, 
+  "U+F695": {
+   "stemDownNW": [
+    0.0, 
+    -0.176
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.132
+   ]
+  }, 
+  "U+F696": {
+   "stemDownNW": [
+    0.0, 
+    -0.176
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.132
+   ]
+  }, 
+  "U+F697": {
+   "stemDownNW": [
+    0.0, 
+    -0.176
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.132
+   ]
+  }, 
+  "U+F698": {
+   "stemDownNW": [
+    0.0, 
+    -0.176
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "U+F699": {
+   "stemDownNW": [
+    0.0, 
+    -0.144
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.088
+   ]
+  }, 
+  "U+F69A": {
+   "stemDownNW": [
+    0.0, 
+    -0.132
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "U+F69B": {
+   "stemDownNW": [
+    0.0, 
+    -0.132
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.088
+   ]
+  }, 
+  "U+F69C": {
+   "stemDownNW": [
+    0.0, 
+    -0.132
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "U+F69D": {
+   "stemDownNW": [
+    0.0, 
+    -0.14
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "U+F69E": {
+   "stemDownNW": [
+    0.0, 
+    -0.14
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "U+F69F": {
+   "stemDownNW": [
+    0.0, 
+    -0.132
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "U+F6A0": {
+   "stemDownNW": [
+    0.0, 
+    -0.132
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.088
+   ]
+  }, 
+  "U+F6A1": {
+   "stemDownNW": [
+    0.0, 
+    -0.14
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "U+F6AD": {
+   "stemDownNW": [
+    0.0, 
+    -0.14
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "U+F6AE": {
+   "stemDownNW": [
+    0.0, 
+    -0.168
+   ], 
+   "stemUpSE": [
+    1.396, 
+    0.14
+   ]
+  }, 
+  "U+F6B0": {
+   "stemDownNW": [
+    0.0, 
+    -0.152
+   ], 
+   "stemUpSE": [
+    1.416, 
+    0.14
+   ]
+  }, 
+  "U+F701": {
+   "stemUpNW": [
+    0.0, 
+    -0.008
+   ]
+  }, 
+  "U+F702": {
+   "stemUpNW": [
+    0.0, 
+    -0.052
+   ]
+  }, 
+  "U+F703": {
+   "stemUpNW": [
+    0.0, 
+    -0.012
+   ]
+  }, 
+  "U+F704": {
+   "stemDownSW": [
+    0.0, 
+    0.044
+   ]
+  }, 
+  "U+F705": {
+   "stemDownSW": [
+    0.0, 
+    0.052
+   ]
+  }, 
+  "accidentalSharpOneArrowDown": {
+   "cutOutSW": [
+    0.12, 
+    -0.916
+   ]
+  }, 
+  "accidentalSharpThreeArrowsDown": {
+   "cutOutSW": [
+    0.3, 
+    -1.464
+   ]
+  }, 
+  "beamAccelRit1": {
+   "repeatOffset": [
+    2.564, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit10": {
+   "repeatOffset": [
+    1.148, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit11": {
+   "repeatOffset": [
+    0.972, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit12": {
+   "repeatOffset": [
+    0.824, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit13": {
+   "repeatOffset": [
+    0.66, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit14": {
+   "repeatOffset": [
+    0.5, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit15": {
+   "repeatOffset": [
+    0.34, 
+    -0.004
+   ]
+  }, 
+  "beamAccelRit2": {
+   "repeatOffset": [
+    2.412, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit3": {
+   "repeatOffset": [
+    2.244, 
+    -0.008
+   ]
+  }, 
+  "beamAccelRit4": {
+   "repeatOffset": [
+    2.084, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit5": {
+   "repeatOffset": [
+    1.92, 
+    0.02
+   ]
+  }, 
+  "beamAccelRit6": {
+   "repeatOffset": [
+    1.764, 
+    0.008
+   ]
+  }, 
+  "beamAccelRit7": {
+   "repeatOffset": [
+    1.616, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit8": {
+   "repeatOffset": [
+    1.456, 
+    0.0
+   ]
+  }, 
+  "beamAccelRit9": {
+   "repeatOffset": [
+    1.304, 
+    0.0
+   ]
+  }, 
+  "flag1024thDown": {
+   "stemDownSW": [
+    0.0, 
+    -3.856
+   ]
+  }, 
+  "flag1024thUp": {
+   "stemUpNW": [
+    0.0, 
+    4.064
+   ]
+  }, 
+  "flag128thDown": {
+   "stemDownSW": [
+    0.0, 
+    -2.076
+   ]
+  }, 
+  "flag128thUp": {
+   "stemUpNW": [
+    0.0, 
+    1.9
+   ]
+  }, 
+  "flag16thDown": {
+   "stemDownSW": [
+    0.0, 
+    0.128
+   ]
+  }, 
+  "flag16thUp": {
+   "stemUpNW": [
+    0.0, 
+    -0.088
+   ]
+  }, 
+  "flag256thDown": {
+   "stemDownSW": [
+    0.0, 
+    -2.812
+   ]
+  }, 
+  "flag256thUp": {
+   "stemUpNW": [
+    0.0, 
+    2.592
+   ]
+  }, 
+  "flag32ndDown": {
+   "stemDownSW": [
+    0.0, 
+    -0.448
+   ]
+  }, 
+  "flag32ndUp": {
+   "stemUpNW": [
+    0.0, 
+    0.376
+   ]
+  }, 
+  "flag512thDown": {
+   "stemDownSW": [
+    0.0, 
+    -3.336
+   ]
+  }, 
+  "flag512thUp": {
+   "stemUpNW": [
+    0.0, 
+    3.324
+   ]
+  }, 
+  "flag64thDown": {
+   "stemDownSW": [
+    0.0, 
+    -1.244
+   ]
+  }, 
+  "flag64thUp": {
+   "stemUpNW": [
+    0.0, 
+    1.172
+   ]
+  }, 
+  "flag8thDown": {
+   "graceNoteSlashNW": [
+    -0.416, 
+    2.34
+   ], 
+   "graceNoteSlashSE": [
+    1.508, 
+    0.884
+   ], 
+   "stemDownSW": [
+    0.0, 
+    0.132
+   ]
+  }, 
+  "flag8thUp": {
+   "graceNoteSlashNE": [
+    1.472, 
+    -0.692
+   ], 
+   "graceNoteSlashSW": [
+    -0.4, 
+    -2.324
+   ], 
+   "stemUpNW": [
+    0.0, 
+    -0.04
+   ]
+  }, 
+  "gClefLigatedNumberAbove": {
+   "numeralBottom": [
+    2.22, 
+    3.476
+   ]
+  }, 
+  "gClefLigatedNumberBelow": {
+   "numeralBottom": [
+    0.94, 
+    -2.596
+   ]
+  }, 
+  "guitarVibratoStroke": {
+   "repeatOffset": [
+    0.572, 
+    0.0
+   ]
+  }, 
+  "guitarWideVibratoStroke": {
+   "repeatOffset": [
+    0.824, 
+    0.0
+   ]
+  }, 
+  "mensuralNoteheadMinimaWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.272, 
+    0.0
+   ]
+  }, 
+  "metNoteDoubleWhole": {
+   "noteheadOrigin": [
+    0.396, 
+    0.0
+   ]
+  }, 
+  "noteABlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteAFlatBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteAFlatHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteAHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteASharpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteASharpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteBBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteBFlatBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteBFlatHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteBHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteBSharpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteBSharpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteCBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteCFlatBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteCFlatHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteCHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteCSharpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteCSharpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteDBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteDFlatBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteDFlatHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteDHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteDSharpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteDSharpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteDoBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteDoHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteEBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteEFlatBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteEFlatHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteEHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteESharpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteESharpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteEmptyBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteEmptyHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteFBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteFFlatBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteFFlatHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteFHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteFSharpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteFSharpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteFaBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteFaHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteGBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteGFlatBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteGFlatHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteGHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteGSharpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteGSharpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteHBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteHHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteHSharpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteHSharpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteLaBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteLaHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteMiBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteMiHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteReBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteReHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteShapeArrowheadLeftBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.22, 
+    0.448
+   ]
+  }, 
+  "noteShapeArrowheadLeftWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.22, 
+    0.448
+   ]
+  }, 
+  "noteShapeDiamondBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.532, 
+    0.0
+   ]
+  }, 
+  "noteShapeDiamondWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.532, 
+    0.0
+   ]
+  }, 
+  "noteShapeIsoscelesTriangleBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.272, 
+    0.0
+   ]
+  }, 
+  "noteShapeIsoscelesTriangleWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.272, 
+    0.0
+   ]
+  }, 
+  "noteShapeKeystoneBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.516
+   ], 
+   "stemUpSE": [
+    1.412, 
+    0.516
+   ]
+  }, 
+  "noteShapeKeystoneWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.516
+   ], 
+   "stemUpSE": [
+    1.412, 
+    0.516
+   ]
+  }, 
+  "noteShapeMoonBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.06
+   ], 
+   "stemUpSE": [
+    1.532, 
+    0.06
+   ]
+  }, 
+  "noteShapeMoonLeftBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.124, 
+    0.0
+   ]
+  }, 
+  "noteShapeMoonLeftWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.124, 
+    0.0
+   ]
+  }, 
+  "noteShapeMoonWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.06
+   ], 
+   "stemUpSE": [
+    1.532, 
+    0.06
+   ]
+  }, 
+  "noteShapeQuarterMoonBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.516
+   ], 
+   "stemUpSE": [
+    1.12, 
+    0.0
+   ]
+  }, 
+  "noteShapeQuarterMoonWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.516
+   ], 
+   "stemUpSE": [
+    1.12, 
+    0.0
+   ]
+  }, 
+  "noteShapeRoundBlack": {
+   "stemDownNW": [
+    0.004, 
+    -0.16
+   ], 
+   "stemUpSE": [
+    1.276, 
+    0.14
+   ]
+  }, 
+  "noteShapeRoundWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.2
+   ], 
+   "stemUpSE": [
+    1.312, 
+    0.196
+   ]
+  }, 
+  "noteShapeSquareBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.52
+   ], 
+   "stemUpSE": [
+    1.532, 
+    -0.52
+   ]
+  }, 
+  "noteShapeSquareWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.52
+   ], 
+   "stemUpSE": [
+    1.532, 
+    -0.52
+   ]
+  }, 
+  "noteShapeTriangleLeftBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.52
+   ], 
+   "stemUpSE": [
+    1.532, 
+    -0.332
+   ]
+  }, 
+  "noteShapeTriangleLeftWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.52
+   ], 
+   "stemUpSE": [
+    1.532, 
+    -0.332
+   ]
+  }, 
+  "noteShapeTriangleRightBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.52
+   ], 
+   "stemUpSE": [
+    1.532, 
+    -0.52
+   ]
+  }, 
+  "noteShapeTriangleRightWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.52
+   ], 
+   "stemUpSE": [
+    1.532, 
+    -0.52
+   ]
+  }, 
+  "noteShapeTriangleRoundBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.18
+   ], 
+   "stemUpSE": [
+    1.532, 
+    0.18
+   ]
+  }, 
+  "noteShapeTriangleRoundLeftBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.396, 
+    0.0
+   ]
+  }, 
+  "noteShapeTriangleRoundLeftWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.396, 
+    0.0
+   ]
+  }, 
+  "noteShapeTriangleRoundWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.18
+   ], 
+   "stemUpSE": [
+    1.532, 
+    0.18
+   ]
+  }, 
+  "noteShapeTriangleUpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.52
+   ], 
+   "stemUpSE": [
+    1.532, 
+    -0.52
+   ]
+  }, 
+  "noteShapeTriangleUpWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.52
+   ], 
+   "stemUpSE": [
+    1.532, 
+    -0.52
+   ]
+  }, 
+  "noteSiBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteSiHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteSoBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteSoHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteTiBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.4, 
+    0.14
+   ]
+  }, 
+  "noteTiHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.128
+   ], 
+   "stemUpSE": [
+    1.452, 
+    0.096
+   ]
+  }, 
+  "noteheadBlack": {
+   "cutOutNW": [
+    0.22, 
+    0.272
+   ], 
+   "cutOutSE": [
+    0.976, 
+    -0.348
+   ], 
+   "splitStemDownNE": [
+    1.064, 
+    -0.28
+   ], 
+   "splitStemDownNW": [
+    0.116, 
+    -0.42
+   ], 
+   "splitStemUpSE": [
+    1.116, 
+    0.428
+   ], 
+   "splitStemUpSW": [
+    0.332, 
+    0.356
+   ], 
+   "stemDownNW": [
+    0.0, 
+    -0.16
+   ], 
+   "stemUpSE": [
+    1.272, 
+    0.14
+   ]
+  }, 
+  "noteheadBlackParens": {
+   "stemDownNW": [
+    0.532, 
+    -0.148
+   ], 
+   "stemUpSE": [
+    1.744, 
+    0.128
+   ]
+  }, 
+  "noteheadCircleSlash": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.032, 
+    0.0
+   ]
+  }, 
+  "noteheadCircleX": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.088, 
+    0.0
+   ]
+  }, 
+  "noteheadCircleXDoubleWhole": {
+   "noteheadOrigin": [
+    0.384, 
+    0.0
+   ]
+  }, 
+  "noteheadCircleXHalf": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.088, 
+    0.0
+   ]
+  }, 
+  "noteheadCircledBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.14
+   ], 
+   "stemUpSE": [
+    1.212, 
+    0.124
+   ]
+  }, 
+  "noteheadCircledBlackLarge": {
+   "stemDownNW": [
+    0.0, 
+    -0.148
+   ], 
+   "stemUpSE": [
+    1.212, 
+    0.128
+   ]
+  }, 
+  "noteheadCircledDoubleWhole": {
+   "noteheadOrigin": [
+    0.436, 
+    0.0
+   ]
+  }, 
+  "noteheadCircledDoubleWholeLarge": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    2.336, 
+    0.0
+   ]
+  }, 
+  "noteheadCircledHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.18
+   ], 
+   "stemUpSE": [
+    1.184, 
+    0.176
+   ]
+  }, 
+  "noteheadCircledHalfLarge": {
+   "stemDownNW": [
+    0.0, 
+    -0.18
+   ], 
+   "stemUpSE": [
+    1.184, 
+    0.176
+   ]
+  }, 
+  "noteheadCircledWholeLarge": {
+   "stemDownNW": [
+    0.0, 
+    -0.004
+   ], 
+   "stemUpSE": [
+    2.224, 
+    0.0
+   ]
+  }, 
+  "noteheadCircledXLarge": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.596, 
+    0.0
+   ]
+  }, 
+  "noteheadClusterDoubleWhole2nd": {
+   "noteheadOrigin": [
+    0.392, 
+    0.0
+   ]
+  }, 
+  "noteheadClusterDoubleWhole3rd": {
+   "noteheadOrigin": [
+    0.4, 
+    0.0
+   ]
+  }, 
+  "noteheadClusterHalf2nd": {
+   "stemDownNW": [
+    0.0, 
+    -0.188
+   ], 
+   "stemUpSE": [
+    1.312, 
+    0.692
+   ]
+  }, 
+  "noteheadClusterHalf3rd": {
+   "stemDownNW": [
+    0.0, 
+    -0.188
+   ], 
+   "stemUpSE": [
+    1.312, 
+    1.212
+   ]
+  }, 
+  "noteheadClusterHalfBottom": {
+   "stemDownNW": [
+    0.0, 
+    -0.204
+   ]
+  }, 
+  "noteheadClusterHalfTop": {
+   "stemUpSE": [
+    1.312, 
+    0.196
+   ]
+  }, 
+  "noteheadClusterQuarter2nd": {
+   "stemDownNW": [
+    0.0, 
+    -0.156
+   ], 
+   "stemUpSE": [
+    1.272, 
+    0.696
+   ]
+  }, 
+  "noteheadClusterQuarter3rd": {
+   "stemDownNW": [
+    0.0, 
+    -0.156
+   ], 
+   "stemUpSE": [
+    1.272, 
+    1.208
+   ]
+  }, 
+  "noteheadClusterQuarterBottom": {
+   "stemDownNW": [
+    0.0, 
+    -0.16
+   ]
+  }, 
+  "noteheadClusterQuarterTop": {
+   "stemUpSE": [
+    1.272, 
+    0.14
+   ]
+  }, 
+  "noteheadClusterRoundBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.108
+   ], 
+   "stemUpSE": [
+    1.312, 
+    2.124
+   ]
+  }, 
+  "noteheadClusterRoundWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.312, 
+    2.124
+   ]
+  }, 
+  "noteheadClusterSquareBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.428
+   ], 
+   "stemUpSE": [
+    1.208, 
+    2.412
+   ]
+  }, 
+  "noteheadClusterSquareWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.404
+   ], 
+   "stemUpSE": [
+    1.208, 
+    2.42
+   ]
+  }, 
+  "noteheadDiamondBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.132, 
+    0.0
+   ]
+  }, 
+  "noteheadDiamondBlackOld": {
+   "stemDownNW": [
+    0.0, 
+    0.008
+   ], 
+   "stemUpSE": [
+    1.2, 
+    -0.008
+   ]
+  }, 
+  "noteheadDiamondBlackWide": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.496, 
+    0.0
+   ]
+  }, 
+  "noteheadDiamondClusterBlack2nd": {
+   "stemDownNW": [
+    0.0, 
+    0.124
+   ], 
+   "stemUpSE": [
+    1.392, 
+    0.528
+   ]
+  }, 
+  "noteheadDiamondClusterBlack3rd": {
+   "stemDownNW": [
+    0.0, 
+    0.128
+   ], 
+   "stemUpSE": [
+    1.392, 
+    0.86
+   ]
+  }, 
+  "noteheadDiamondClusterBlackBottom": {
+   "stemDownNW": [
+    0.0, 
+    0.128
+   ]
+  }, 
+  "noteheadDiamondClusterBlackTop": {
+   "stemUpSE": [
+    1.392, 
+    -0.176
+   ]
+  }, 
+  "noteheadDiamondClusterWhite2nd": {
+   "stemDownNW": [
+    0.0, 
+    0.128
+   ], 
+   "stemUpSE": [
+    1.392, 
+    0.532
+   ]
+  }, 
+  "noteheadDiamondClusterWhite3rd": {
+   "stemDownNW": [
+    0.0, 
+    0.124
+   ], 
+   "stemUpSE": [
+    1.392, 
+    0.856
+   ]
+  }, 
+  "noteheadDiamondClusterWhiteBottom": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ]
+  }, 
+  "noteheadDiamondClusterWhiteTop": {
+   "stemUpSE": [
+    1.392, 
+    0.0
+   ]
+  }, 
+  "noteheadDiamondDoubleWhole": {
+   "noteheadOrigin": [
+    0.392, 
+    0.06
+   ]
+  }, 
+  "noteheadDiamondDoubleWholeOld": {
+   "noteheadOrigin": [
+    0.432, 
+    0.008
+   ]
+  }, 
+  "noteheadDiamondHalf": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.132, 
+    0.0
+   ]
+  }, 
+  "noteheadDiamondHalfFilled": {
+   "stemDownNW": [
+    0.0, 
+    0.008
+   ], 
+   "stemUpSE": [
+    1.2, 
+    -0.008
+   ]
+  }, 
+  "noteheadDiamondHalfOld": {
+   "stemDownNW": [
+    0.0, 
+    0.008
+   ], 
+   "stemUpSE": [
+    1.2, 
+    -0.008
+   ]
+  }, 
+  "noteheadDiamondHalfWide": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.496, 
+    0.0
+   ]
+  }, 
+  "noteheadDiamondOpen": {
+   "stemDownNW": [
+    0.0, 
+    0.008
+   ], 
+   "stemUpSE": [
+    1.2, 
+    -0.008
+   ]
+  }, 
+  "noteheadDiamondWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.132, 
+    0.0
+   ]
+  }, 
+  "noteheadDiamondWhiteWide": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.496, 
+    0.0
+   ]
+  }, 
+  "noteheadDoubleWhole": {
+   "noteheadOrigin": [
+    0.36, 
+    0.0
+   ]
+  }, 
+  "noteheadDoubleWholeAlt": {
+   "noteheadOrigin": [
+    0.092, 
+    0.0
+   ]
+  }, 
+  "noteheadDoubleWholeParens": {
+   "noteheadOrigin": [
+    0.908, 
+    0.0
+   ]
+  }, 
+  "noteheadDoubleWholeWithX": {
+   "noteheadOrigin": [
+    0.384, 
+    0.0
+   ]
+  }, 
+  "noteheadHalf": {
+   "cutOutNW": [
+    0.208, 
+    0.268
+   ], 
+   "cutOutSE": [
+    1.104, 
+    -0.296
+   ], 
+   "splitStemDownNE": [
+    1.012, 
+    -0.376
+   ], 
+   "splitStemDownNW": [
+    0.124, 
+    -0.436
+   ], 
+   "splitStemUpSE": [
+    1.116, 
+    0.476
+   ], 
+   "splitStemUpSW": [
+    0.332, 
+    0.372
+   ], 
+   "stemDownNW": [
+    0.0, 
+    -0.2
+   ], 
+   "stemUpSE": [
+    1.312, 
+    0.196
+   ]
+  }, 
+  "noteheadHalfParens": {
+   "stemDownNW": [
+    0.568, 
+    -0.184
+   ], 
+   "stemUpSE": [
+    1.752, 
+    0.172
+   ]
+  }, 
+  "noteheadHalfWithX": {
+   "stemDownNW": [
+    0.0, 
+    -0.2
+   ], 
+   "stemUpSE": [
+    1.312, 
+    0.196
+   ]
+  }, 
+  "noteheadHeavyX": {
+   "stemDownNW": [
+    0.0, 
+    -0.516
+   ], 
+   "stemUpSE": [
+    1.736, 
+    0.516
+   ]
+  }, 
+  "noteheadHeavyXHat": {
+   "stemDownNW": [
+    0.0, 
+    -0.516
+   ], 
+   "stemUpSE": [
+    1.664, 
+    0.592
+   ]
+  }, 
+  "noteheadLargeArrowDownBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.5
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.5
+   ]
+  }, 
+  "noteheadLargeArrowDownDoubleWhole": {
+   "noteheadOrigin": [
+    0.452, 
+    0.0
+   ]
+  }, 
+  "noteheadLargeArrowDownHalf": {
+   "stemDownNW": [
+    0.0, 
+    0.5
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.5
+   ]
+  }, 
+  "noteheadLargeArrowUpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.5
+   ], 
+   "stemUpSE": [
+    1.26, 
+    -0.5
+   ]
+  }, 
+  "noteheadLargeArrowUpDoubleWhole": {
+   "noteheadOrigin": [
+    0.452, 
+    0.0
+   ]
+  }, 
+  "noteheadLargeArrowUpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.5
+   ], 
+   "stemUpSE": [
+    1.26, 
+    -0.5
+   ]
+  }, 
+  "noteheadMoonBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.06
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.06
+   ]
+  }, 
+  "noteheadMoonWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.06
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.06
+   ]
+  }, 
+  "noteheadPlusBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.012, 
+    0.0
+   ]
+  }, 
+  "noteheadPlusDoubleWhole": {
+   "noteheadOrigin": [
+    0.488, 
+    0.0
+   ]
+  }, 
+  "noteheadPlusHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.172
+   ], 
+   "stemUpSE": [
+    1.068, 
+    0.16
+   ]
+  }, 
+  "noteheadRoundBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.032, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundBlackDoubleSlashed": {
+   "stemDownNW": [
+    0.0, 
+    0.004
+   ], 
+   "stemUpSE": [
+    1.032, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundBlackLarge": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.996, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundBlackSlashed": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.032, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundBlackSlashedLarge": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.996, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.032, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundWhiteDoubleSlashed": {
+   "stemDownNW": [
+    0.0, 
+    0.004
+   ], 
+   "stemUpSE": [
+    1.032, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundWhiteLarge": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.996, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundWhiteSlashed": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.032, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundWhiteSlashedLarge": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.996, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundWhiteWithDot": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.032, 
+    0.0
+   ]
+  }, 
+  "noteheadRoundWhiteWithDotLarge": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.996, 
+    0.0
+   ]
+  }, 
+  "noteheadSlashDiamondWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    2.028, 
+    0.0
+   ]
+  }, 
+  "noteheadSlashHorizontalEnds": {
+   "stemDownNW": [
+    0.0, 
+    -1.016
+   ], 
+   "stemUpSE": [
+    2.56, 
+    1.012
+   ]
+  }, 
+  "noteheadSlashHorizontalEndsMuted": {
+   "stemDownNW": [
+    0.0, 
+    -1.016
+   ], 
+   "stemUpSE": [
+    2.536, 
+    1.012
+   ]
+  }, 
+  "noteheadSlashVerticalEnds": {
+   "stemDownNW": [
+    0.0, 
+    -0.664
+   ], 
+   "stemUpSE": [
+    1.324, 
+    0.64
+   ]
+  }, 
+  "noteheadSlashVerticalEndsMuted": {
+   "stemDownNW": [
+    0.0, 
+    -0.66
+   ], 
+   "stemUpSE": [
+    1.652, 
+    0.652
+   ]
+  }, 
+  "noteheadSlashVerticalEndsSmall": {
+   "stemDownNW": [
+    0.0, 
+    -0.26
+   ], 
+   "stemUpSE": [
+    0.756, 
+    0.264
+   ]
+  }, 
+  "noteheadSlashWhiteHalf": {
+   "stemDownNW": [
+    0.0, 
+    -1.016
+   ], 
+   "stemUpSE": [
+    3.424, 
+    1.012
+   ]
+  }, 
+  "noteheadSlashWhiteMuted": {
+   "stemDownNW": [
+    0.0, 
+    -1.016
+   ], 
+   "stemUpSE": [
+    3.304, 
+    1.012
+   ]
+  }, 
+  "noteheadSlashX": {
+   "stemDownNW": [
+    0.0, 
+    -1.016
+   ], 
+   "stemUpSE": [
+    2.076, 
+    1.012
+   ]
+  }, 
+  "noteheadSlashedBlack1": {
+   "stemDownNW": [
+    0.0, 
+    -0.164
+   ], 
+   "stemUpSE": [
+    1.28, 
+    0.136
+   ]
+  }, 
+  "noteheadSlashedBlack2": {
+   "stemDownNW": [
+    0.0, 
+    -0.16
+   ], 
+   "stemUpSE": [
+    1.272, 
+    0.14
+   ]
+  }, 
+  "noteheadSlashedDoubleWhole1": {
+   "noteheadOrigin": [
+    0.388, 
+    0.0
+   ]
+  }, 
+  "noteheadSlashedDoubleWhole2": {
+   "noteheadOrigin": [
+    0.388, 
+    -0.004
+   ]
+  }, 
+  "noteheadSlashedHalf1": {
+   "stemDownNW": [
+    0.0, 
+    -0.2
+   ], 
+   "stemUpSE": [
+    1.312, 
+    0.196
+   ]
+  }, 
+  "noteheadSlashedHalf2": {
+   "stemDownNW": [
+    0.0, 
+    -0.2
+   ], 
+   "stemUpSE": [
+    1.312, 
+    0.196
+   ]
+  }, 
+  "noteheadSquareBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.472
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.472
+   ]
+  }, 
+  "noteheadSquareBlackLarge": {
+   "stemDownNW": [
+    0.0, 
+    0.0
+   ], 
+   "stemUpSE": [
+    1.996, 
+    0.0
+   ]
+  }, 
+  "noteheadSquareBlackWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.996
+   ], 
+   "stemUpSE": [
+    1.996, 
+    1.0
+   ]
+  }, 
+  "noteheadSquareWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.472
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.472
+   ]
+  }, 
+  "noteheadTriangleDownBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.516
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.516
+   ]
+  }, 
+  "noteheadTriangleDownDoubleWhole": {
+   "noteheadOrigin": [
+    0.484, 
+    0.0
+   ]
+  }, 
+  "noteheadTriangleDownHalf": {
+   "stemDownNW": [
+    0.0, 
+    0.512
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.512
+   ]
+  }, 
+  "noteheadTriangleDownWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.516
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.516
+   ]
+  }, 
+  "noteheadTriangleLeftBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.472
+   ], 
+   "stemUpSE": [
+    1.26, 
+    -0.472
+   ]
+  }, 
+  "noteheadTriangleLeftWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.496
+   ], 
+   "stemUpSE": [
+    1.148, 
+    -0.496
+   ]
+  }, 
+  "noteheadTriangleRightBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.472
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.392
+   ]
+  }, 
+  "noteheadTriangleRightWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.532
+   ], 
+   "stemUpSE": [
+    1.148, 
+    0.284
+   ]
+  }, 
+  "noteheadTriangleRoundDownBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.184
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.184
+   ]
+  }, 
+  "noteheadTriangleRoundDownWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.184
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.184
+   ]
+  }, 
+  "noteheadTriangleUpBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.512
+   ], 
+   "stemUpSE": [
+    1.26, 
+    -0.512
+   ]
+  }, 
+  "noteheadTriangleUpDoubleWhole": {
+   "noteheadOrigin": [
+    0.484, 
+    0.0
+   ]
+  }, 
+  "noteheadTriangleUpHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.516
+   ], 
+   "stemUpSE": [
+    1.26, 
+    -0.516
+   ]
+  }, 
+  "noteheadTriangleUpRightBlack": {
+   "stemDownNW": [
+    0.0, 
+    0.472
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.472
+   ]
+  }, 
+  "noteheadTriangleUpRightWhite": {
+   "stemDownNW": [
+    0.0, 
+    0.472
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.472
+   ]
+  }, 
+  "noteheadTriangleUpWhite": {
+   "stemDownNW": [
+    0.0, 
+    -0.512
+   ], 
+   "stemUpSE": [
+    1.26, 
+    -0.512
+   ]
+  }, 
+  "noteheadVoidWithX": {
+   "stemDownNW": [
+    0.0, 
+    -0.16
+   ], 
+   "stemUpSE": [
+    1.272, 
+    0.14
+   ]
+  }, 
+  "noteheadWhole": {
+   "cutOutNW": [
+    0.164, 
+    0.336
+   ], 
+   "cutOutSE": [
+    1.496, 
+    -0.348
+   ]
+  }, 
+  "noteheadXBlack": {
+   "stemDownNW": [
+    0.0, 
+    -0.444
+   ], 
+   "stemUpSE": [
+    1.076, 
+    0.444
+   ]
+  }, 
+  "noteheadXDoubleWhole": {
+   "noteheadOrigin": [
+    0.38, 
+    0.0
+   ]
+  }, 
+  "noteheadXHalf": {
+   "stemDownNW": [
+    0.0, 
+    -0.548
+   ], 
+   "stemUpSE": [
+    1.592, 
+    0.544
+   ]
+  }, 
+  "noteheadXOrnate": {
+   "stemDownNW": [
+    0.0, 
+    -0.5
+   ], 
+   "stemUpSE": [
+    1.008, 
+    0.5
+   ]
+  }, 
+  "noteheadXOrnateEllipse": {
+   "stemDownNW": [
+    0.264, 
+    -0.46
+   ], 
+   "stemUpSE": [
+    1.26, 
+    0.46
+   ]
+  }, 
+  "ornamentBottomLeftConcaveStroke": {
+   "repeatOffset": [
+    0.484, 
+    0.0
+   ]
+  }, 
+  "ornamentBottomLeftConcaveStrokeLarge": {
+   "repeatOffset": [
+    1.656, 
+    0.0
+   ]
+  }, 
+  "ornamentBottomLeftConvexStroke": {
+   "repeatOffset": [
+    1.82, 
+    0.0
+   ]
+  }, 
+  "ornamentHighLeftConcaveStroke": {
+   "repeatOffset": [
+    1.428, 
+    -0.008
+   ]
+  }, 
+  "ornamentHighLeftConvexStroke": {
+   "repeatOffset": [
+    1.104, 
+    -0.008
+   ]
+  }, 
+  "ornamentLeftPlus": {
+   "repeatOffset": [
+    2.532, 
+    0.0
+   ]
+  }, 
+  "ornamentLeftShakeT": {
+   "repeatOffset": [
+    0.912, 
+    0.0
+   ]
+  }, 
+  "ornamentLeftVerticalStroke": {
+   "repeatOffset": [
+    0.748, 
+    0.0
+   ]
+  }, 
+  "ornamentLeftVerticalStrokeWithCross": {
+   "repeatOffset": [
+    1.032, 
+    -0.004
+   ]
+  }, 
+  "ornamentLowLeftConcaveStroke": {
+   "repeatOffset": [
+    1.408, 
+    0.0
+   ]
+  }, 
+  "ornamentLowLeftConvexStroke": {
+   "repeatOffset": [
+    1.36, 
+    0.0
+   ]
+  }, 
+  "ornamentMiddleVerticalStroke": {
+   "repeatOffset": [
+    0.004, 
+    0.0
+   ]
+  }, 
+  "ornamentTopLeftConcaveStroke": {
+   "repeatOffset": [
+    1.428, 
+    0.0
+   ]
+  }, 
+  "ornamentTopLeftConvexStroke": {
+   "repeatOffset": [
+    1.132, 
+    0.0
+   ]
+  }, 
+  "ornamentZigZagLineNoRightEnd": {
+   "repeatOffset": [
+    1.0, 
+    0.0
+   ]
+  }, 
+  "ornamentZigZagLineWithRightEnd": {
+   "repeatOffset": [
+    1.244, 
+    0.0
+   ]
+  }, 
+  "wiggleArpeggiatoDown": {
+   "repeatOffset": [
+    1.02, 
+    0.0
+   ]
+  }, 
+  "wiggleArpeggiatoDownArrow": {
+   "repeatOffset": [
+    1.788, 
+    0.0
+   ]
+  }, 
+  "wiggleArpeggiatoDownSwash": {
+   "repeatOffset": [
+    1.736, 
+    0.0
+   ]
+  }, 
+  "wiggleArpeggiatoUp": {
+   "repeatOffset": [
+    1.028, 
+    -0.004
+   ]
+  }, 
+  "wiggleArpeggiatoUpArrow": {
+   "repeatOffset": [
+    1.836, 
+    0.0
+   ]
+  }, 
+  "wiggleArpeggiatoUpSwash": {
+   "repeatOffset": [
+    1.94, 
+    0.0
+   ]
+  }, 
+  "wiggleCircular": {
+   "repeatOffset": [
+    1.484, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularConstant": {
+   "repeatOffset": [
+    0.824, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularConstantFlipped": {
+   "repeatOffset": [
+    0.824, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularConstantFlippedLarge": {
+   "repeatOffset": [
+    1.188, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularConstantLarge": {
+   "repeatOffset": [
+    1.196, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularEnd": {
+   "repeatOffset": [
+    0.756, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularLarge": {
+   "repeatOffset": [
+    1.604, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularLarger": {
+   "repeatOffset": [
+    2.252, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularLargerStill": {
+   "repeatOffset": [
+    2.964, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularLargest": {
+   "repeatOffset": [
+    3.968, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularSmall": {
+   "repeatOffset": [
+    1.1, 
+    0.0
+   ]
+  }, 
+  "wiggleCircularStart": {
+   "repeatOffset": [
+    1.92, 
+    0.0
+   ]
+  }, 
+  "wiggleGlissando": {
+   "repeatOffset": [
+    0.948, 
+    -0.004
+   ]
+  }, 
+  "wiggleGlissandoGroup1": {
+   "repeatOffset": [
+    1.228, 
+    0.0
+   ]
+  }, 
+  "wiggleGlissandoGroup2": {
+   "repeatOffset": [
+    0.556, 
+    0.0
+   ]
+  }, 
+  "wiggleGlissandoGroup3": {
+   "repeatOffset": [
+    0.516, 
+    0.0
+   ]
+  }, 
+  "wiggleRandom1": {
+   "repeatOffset": [
+    7.912, 
+    0.0
+   ]
+  }, 
+  "wiggleRandom2": {
+   "repeatOffset": [
+    7.62, 
+    0.0
+   ]
+  }, 
+  "wiggleRandom3": {
+   "repeatOffset": [
+    7.424, 
+    0.0
+   ]
+  }, 
+  "wiggleRandom4": {
+   "repeatOffset": [
+    7.424, 
+    0.0
+   ]
+  }, 
+  "wiggleSawtooth": {
+   "repeatOffset": [
+    2.884, 
+    0.004
+   ]
+  }, 
+  "wiggleSawtoothNarrow": {
+   "repeatOffset": [
+    2.244, 
+    0.0
+   ]
+  }, 
+  "wiggleSawtoothWide": {
+   "repeatOffset": [
+    3.208, 
+    0.0
+   ]
+  }, 
+  "wiggleSquareWave": {
+   "repeatOffset": [
+    3.012, 
+    -0.004
+   ]
+  }, 
+  "wiggleSquareWaveNarrow": {
+   "repeatOffset": [
+    2.06, 
+    0.0
+   ]
+  }, 
+  "wiggleSquareWaveWide": {
+   "repeatOffset": [
+    3.98, 
+    0.0
+   ]
+  }, 
+  "wiggleTrill": {
+   "repeatOffset": [
+    0.852, 
+    0.0
+   ]
+  }, 
+  "wiggleTrillFast": {
+   "repeatOffset": [
+    0.756, 
+    0.0
+   ]
+  }, 
+  "wiggleTrillFaster": {
+   "repeatOffset": [
+    0.688, 
+    0.0
+   ]
+  }, 
+  "wiggleTrillFasterStill": {
+   "repeatOffset": [
+    0.604, 
+    0.0
+   ]
+  }, 
+  "wiggleTrillFastest": {
+   "repeatOffset": [
+    0.528, 
+    0.0
+   ]
+  }, 
+  "wiggleTrillSlow": {
+   "repeatOffset": [
+    1.128, 
+    0.0
+   ]
+  }, 
+  "wiggleTrillSlower": {
+   "repeatOffset": [
+    1.268, 
+    0.0
+   ]
+  }, 
+  "wiggleTrillSlowerStill": {
+   "repeatOffset": [
+    1.392, 
+    0.0
+   ]
+  }, 
+  "wiggleTrillSlowest": {
+   "repeatOffset": [
+    1.576, 
+    0.0
+   ]
+  }, 
+  "wiggleVIbratoLargestSlower": {
+   "repeatOffset": [
+    3.732, 
+    0.0
+   ]
+  }, 
+  "wiggleVIbratoMediumSlower": {
+   "repeatOffset": [
+    1.624, 
+    0.0
+   ]
+  }, 
+  "wiggleVibrato": {
+   "repeatOffset": [
+    0.572, 
+    -0.004
+   ]
+  }, 
+  "wiggleVibratoLargeFast": {
+   "repeatOffset": [
+    1.732, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargeFaster": {
+   "repeatOffset": [
+    1.504, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargeFasterStill": {
+   "repeatOffset": [
+    1.264, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargeFastest": {
+   "repeatOffset": [
+    1.096, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargeSlow": {
+   "repeatOffset": [
+    2.044, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargeSlower": {
+   "repeatOffset": [
+    2.524, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargeSlowest": {
+   "repeatOffset": [
+    3.004, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargestFast": {
+   "repeatOffset": [
+    2.732, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargestFaster": {
+   "repeatOffset": [
+    2.244, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargestFasterStill": {
+   "repeatOffset": [
+    1.916, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargestFastest": {
+   "repeatOffset": [
+    1.616, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargestSlow": {
+   "repeatOffset": [
+    3.204, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoLargestSlowest": {
+   "repeatOffset": [
+    4.464, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoMediumFast": {
+   "repeatOffset": [
+    1.152, 
+    -0.004
+   ]
+  }, 
+  "wiggleVibratoMediumFaster": {
+   "repeatOffset": [
+    0.968, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoMediumFasterStill": {
+   "repeatOffset": [
+    0.828, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoMediumFastest": {
+   "repeatOffset": [
+    0.74, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoMediumSlow": {
+   "repeatOffset": [
+    1.408, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoMediumSlowest": {
+   "repeatOffset": [
+    1.964, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallFast": {
+   "repeatOffset": [
+    0.816, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallFaster": {
+   "repeatOffset": [
+    0.68, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallFasterStill": {
+   "repeatOffset": [
+    0.596, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallFastest": {
+   "repeatOffset": [
+    0.544, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallSlow": {
+   "repeatOffset": [
+    0.996, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallSlower": {
+   "repeatOffset": [
+    1.176, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallSlowest": {
+   "repeatOffset": [
+    1.452, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestFast": {
+   "repeatOffset": [
+    0.668, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestFaster": {
+   "repeatOffset": [
+    0.592, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestFasterStill": {
+   "repeatOffset": [
+    0.492, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestFastest": {
+   "repeatOffset": [
+    0.46, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestSlow": {
+   "repeatOffset": [
+    0.788, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestSlower": {
+   "repeatOffset": [
+    0.912, 
+    0.0
+   ]
+  }, 
+  "wiggleVibratoSmallestSlowest": {
+   "repeatOffset": [
+    1.156, 
+    -0.004
+   ]
+  }, 
+  "wiggleVibratoStart": {
+   "repeatOffset": [
+    1.828, 
+    -0.004
+   ]
+  }, 
+  "wiggleVibratoWide": {
+   "repeatOffset": [
+    0.824, 
+    0.0
+   ]
+  }, 
+  "wiggleWavy": {
+   "repeatOffset": [
+    3.188, 
+    0.0
+   ]
+  }, 
+  "wiggleWavyNarrow": {
+   "repeatOffset": [
+    2.22, 
+    0.0
+   ]
+  }, 
+  "wiggleWavyWide": {
+   "repeatOffset": [
+    4.152, 
+    0.0
+   ]
+  }
+ }, 
+ "optionalGlyphs": {
+  "4stringTabClefSerif": {
+   "classes": [], 
+   "codepoint": "U+F40D"
+  }, 
+  "4stringTabClefTall": {
+   "classes": [], 
+   "codepoint": "U+F40C"
+  }, 
+  "6stringTabClefSerif": {
+   "classes": [], 
+   "codepoint": "U+F40B"
+  }, 
+  "6stringTabClefTall": {
+   "classes": [], 
+   "codepoint": "U+F40A"
+  }, 
+  "U+F43F": {
+   "classes": [], 
+   "codepoint": "U+F43F"
+  }, 
+  "U+F600": {
+   "classes": [], 
+   "codepoint": "U+F600"
+  }, 
+  "U+F601": {
+   "classes": [], 
+   "codepoint": "U+F601"
+  }, 
+  "U+F602": {
+   "classes": [], 
+   "codepoint": "U+F602"
+  }, 
+  "U+F603": {
+   "classes": [], 
+   "codepoint": "U+F603"
+  }, 
+  "U+F604": {
+   "classes": [], 
+   "codepoint": "U+F604"
+  }, 
+  "U+F605": {
+   "classes": [], 
+   "codepoint": "U+F605"
+  }, 
+  "U+F606": {
+   "classes": [], 
+   "codepoint": "U+F606"
+  }, 
+  "U+F607": {
+   "classes": [], 
+   "codepoint": "U+F607"
+  }, 
+  "U+F608": {
+   "classes": [], 
+   "codepoint": "U+F608"
+  }, 
+  "U+F609": {
+   "classes": [], 
+   "codepoint": "U+F609"
+  }, 
+  "U+F60A": {
+   "classes": [], 
+   "codepoint": "U+F60A"
+  }, 
+  "U+F60B": {
+   "classes": [], 
+   "codepoint": "U+F60B"
+  }, 
+  "U+F60C": {
+   "classes": [], 
+   "codepoint": "U+F60C"
+  }, 
+  "U+F610": {
+   "classes": [], 
+   "codepoint": "U+F610"
+  }, 
+  "U+F611": {
+   "classes": [], 
+   "codepoint": "U+F611"
+  }, 
+  "U+F612": {
+   "classes": [], 
+   "codepoint": "U+F612"
+  }, 
+  "U+F613": {
+   "classes": [], 
+   "codepoint": "U+F613"
+  }, 
+  "U+F614": {
+   "classes": [], 
+   "codepoint": "U+F614"
+  }, 
+  "U+F615": {
+   "classes": [], 
+   "codepoint": "U+F615"
+  }, 
+  "U+F616": {
+   "classes": [], 
+   "codepoint": "U+F616"
+  }, 
+  "U+F617": {
+   "classes": [], 
+   "codepoint": "U+F617"
+  }, 
+  "U+F618": {
+   "classes": [], 
+   "codepoint": "U+F618"
+  }, 
+  "U+F619": {
+   "classes": [], 
+   "codepoint": "U+F619"
+  }, 
+  "U+F61A": {
+   "classes": [], 
+   "codepoint": "U+F61A"
+  }, 
+  "U+F61B": {
+   "classes": [], 
+   "codepoint": "U+F61B"
+  }, 
+  "U+F61C": {
+   "classes": [], 
+   "codepoint": "U+F61C"
+  }, 
+  "U+F624": {
+   "classes": [], 
+   "codepoint": "U+F624"
+  }, 
+  "U+F625": {
+   "classes": [], 
+   "codepoint": "U+F625"
+  }, 
+  "U+F626": {
+   "classes": [], 
+   "codepoint": "U+F626"
+  }, 
+  "U+F627": {
+   "classes": [], 
+   "codepoint": "U+F627"
+  }, 
+  "U+F628": {
+   "classes": [], 
+   "codepoint": "U+F628"
+  }, 
+  "U+F629": {
+   "classes": [], 
+   "codepoint": "U+F629"
+  }, 
+  "U+F62A": {
+   "classes": [], 
+   "codepoint": "U+F62A"
+  }, 
+  "U+F62B": {
+   "classes": [], 
+   "codepoint": "U+F62B"
+  }, 
+  "U+F62C": {
+   "classes": [], 
+   "codepoint": "U+F62C"
+  }, 
+  "U+F62D": {
+   "classes": [], 
+   "codepoint": "U+F62D"
+  }, 
+  "U+F62E": {
+   "classes": [], 
+   "codepoint": "U+F62E"
+  }, 
+  "U+F62F": {
+   "classes": [], 
+   "codepoint": "U+F62F"
+  }, 
+  "U+F630": {
+   "classes": [], 
+   "codepoint": "U+F630"
+  }, 
+  "U+F631": {
+   "classes": [], 
+   "codepoint": "U+F631"
+  }, 
+  "U+F632": {
+   "classes": [], 
+   "codepoint": "U+F632"
+  }, 
+  "U+F633": {
+   "classes": [], 
+   "codepoint": "U+F633"
+  }, 
+  "U+F634": {
+   "classes": [], 
+   "codepoint": "U+F634"
+  }, 
+  "U+F635": {
+   "classes": [], 
+   "codepoint": "U+F635"
+  }, 
+  "U+F636": {
+   "classes": [], 
+   "codepoint": "U+F636"
+  }, 
+  "U+F670": {
+   "classes": [], 
+   "codepoint": "U+F670"
+  }, 
+  "U+F673": {
+   "classes": [], 
+   "codepoint": "U+F673"
+  }, 
+  "U+F674": {
+   "classes": [], 
+   "codepoint": "U+F674"
+  }, 
+  "U+F675": {
+   "classes": [], 
+   "codepoint": "U+F675"
+  }, 
+  "U+F676": {
+   "classes": [], 
+   "codepoint": "U+F676"
+  }, 
+  "U+F677": {
+   "classes": [], 
+   "codepoint": "U+F677"
+  }, 
+  "U+F678": {
+   "classes": [], 
+   "codepoint": "U+F678"
+  }, 
+  "U+F679": {
+   "classes": [], 
+   "codepoint": "U+F679"
+  }, 
+  "U+F67A": {
+   "classes": [], 
+   "codepoint": "U+F67A"
+  }, 
+  "U+F67B": {
+   "classes": [], 
+   "codepoint": "U+F67B"
+  }, 
+  "U+F67C": {
+   "classes": [], 
+   "codepoint": "U+F67C"
+  }, 
+  "U+F67D": {
+   "classes": [], 
+   "codepoint": "U+F67D"
+  }, 
+  "U+F67E": {
+   "classes": [], 
+   "codepoint": "U+F67E"
+  }, 
+  "U+F67F": {
+   "classes": [], 
+   "codepoint": "U+F67F"
+  }, 
+  "U+F680": {
+   "classes": [], 
+   "codepoint": "U+F680"
+  }, 
+  "U+F681": {
+   "classes": [], 
+   "codepoint": "U+F681"
+  }, 
+  "U+F682": {
+   "classes": [], 
+   "codepoint": "U+F682"
+  }, 
+  "U+F683": {
+   "classes": [], 
+   "codepoint": "U+F683"
+  }, 
+  "U+F684": {
+   "classes": [], 
+   "codepoint": "U+F684"
+  }, 
+  "U+F685": {
+   "classes": [], 
+   "codepoint": "U+F685"
+  }, 
+  "U+F686": {
+   "classes": [], 
+   "codepoint": "U+F686"
+  }, 
+  "U+F687": {
+   "classes": [], 
+   "codepoint": "U+F687"
+  }, 
+  "U+F688": {
+   "classes": [], 
+   "codepoint": "U+F688"
+  }, 
+  "U+F689": {
+   "classes": [], 
+   "codepoint": "U+F689"
+  }, 
+  "U+F68A": {
+   "classes": [], 
+   "codepoint": "U+F68A"
+  }, 
+  "U+F68C": {
+   "classes": [], 
+   "codepoint": "U+F68C"
+  }, 
+  "U+F68D": {
+   "classes": [], 
+   "codepoint": "U+F68D"
+  }, 
+  "U+F68E": {
+   "classes": [], 
+   "codepoint": "U+F68E"
+  }, 
+  "U+F690": {
+   "classes": [], 
+   "codepoint": "U+F690"
+  }, 
+  "U+F691": {
+   "classes": [], 
+   "codepoint": "U+F691"
+  }, 
+  "U+F692": {
+   "classes": [], 
+   "codepoint": "U+F692"
+  }, 
+  "U+F693": {
+   "classes": [], 
+   "codepoint": "U+F693"
+  }, 
+  "U+F694": {
+   "classes": [], 
+   "codepoint": "U+F694"
+  }, 
+  "U+F695": {
+   "classes": [], 
+   "codepoint": "U+F695"
+  }, 
+  "U+F696": {
+   "classes": [], 
+   "codepoint": "U+F696"
+  }, 
+  "U+F697": {
+   "classes": [], 
+   "codepoint": "U+F697"
+  }, 
+  "U+F698": {
+   "classes": [], 
+   "codepoint": "U+F698"
+  }, 
+  "U+F699": {
+   "classes": [], 
+   "codepoint": "U+F699"
+  }, 
+  "U+F69A": {
+   "classes": [], 
+   "codepoint": "U+F69A"
+  }, 
+  "U+F69B": {
+   "classes": [], 
+   "codepoint": "U+F69B"
+  }, 
+  "U+F69C": {
+   "classes": [], 
+   "codepoint": "U+F69C"
+  }, 
+  "U+F69D": {
+   "classes": [], 
+   "codepoint": "U+F69D"
+  }, 
+  "U+F69E": {
+   "classes": [], 
+   "codepoint": "U+F69E"
+  }, 
+  "U+F69F": {
+   "classes": [], 
+   "codepoint": "U+F69F"
+  }, 
+  "U+F6A0": {
+   "classes": [], 
+   "codepoint": "U+F6A0"
+  }, 
+  "U+F6A1": {
+   "classes": [], 
+   "codepoint": "U+F6A1"
+  }, 
+  "U+F6A2": {
+   "classes": [], 
+   "codepoint": "U+F6A2"
+  }, 
+  "U+F6A3": {
+   "classes": [], 
+   "codepoint": "U+F6A3"
+  }, 
+  "U+F6A4": {
+   "classes": [], 
+   "codepoint": "U+F6A4"
+  }, 
+  "U+F6A5": {
+   "classes": [], 
+   "codepoint": "U+F6A5"
+  }, 
+  "U+F6A6": {
+   "classes": [], 
+   "codepoint": "U+F6A6"
+  }, 
+  "U+F6A7": {
+   "classes": [], 
+   "codepoint": "U+F6A7"
+  }, 
+  "U+F6A8": {
+   "classes": [], 
+   "codepoint": "U+F6A8"
+  }, 
+  "U+F6A9": {
+   "classes": [], 
+   "codepoint": "U+F6A9"
+  }, 
+  "U+F6AA": {
+   "classes": [], 
+   "codepoint": "U+F6AA"
+  }, 
+  "U+F6AB": {
+   "classes": [], 
+   "codepoint": "U+F6AB"
+  }, 
+  "U+F6AC": {
+   "classes": [], 
+   "codepoint": "U+F6AC"
+  }, 
+  "U+F6AD": {
+   "classes": [], 
+   "codepoint": "U+F6AD"
+  }, 
+  "U+F6AE": {
+   "classes": [], 
+   "codepoint": "U+F6AE"
+  }, 
+  "U+F6AF": {
+   "classes": [], 
+   "codepoint": "U+F6AF"
+  }, 
+  "U+F6B0": {
+   "classes": [], 
+   "codepoint": "U+F6B0"
+  }, 
+  "U+F700": {
+   "classes": [], 
+   "codepoint": "U+F700"
+  }, 
+  "U+F701": {
+   "classes": [], 
+   "codepoint": "U+F701"
+  }, 
+  "U+F702": {
+   "classes": [], 
+   "codepoint": "U+F702"
+  }, 
+  "U+F703": {
+   "classes": [], 
+   "codepoint": "U+F703"
+  }, 
+  "U+F704": {
+   "classes": [], 
+   "codepoint": "U+F704"
+  }, 
+  "U+F705": {
+   "classes": [], 
+   "codepoint": "U+F705"
+  }, 
+  "U+F706": {
+   "classes": [], 
+   "codepoint": "U+F706"
+  }, 
+  "U+F707": {
+   "classes": [], 
+   "codepoint": "U+F707"
+  }, 
+  "U+F710": {
+   "classes": [], 
+   "codepoint": "U+F710"
+  }, 
+  "U+F714": {
+   "classes": [], 
+   "codepoint": "U+F714"
+  }, 
+  "U+F715": {
+   "classes": [], 
+   "codepoint": "U+F715"
+  }, 
+  "U+F716": {
+   "classes": [], 
+   "codepoint": "U+F716"
+  }, 
+  "U+F717": {
+   "classes": [], 
+   "codepoint": "U+F717"
+  }, 
+  "U+F718": {
+   "classes": [], 
+   "codepoint": "U+F718"
+  }, 
+  "U+F719": {
+   "classes": [], 
+   "codepoint": "U+F719"
+  }, 
+  "U+F720": {
+   "classes": [], 
+   "codepoint": "U+F720"
+  }, 
+  "U+F721": {
+   "classes": [], 
+   "codepoint": "U+F721"
+  }, 
+  "U+F722": {
+   "classes": [], 
+   "codepoint": "U+F722"
+  }, 
+  "U+F7C2": {
+   "classes": [], 
+   "codepoint": "U+F7C2"
+  }, 
+  "U+F7C3": {
+   "classes": [], 
+   "codepoint": "U+F7C3"
+  }, 
+  "U+F7E0": {
+   "classes": [], 
+   "codepoint": "U+F7E0"
+  }, 
+  "U+F7E1": {
+   "classes": [], 
+   "codepoint": "U+F7E1"
+  }, 
+  "U+F7E2": {
+   "classes": [], 
+   "codepoint": "U+F7E2"
+  }, 
+  "U+F7E3": {
+   "classes": [], 
+   "codepoint": "U+F7E3"
+  }, 
+  "U+F7E4": {
+   "classes": [], 
+   "codepoint": "U+F7E4"
+  }, 
+  "U+F7E5": {
+   "classes": [], 
+   "codepoint": "U+F7E5"
+  }, 
+  "U+F7E6": {
+   "classes": [], 
+   "codepoint": "U+F7E6"
+  }, 
+  "U+F7E7": {
+   "classes": [], 
+   "codepoint": "U+F7E7"
+  }, 
+  "U+F7E8": {
+   "classes": [], 
+   "codepoint": "U+F7E8"
+  }, 
+  "U+F7E9": {
+   "classes": [], 
+   "codepoint": "U+F7E9"
+  }, 
+  "U+F7EA": {
+   "classes": [], 
+   "codepoint": "U+F7EA"
+  }, 
+  "U+F7EB": {
+   "classes": [], 
+   "codepoint": "U+F7EB"
+  }, 
+  "U+F7EC": {
+   "classes": [], 
+   "codepoint": "U+F7EC"
+  }, 
+  "U+F7ED": {
+   "classes": [], 
+   "codepoint": "U+F7ED"
+  }, 
+  "U+F7EE": {
+   "classes": [], 
+   "codepoint": "U+F7EE"
+  }, 
+  "accdnPushAlt": {
+   "classes": [], 
+   "codepoint": "U+F45B"
+  }, 
+  "accidentalDoubleFlatJoinedStems": {
+   "classes": [], 
+   "codepoint": "U+F4A1"
+  }, 
+  "accidentalDoubleFlatParens": {
+   "classes": [], 
+   "codepoint": "U+F5D9"
+  }, 
+  "accidentalDoubleSharpParens": {
+   "classes": [], 
+   "codepoint": "U+F5D8"
+  }, 
+  "accidentalFlatJohnstonDown": {
+   "classes": [], 
+   "codepoint": "U+F5DF"
+  }, 
+  "accidentalFlatJohnstonEl": {
+   "classes": [], 
+   "codepoint": "U+F5DD"
+  }, 
+  "accidentalFlatJohnstonElDown": {
+   "classes": [], 
+   "codepoint": "U+F5EB"
+  }, 
+  "accidentalFlatJohnstonUp": {
+   "classes": [], 
+   "codepoint": "U+F5DE"
+  }, 
+  "accidentalFlatJohnstonUpEl": {
+   "classes": [], 
+   "codepoint": "U+F5EA"
+  }, 
+  "accidentalFlatParens": {
+   "classes": [], 
+   "codepoint": "U+F5D5"
+  }, 
+  "accidentalFlatSmall": {
+   "classes": [], 
+   "codepoint": "U+F713"
+  }, 
+  "accidentalJohnstonDownEl": {
+   "classes": [], 
+   "codepoint": "U+F5E5"
+  }, 
+  "accidentalJohnstonSevenDown": {
+   "classes": [], 
+   "codepoint": "U+F5E3"
+  }, 
+  "accidentalJohnstonSevenFlat": {
+   "classes": [], 
+   "codepoint": "U+F5E1"
+  }, 
+  "accidentalJohnstonSevenFlatDown": {
+   "classes": [], 
+   "codepoint": "U+F5ED"
+  }, 
+  "accidentalJohnstonSevenFlatUp": {
+   "classes": [], 
+   "codepoint": "U+F5EC"
+  }, 
+  "accidentalJohnstonSevenSharp": {
+   "classes": [], 
+   "codepoint": "U+F5E0"
+  }, 
+  "accidentalJohnstonSevenSharpDown": {
+   "classes": [], 
+   "codepoint": "U+F5E9"
+  }, 
+  "accidentalJohnstonSevenSharpUp": {
+   "classes": [], 
+   "codepoint": "U+F5E8"
+  }, 
+  "accidentalJohnstonSevenUp": {
+   "classes": [], 
+   "codepoint": "U+F5E2"
+  }, 
+  "accidentalJohnstonUpEl": {
+   "classes": [], 
+   "codepoint": "U+F5E4"
+  }, 
+  "accidentalNaturalParens": {
+   "classes": [], 
+   "codepoint": "U+F5D6"
+  }, 
+  "accidentalNaturalSmall": {
+   "classes": [], 
+   "codepoint": "U+F712"
+  }, 
+  "accidentalSharpJohnstonDown": {
+   "classes": [], 
+   "codepoint": "U+F5DC"
+  }, 
+  "accidentalSharpJohnstonDownEl": {
+   "classes": [], 
+   "codepoint": "U+F5E7"
+  }, 
+  "accidentalSharpJohnstonEl": {
+   "classes": [], 
+   "codepoint": "U+F5DA"
+  }, 
+  "accidentalSharpJohnstonUp": {
+   "classes": [], 
+   "codepoint": "U+F5DB"
+  }, 
+  "accidentalSharpJohnstonUpEl": {
+   "classes": [], 
+   "codepoint": "U+F5E6"
+  }, 
+  "accidentalSharpParens": {
+   "classes": [], 
+   "codepoint": "U+F5D7"
+  }, 
+  "accidentalSharpSmall": {
+   "classes": [], 
+   "codepoint": "U+F711"
+  }, 
+  "accidentalTripleFlatJoinedStems": {
+   "classes": [], 
+   "codepoint": "U+F4A2"
+  }, 
+  "analyticsHauptrhythmusR": {
+   "classes": [], 
+   "codepoint": "U+F4B9"
+  }, 
+  "braceFlat": {
+   "classes": [], 
+   "codepoint": "U+F403"
+  }, 
+  "braceLarge": {
+   "classes": [], 
+   "codepoint": "U+F401"
+  }, 
+  "braceLarger": {
+   "classes": [], 
+   "codepoint": "U+F402"
+  }, 
+  "braceSmall": {
+   "classes": [], 
+   "codepoint": "U+F400"
+  }, 
+  "cClefFrench": {
+   "classes": [], 
+   "codepoint": "U+F408"
+  }, 
+  "cClefSmall": {
+   "classes": [], 
+   "codepoint": "U+F473"
+  }, 
+  "codaJapanese": {
+   "classes": [], 
+   "codepoint": "U+F405"
+  }, 
+  "doubleTongueAboveNoSlur": {
+   "classes": [], 
+   "codepoint": "U+F42D"
+  }, 
+  "doubleTongueBelowNoSlur": {
+   "classes": [], 
+   "codepoint": "U+F42E"
+  }, 
+  "fClef19thCentury": {
+   "classes": [], 
+   "codepoint": "U+F407"
+  }, 
+  "fClef5Below": {
+   "classes": [], 
+   "codepoint": "U+F532"
+  }, 
+  "fClefFrench": {
+   "classes": [], 
+   "codepoint": "U+F406"
+  }, 
+  "fClefSmall": {
+   "classes": [], 
+   "codepoint": "U+F474"
+  }, 
+  "flag1024thDownStraight": {
+   "classes": [], 
+   "codepoint": "U+F426"
+  }, 
+  "flag1024thUpStraight": {
+   "classes": [], 
+   "codepoint": "U+F424"
+  }, 
+  "flag128thDownStraight": {
+   "classes": [], 
+   "codepoint": "U+F41D"
+  }, 
+  "flag128thUpStraight": {
+   "classes": [], 
+   "codepoint": "U+F41B"
+  }, 
+  "flag16thDownStraight": {
+   "classes": [], 
+   "codepoint": "U+F414"
+  }, 
+  "flag16thUpStraight": {
+   "classes": [], 
+   "codepoint": "U+F412"
+  }, 
+  "flag256thDownStraight": {
+   "classes": [], 
+   "codepoint": "U+F420"
+  }, 
+  "flag256thUpStraight": {
+   "classes": [], 
+   "codepoint": "U+F41E"
+  }, 
+  "flag32ndDownStraight": {
+   "classes": [], 
+   "codepoint": "U+F417"
+  }, 
+  "flag32ndUpStraight": {
+   "classes": [], 
+   "codepoint": "U+F415"
+  }, 
+  "flag512thDownStraight": {
+   "classes": [], 
+   "codepoint": "U+F423"
+  }, 
+  "flag512thUpStraight": {
+   "classes": [], 
+   "codepoint": "U+F421"
+  }, 
+  "flag64thDownStraight": {
+   "classes": [], 
+   "codepoint": "U+F41A"
+  }, 
+  "flag64thUpStraight": {
+   "classes": [], 
+   "codepoint": "U+F418"
+  }, 
+  "flag8thDownStraight": {
+   "classes": [], 
+   "codepoint": "U+F411"
+  }, 
+  "flag8thUpStraight": {
+   "classes": [], 
+   "codepoint": "U+F40F"
+  }, 
+  "gClef0Below": {
+   "classes": [], 
+   "codepoint": "U+F533"
+  }, 
+  "gClef10Below": {
+   "classes": [], 
+   "codepoint": "U+F534"
+  }, 
+  "gClef11Below": {
+   "classes": [], 
+   "codepoint": "U+F535"
+  }, 
+  "gClef12Below": {
+   "classes": [], 
+   "codepoint": "U+F536"
+  }, 
+  "gClef13Below": {
+   "classes": [], 
+   "codepoint": "U+F537"
+  }, 
+  "gClef14Below": {
+   "classes": [], 
+   "codepoint": "U+F538"
+  }, 
+  "gClef15Below": {
+   "classes": [], 
+   "codepoint": "U+F539"
+  }, 
+  "gClef16Below": {
+   "classes": [], 
+   "codepoint": "U+F53A"
+  }, 
+  "gClef17Below": {
+   "classes": [], 
+   "codepoint": "U+F53B"
+  }, 
+  "gClef2Above": {
+   "classes": [], 
+   "codepoint": "U+F53C"
+  }, 
+  "gClef2Below": {
+   "classes": [], 
+   "codepoint": "U+F53D"
+  }, 
+  "gClef3Above": {
+   "classes": [], 
+   "codepoint": "U+F53E"
+  }, 
+  "gClef3Below": {
+   "classes": [], 
+   "codepoint": "U+F53F"
+  }, 
+  "gClef4Above": {
+   "classes": [], 
+   "codepoint": "U+F540"
+  }, 
+  "gClef4Below": {
+   "classes": [], 
+   "codepoint": "U+F541"
+  }, 
+  "gClef5Above": {
+   "classes": [], 
+   "codepoint": "U+F542"
+  }, 
+  "gClef5Below": {
+   "classes": [], 
+   "codepoint": "U+F543"
+  }, 
+  "gClef6Above": {
+   "classes": [], 
+   "codepoint": "U+F544"
+  }, 
+  "gClef6Below": {
+   "classes": [], 
+   "codepoint": "U+F545"
+  }, 
+  "gClef7Above": {
+   "classes": [], 
+   "codepoint": "U+F546"
+  }, 
+  "gClef7Below": {
+   "classes": [], 
+   "codepoint": "U+F547"
+  }, 
+  "gClef8Above": {
+   "classes": [], 
+   "codepoint": "U+F548"
+  }, 
+  "gClef8Below": {
+   "classes": [], 
+   "codepoint": "U+F549"
+  }, 
+  "gClef9Above": {
+   "classes": [], 
+   "codepoint": "U+F54A"
+  }, 
+  "gClef9Below": {
+   "classes": [], 
+   "codepoint": "U+F54B"
+  }, 
+  "gClefFlat10Below": {
+   "classes": [], 
+   "codepoint": "U+F54C"
+  }, 
+  "gClefFlat11Below": {
+   "classes": [], 
+   "codepoint": "U+F54D"
+  }, 
+  "gClefFlat13Below": {
+   "classes": [], 
+   "codepoint": "U+F54E"
+  }, 
+  "gClefFlat14Below": {
+   "classes": [], 
+   "codepoint": "U+F54F"
+  }, 
+  "gClefFlat15Below": {
+   "classes": [], 
+   "codepoint": "U+F550"
+  }, 
+  "gClefFlat16Below": {
+   "classes": [], 
+   "codepoint": "U+F551"
+  }, 
+  "gClefFlat1Below": {
+   "classes": [], 
+   "codepoint": "U+F552"
+  }, 
+  "gClefFlat2Above": {
+   "classes": [], 
+   "codepoint": "U+F553"
+  }, 
+  "gClefFlat2Below": {
+   "classes": [], 
+   "codepoint": "U+F554"
+  }, 
+  "gClefFlat3Above": {
+   "classes": [], 
+   "codepoint": "U+F555"
+  }, 
+  "gClefFlat3Below": {
+   "classes": [], 
+   "codepoint": "U+F556"
+  }, 
+  "gClefFlat4Below": {
+   "classes": [], 
+   "codepoint": "U+F557"
+  }, 
+  "gClefFlat5Above": {
+   "classes": [], 
+   "codepoint": "U+F558"
+  }, 
+  "gClefFlat6Above": {
+   "classes": [], 
+   "codepoint": "U+F559"
+  }, 
+  "gClefFlat6Below": {
+   "classes": [], 
+   "codepoint": "U+F55A"
+  }, 
+  "gClefFlat7Above": {
+   "classes": [], 
+   "codepoint": "U+F55B"
+  }, 
+  "gClefFlat7Below": {
+   "classes": [], 
+   "codepoint": "U+F55C"
+  }, 
+  "gClefFlat8Above": {
+   "classes": [], 
+   "codepoint": "U+F55D"
+  }, 
+  "gClefFlat9Above": {
+   "classes": [], 
+   "codepoint": "U+F55E"
+  }, 
+  "gClefFlat9Below": {
+   "classes": [], 
+   "codepoint": "U+F55F"
+  }, 
+  "gClefNat2Below": {
+   "classes": [], 
+   "codepoint": "U+F560"
+  }, 
+  "gClefNatural10Below": {
+   "classes": [], 
+   "codepoint": "U+F561"
+  }, 
+  "gClefNatural13Below": {
+   "classes": [], 
+   "codepoint": "U+F562"
+  }, 
+  "gClefNatural17Below": {
+   "classes": [], 
+   "codepoint": "U+F563"
+  }, 
+  "gClefNatural2Above": {
+   "classes": [], 
+   "codepoint": "U+F564"
+  }, 
+  "gClefNatural3Above": {
+   "classes": [], 
+   "codepoint": "U+F565"
+  }, 
+  "gClefNatural3Below": {
+   "classes": [], 
+   "codepoint": "U+F566"
+  }, 
+  "gClefNatural6Above": {
+   "classes": [], 
+   "codepoint": "U+F567"
+  }, 
+  "gClefNatural6Below": {
+   "classes": [], 
+   "codepoint": "U+F568"
+  }, 
+  "gClefNatural7Above": {
+   "classes": [], 
+   "codepoint": "U+F569"
+  }, 
+  "gClefNatural9Above": {
+   "classes": [], 
+   "codepoint": "U+F56A"
+  }, 
+  "gClefNatural9Below": {
+   "classes": [], 
+   "codepoint": "U+F56B"
+  }, 
+  "gClefSharp12Below": {
+   "classes": [], 
+   "codepoint": "U+F56C"
+  }, 
+  "gClefSharp1Above": {
+   "classes": [], 
+   "codepoint": "U+F56D"
+  }, 
+  "gClefSharp4Above": {
+   "classes": [], 
+   "codepoint": "U+F56E"
+  }, 
+  "gClefSharp5Below": {
+   "classes": [], 
+   "codepoint": "U+F56F"
+  }, 
+  "gClefSmall": {
+   "classes": [], 
+   "codepoint": "U+F472"
+  }, 
+  "guitarGolpeFlamenco": {
+   "classes": [], 
+   "codepoint": "U+F4B8"
+  }, 
+  "harpMetalRodAlt": {
+   "classes": [], 
+   "codepoint": "U+F436"
+  }, 
+  "harpTuningKeyAlt": {
+   "classes": [], 
+   "codepoint": "U+F437"
+  }, 
+  "keyboardPedalPedNoDot": {
+   "classes": [], 
+   "codepoint": "U+F434"
+  }, 
+  "keyboardPedalSostNoDot": {
+   "classes": [], 
+   "codepoint": "U+F435"
+  }, 
+  "mensuralProportion4Old": {
+   "classes": [], 
+   "codepoint": "U+F43D"
+  }, 
+  "noteheadBlackParens": {
+   "classes": [], 
+   "codepoint": "U+F5D1"
+  }, 
+  "noteheadDoubleWholeAlt": {
+   "classes": [], 
+   "codepoint": "U+F40E"
+  }, 
+  "noteheadDoubleWholeParens": {
+   "classes": [], 
+   "codepoint": "U+F5D4"
+  }, 
+  "noteheadHalfParens": {
+   "classes": [], 
+   "codepoint": "U+F5D2"
+  }, 
+  "noteheadWholeParens": {
+   "classes": [], 
+   "codepoint": "U+F5D3"
+  }, 
+  "ornamentTrillFlatAbove": {
+   "classes": [], 
+   "codepoint": "U+F5B2"
+  }, 
+  "ornamentTrillNaturalAbove": {
+   "classes": [], 
+   "codepoint": "U+F5B3"
+  }, 
+  "ornamentTrillSharpAbove": {
+   "classes": [], 
+   "codepoint": "U+F5B4"
+  }, 
+  "ornamentTurnFlatAbove": {
+   "classes": [], 
+   "codepoint": "U+F5B5"
+  }, 
+  "ornamentTurnFlatAboveSharpBelow": {
+   "classes": [], 
+   "codepoint": "U+F5B6"
+  }, 
+  "ornamentTurnFlatBelow": {
+   "classes": [], 
+   "codepoint": "U+F5B7"
+  }, 
+  "ornamentTurnNaturalAbove": {
+   "classes": [], 
+   "codepoint": "U+F5B8"
+  }, 
+  "ornamentTurnNaturalBelow": {
+   "classes": [], 
+   "codepoint": "U+F5B9"
+  }, 
+  "ornamentTurnSharpAbove": {
+   "classes": [], 
+   "codepoint": "U+F5BA"
+  }, 
+  "ornamentTurnSharpAboveFlatBelow": {
+   "classes": [], 
+   "codepoint": "U+F5BB"
+  }, 
+  "ornamentTurnSharpBelow": {
+   "classes": [], 
+   "codepoint": "U+F5BC"
+  }, 
+  "pictBassDrumPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4AF"
+  }, 
+  "pictBongosPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4B0"
+  }, 
+  "pictCastanetsSmithBrindle": {
+   "classes": [], 
+   "codepoint": "U+F439"
+  }, 
+  "pictCongaPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4B1"
+  }, 
+  "pictCowBellBerio": {
+   "classes": [], 
+   "codepoint": "U+F43B"
+  }, 
+  "pictFlexatonePeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4B6"
+  }, 
+  "pictGlspPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4AA"
+  }, 
+  "pictGuiroPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4B5"
+  }, 
+  "pictGuiroSevsay": {
+   "classes": [], 
+   "codepoint": "U+F4B4"
+  }, 
+  "pictLithophonePeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4A7"
+  }, 
+  "pictLotusFlutePeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4AC"
+  }, 
+  "pictMarPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4AB"
+  }, 
+  "pictMaracaSmithBrindle": {
+   "classes": [], 
+   "codepoint": "U+F43C"
+  }, 
+  "pictMusicalSawPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4B7"
+  }, 
+  "pictSleighBellSmithBrindle": {
+   "classes": [], 
+   "codepoint": "U+F43A"
+  }, 
+  "pictTambourineStockhausen": {
+   "classes": [], 
+   "codepoint": "U+F438"
+  }, 
+  "pictTimbalesPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4B3"
+  }, 
+  "pictTimpaniPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4AE"
+  }, 
+  "pictTomTomChinesePeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4AD"
+  }, 
+  "pictTomTomPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4B2"
+  }, 
+  "pictTubaphonePeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4A8"
+  }, 
+  "pictVibMotorOffPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4A6"
+  }, 
+  "pictVibPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4A5"
+  }, 
+  "pictXylBassPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4A3"
+  }, 
+  "pictXylPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4A9"
+  }, 
+  "pictXylTenorPeinkofer": {
+   "classes": [], 
+   "codepoint": "U+F4A4"
+  }, 
+  "pluckedSnapPizzicatoAboveGerman": {
+   "classes": [], 
+   "codepoint": "U+F433"
+  }, 
+  "pluckedSnapPizzicatoBelowGerman": {
+   "classes": [], 
+   "codepoint": "U+F432"
+  }, 
+  "repeatRightLeftThick": {
+   "classes": [], 
+   "codepoint": "U+F45C"
+  }, 
+  "segnoJapanese": {
+   "classes": [], 
+   "codepoint": "U+F404"
+  }, 
+  "stringsChangeBowDirectionImposed": {
+   "classes": [], 
+   "codepoint": "U+F43E"
+  }, 
+  "stringsChangeBowDirectionLiga": {
+   "classes": [], 
+   "codepoint": "U+F431"
+  }, 
+  "timeSig0Large": {
+   "classes": [], 
+   "codepoint": "U+F440"
+  }, 
+  "timeSig1Large": {
+   "classes": [], 
+   "codepoint": "U+F441"
+  }, 
+  "timeSig2Large": {
+   "classes": [], 
+   "codepoint": "U+F442"
+  }, 
+  "timeSig3Large": {
+   "classes": [], 
+   "codepoint": "U+F443"
+  }, 
+  "timeSig4Large": {
+   "classes": [], 
+   "codepoint": "U+F444"
+  }, 
+  "timeSig5Large": {
+   "classes": [], 
+   "codepoint": "U+F445"
+  }, 
+  "timeSig6Large": {
+   "classes": [], 
+   "codepoint": "U+F446"
+  }, 
+  "timeSig7Large": {
+   "classes": [], 
+   "codepoint": "U+F447"
+  }, 
+  "timeSig8Large": {
+   "classes": [], 
+   "codepoint": "U+F448"
+  }, 
+  "timeSig9Large": {
+   "classes": [], 
+   "codepoint": "U+F449"
+  }, 
+  "timeSigCommonLarge": {
+   "classes": [], 
+   "codepoint": "U+F44A"
+  }, 
+  "timeSigCutCommonLarge": {
+   "classes": [], 
+   "codepoint": "U+F44B"
+  }, 
+  "timeSigPlusLarge": {
+   "classes": [], 
+   "codepoint": "U+F44C"
+  }, 
+  "tripleTongueAboveNoSlur": {
+   "classes": [], 
+   "codepoint": "U+F42F"
+  }, 
+  "tripleTongueBelowNoSlur": {
+   "classes": [], 
+   "codepoint": "U+F430"
+  }, 
+  "unpitchedPercussionClef1Alt": {
+   "classes": [], 
+   "codepoint": "U+F409"
+  }
+ }
+}

--- a/tests/musxdomtests.cpp
+++ b/tests/musxdomtests.cpp
@@ -55,6 +55,7 @@ int main(int argc, char **argv) {
 
     ::testing::InitGoogleTest(&argc, argv);
     ::testing::AddGlobalTestEnvironment(new TestEnvironment);
+    ::musx::util::TestConfiguration::setTestDataPath(std::filesystem::current_path());
     int result = RUN_ALL_TESTS();
     const auto endMessages = musxtest::g_endMessages.str();
     if (!endMessages.empty()) {


### PR DESCRIPTION
This PR add Finale Maestro metadata and a mechanism to find it so that we have consistent tests even on GitHub CI build instances without the need to have SMuFL fonts installed.