### PR TITLE
Refinements

### DIFF
--- a/src/musx/dom/SmartShape.h
+++ b/src/musx/dom/SmartShape.h
@@ -134,8 +134,9 @@ public:
     /// @note This function does not check for an actual assignment. It simply returns an entry the endpoint would be associated
     /// with if it were assigned. Use #calcIsAssigned to determine if the endpoint is actually assigned.
     /// @param forPartId The linked part or score for which to create the @ref EntryInfoPtr.
+    /// @param findExact If true, only find an entry that matches to within 1 evpu. Otherwise find the closest entry in the measure.
     /// @return The entry if the endpoint is entry-attached or measure-attached within 1 Edu of an entry. Null if not.
-    EntryInfoPtr calcAssociatedEntry(Cmper forPartId) const;
+    EntryInfoPtr calcAssociatedEntry(Cmper forPartId, bool findExact = true) const;
 
     /// @brief Gets the measure assignment for this endpoint or null if none.
     MusxInstance<others::SmartShapeMeasureAssign> getMeasureAssignment() const;

--- a/src/musx/dom/Staff.cpp
+++ b/src/musx/dom/Staff.cpp
@@ -814,17 +814,25 @@ MusxInstance<StaffComposite> StaffComposite::createCurrent(const DocumentPtr& do
 // ***** StaffStyle *****
 // **********************
 
-MusxInstanceList<others::StaffStyle> others::StaffStyle::findAllOverlappingStyles(const DocumentPtr& document,
+bool StaffStyle::containsInstrumentChange() const
+{
+    if (masks->notationStyle || masks->defaultClef || masks->showNoteColors || masks->hideKeySigsShowAccis) {
+        return true;
+    }
+    return this->hasInstrumentAssigned();
+}
+
+MusxInstanceList<StaffStyle> StaffStyle::findAllOverlappingStyles(const DocumentPtr& document,
         Cmper partId, StaffCmper staffId, MeasCmper measId, Edu eduPosition)
 {
-    auto staffStyleAssignments = document->getOthers()->getArray<others::StaffStyleAssign>(partId, staffId);
-    std::vector<MusxInstance<others::StaffStyleAssign>> applicableAssignments;
+    auto staffStyleAssignments = document->getOthers()->getArray<StaffStyleAssign>(partId, staffId);
+    std::vector<MusxInstance<StaffStyleAssign>> applicableAssignments;
     std::copy_if(staffStyleAssignments.begin(), staffStyleAssignments.end(), std::back_inserter(applicableAssignments),
-        [measId, eduPosition](const MusxInstance<others::StaffStyleAssign>& range) {
+        [measId, eduPosition](const MusxInstance<StaffStyleAssign>& range) {
             return range->contains(measId, eduPosition);
         });
 
-    MusxInstanceList<others::StaffStyle> result(document, partId);
+    MusxInstanceList<StaffStyle> result(document, partId);
     result.reserve(applicableAssignments.size());
     for (const auto& assign : applicableAssignments) {
         if (auto style = assign->getStaffStyle()) {

--- a/src/musx/dom/Staff.h
+++ b/src/musx/dom/Staff.h
@@ -513,6 +513,30 @@ public:
     std::shared_ptr<Masks> masks;       ///< override masks: guaranteed to exist by #integrityCheck, which is called by the factory
                                         ///< (xml node is `<mask>`)
 
+    /// @brief Determines whether this staff style represents or includes an instrument change.
+    ///
+    /// Beginning with Finale 2012, a dedicated group of staff style masks was reserved exclusively
+    /// for instrument changes. These masks always appear together and never occur in staff styles
+    /// used for other purposes. The masks are `notationStyle`, `defaultClef`, `showNoteColors`, and
+    /// `hideKeySigsShowAccis`. If the #instUuid is a real instrument (rather than Blank or Unknown),
+    /// that also indicates an instrument change.
+    ///
+    /// Earlier Finale files may not follow this convention. The could potentially contain
+    /// staff styles where one or more instrument-change masks is set independently. To handle both
+    /// modern and legacy cases, this function tests whether *any* of the instrument-change masks is
+    /// active in the current staff style.
+    ///
+    /// In addition, there is a set of masks that may be included in an instrument change staff style
+    /// or also may be included in a regular staff style. These are `staffType`, `transposition`, `fullName`,
+    /// and `abrvName`. This function ignores these optional masks.
+    ///
+    /// @note If the current instance is a @ref StaffComposite, it incorporates all masks in effect at the
+    /// music location for which it was created. For this reason, testing for any instrument-change
+    /// masks (rather than all) remains useful even in modern files.
+    /// @return `true` if one or more instrument-change masks are set in the current his staff style;
+    ///         `false` otherwise.
+    bool containsInstrumentChange() const;
+
     /// @brief Finds a subset from all StaffStyle instances that overlap with the specified
     /// metric position on a given staff in a give linked part or score.
     /// @param document The document to search


### PR DESCRIPTION
- `StaffStyle::containsInstrumentChange` utility func
- Add `findExact` to calcAssociatedEntry
- Skip grace note when calculating nearest entry for beat-attached Smart Shapes