### PR TITLE
fix error in interpreting enigmaxml

### DIFF
--- a/src/musx/dom/Options.h
+++ b/src/musx/dom/Options.h
@@ -709,7 +709,7 @@ public:
         : OptionsBase(document, partId, shareMode) {}
 
     bool showRepeatsForParts{};             ///< "Show Repeats for Parts"
-    bool showSoundingOctaveInConcertPitch{}; ///< Inverse of "Keep Octave Transposition in Concert Pitch" (xml node is `<retainOctaveTransInConcertPitch>`)
+    bool keepWrittenOctaveInConcertPitch{}; ///< "Keep Octave Transposition in Concert Pitch" (xml node is `<retainOctaveTransInConcertPitch>`)
     bool showActiveLayerOnly{};             ///< "Show Active Layer Only" (xml node is `<showCurrentLayerOnly>`)
     bool consolidateRestsAcrossLayers{};    ///< "Consolidate Rests Across Layers" (xml node is `<combineRestsAcrossLayers>`)
     Evpu shapeDesignerDashLength{};         ///< Shape Designer dash length in @ref Evpu. (xml node is `<sdDashOn>`)

--- a/src/musx/factory/FieldPopulatorsOptions.cpp
+++ b/src/musx/factory/FieldPopulatorsOptions.cpp
@@ -627,7 +627,7 @@ MUSX_XML_ELEMENT_ARRAY(LyricOptions, {
 
 MUSX_XML_ELEMENT_ARRAY(MiscOptions, {
     {"showRepeatsForParts", [](const XmlElementPtr& e, const std::shared_ptr<MiscOptions>& i) { i->showRepeatsForParts = populateBoolean(e, i); }},
-    {"retainOctaveTransInConcertPitch", [](const XmlElementPtr& e, const std::shared_ptr<MiscOptions>& i) { i->showSoundingOctaveInConcertPitch = populateBoolean(e, i); }},
+    {"retainOctaveTransInConcertPitch", [](const XmlElementPtr& e, const std::shared_ptr<MiscOptions>& i) { i->keepWrittenOctaveInConcertPitch = populateBoolean(e, i); }},
     {"showCurrentLayerOnly", [](const XmlElementPtr& e, const std::shared_ptr<MiscOptions>& i) { i->showActiveLayerOnly = populateBoolean(e, i); }},
     {"combineRestsAcrossLayers", [](const XmlElementPtr& e, const std::shared_ptr<MiscOptions>& i) { i->consolidateRestsAcrossLayers = populateBoolean(e, i); }},
     {"sdDashOn", [](const XmlElementPtr& e, const std::shared_ptr<MiscOptions>& i) {i->shapeDesignerDashLength = e->getTextAs<Evpu>();}},

--- a/tests/options/misc_options.cpp
+++ b/tests/options/misc_options.cpp
@@ -52,7 +52,7 @@ TEST(MiscOptionsTest, PropertiesTest)
 
     // Test all properties of MiscOptions
     EXPECT_TRUE(miscOptions->showRepeatsForParts);
-    EXPECT_TRUE(miscOptions->showSoundingOctaveInConcertPitch);
+    EXPECT_TRUE(miscOptions->keepWrittenOctaveInConcertPitch);
     EXPECT_TRUE(miscOptions->showActiveLayerOnly);
     EXPECT_TRUE(miscOptions->consolidateRestsAcrossLayers);
     EXPECT_EQ(miscOptions->shapeDesignerDashLength, 18);


### PR DESCRIPTION
Docs and variable name were incorrect for `MiscOptions::keepWrittenOctaveInConcertPitch`.