### PR TITLE
Articulation symbol detection

### DIFF
--- a/src/musx/dom/Details.cpp
+++ b/src/musx/dom/Details.cpp
@@ -110,12 +110,7 @@ std::optional<details::ArticulationAssign::SelectedSymbolContext>
 details::ArticulationAssign::calcSelectedSymbolContext(const EntryInfoPtr& entryInfo) const
 {
     SelectedSymbolContext result;
-    if (!entryInfo || !articDef || entryInfo.calcDisplaysAsRest()) {
-        return std::nullopt;
-    }
-
-    const auto entry = entryInfo->getEntry();
-    if (!entry || entry->notes.empty()) {
+    if (!entryInfo) {
         return std::nullopt;
     }
 
@@ -126,15 +121,6 @@ details::ArticulationAssign::calcSelectedSymbolContext(const EntryInfoPtr& entry
 
     result.symbol = result.definition->calcSelectedSymbol(calcPlacementAbove(result.definition, entryInfo));
     return result;
-}
-
-std::optional<details::ArticulationAssign::SymbolInfo>
-details::ArticulationAssign::calcSymbolInfo(const EntryInfoPtr& entryInfo) const
-{
-    if (const auto context = calcSelectedSymbolContext(entryInfo)) {
-        return context->symbol;
-    }
-    return std::nullopt;
 }
 
 std::optional<details::ArticulationAssign::PseudoTieShapeContext>

--- a/src/musx/dom/Details.cpp
+++ b/src/musx/dom/Details.cpp
@@ -82,13 +82,14 @@ bool details::ArticulationAssign::calcPlacementAbove(const MusxInstance<others::
     if (!definition->autoVert) {
         return vertOffset >= 0;
     }
-    const bool stemSideInMultiLayer = definition->isStemSideWhenMultipleLayers
-        && entryInfo.getFrame()->getContext()->calcIsMultiLayer();
 
     using AD = others::ArticulationDef;
     switch (definition->autoVertMode) {
-    case AD::AutoVerticalMode::AboveEntry:
+    case AD::AutoVerticalMode::AboveEntry: {
+        const bool stemSideInMultiLayer = definition->isStemSideWhenMultipleLayers
+            && entryInfo.getFrame()->getContext()->calcIsMultiLayer();
         return stemSideInMultiLayer ? stemUp : true;
+    }
     case AD::AutoVerticalMode::BelowEntry:
         return false;
     case AD::AutoVerticalMode::StemSide:
@@ -119,13 +120,13 @@ VerticalPlacement details::ArticulationAssign::calcVerticalPlacement(
         return vertOffset >= 0 ? VerticalPlacement::Above : VerticalPlacement::Below;
     }
 
-    const bool stemSideInMultiLayer = definition->isStemSideWhenMultipleLayers
-        && entryInfo.getFrame()->getContext()->calcIsMultiLayer();
-
     using AD = others::ArticulationDef;
     switch (definition->autoVertMode) {
-    case AD::AutoVerticalMode::AboveEntry:
+    case AD::AutoVerticalMode::AboveEntry: {
+        const bool stemSideInMultiLayer = definition->isStemSideWhenMultipleLayers
+            && entryInfo.getFrame()->getContext()->calcIsMultiLayer();
         return stemSideInMultiLayer ? VerticalPlacement::Float : VerticalPlacement::Above;
+    }
     case AD::AutoVerticalMode::BelowEntry:
         return VerticalPlacement::Below;
     case AD::AutoVerticalMode::AlwaysNoteheadSide:

--- a/src/musx/dom/Details.cpp
+++ b/src/musx/dom/Details.cpp
@@ -72,13 +72,13 @@ namespace details {
 // ******************************
 
 bool details::ArticulationAssign::calcPlacementAbove(const MusxInstance<others::ArticulationDef>& definition,
-    const EntryInfoPtr& forStartEntry) const
+    const EntryInfoPtr& entryInfo) const
 {
     if (overridePlacement) {
         return aboveEntry;
     }
 
-    const bool stemUp = forStartEntry.calcUpStem();
+    const bool stemUp = entryInfo.calcUpStem();
     if (!definition->autoVert) {
         return vertOffset >= 0;
     }
@@ -92,7 +92,7 @@ bool details::ArticulationAssign::calcPlacementAbove(const MusxInstance<others::
     case AD::AutoVerticalMode::StemSide:
         return stemUp;
     case AD::AutoVerticalMode::AlwaysNoteheadSide:
-        switch (forStartEntry.calcStemDirectionForced()) {
+        switch (entryInfo.calcStemDirectionForced()) {
         case StemDirection::AlwaysUp:
         case StemDirection::AlwaysDown:
             return stemUp;
@@ -106,24 +106,48 @@ bool details::ArticulationAssign::calcPlacementAbove(const MusxInstance<others::
     }
 }
 
-std::optional<details::ArticulationAssign::PseudoTieShapeContext>
-details::ArticulationAssign::calcPseudoTieShapeContext(const EntryInfoPtr& forStartEntry) const
+std::optional<details::ArticulationAssign::SelectedSymbolContext>
+details::ArticulationAssign::calcSelectedSymbolContext(const EntryInfoPtr& entryInfo) const
 {
-    PseudoTieShapeContext result;
-    if (!forStartEntry || !articDef || forStartEntry.calcDisplaysAsRest()) {
+    SelectedSymbolContext result;
+    if (!entryInfo || !articDef || entryInfo.calcDisplaysAsRest()) {
         return std::nullopt;
     }
 
-    const auto entry = forStartEntry->getEntry();
+    const auto entry = entryInfo->getEntry();
     if (!entry || entry->notes.empty()) {
         return std::nullopt;
     }
 
-    const auto doc = getDocument();
-    result.definition = doc->getOthers()->get<others::ArticulationDef>(getRequestedPartId(), articDef);
+    result.definition = getDocument()->getOthers()->get<others::ArticulationDef>(getRequestedPartId(), articDef);
     if (!result.definition) {
         return std::nullopt;
     }
+
+    result.symbol = result.definition->calcSelectedSymbol(calcPlacementAbove(result.definition, entryInfo));
+    return result;
+}
+
+std::optional<details::ArticulationAssign::SymbolInfo>
+details::ArticulationAssign::calcSymbolInfo(const EntryInfoPtr& entryInfo) const
+{
+    if (const auto context = calcSelectedSymbolContext(entryInfo)) {
+        return context->symbol;
+    }
+    return std::nullopt;
+}
+
+std::optional<details::ArticulationAssign::PseudoTieShapeContext>
+details::ArticulationAssign::calcPseudoTieShapeContext(const EntryInfoPtr& forStartEntry) const
+{
+    PseudoTieShapeContext result;
+    const auto selectedSymbolContext = calcSelectedSymbolContext(forStartEntry);
+    if (!selectedSymbolContext) {
+        return std::nullopt;
+    }
+    const auto doc = getDocument();
+    result.definition = selectedSymbolContext->definition;
+    result.selectedSymbol = selectedSymbolContext->symbol;
     const auto def = result.definition;
 
     using AD = others::ArticulationDef;
@@ -133,8 +157,6 @@ details::ArticulationAssign::calcPseudoTieShapeContext(const EntryInfoPtr& forSt
     if (def->autoVert && def->autoVertMode == AD::AutoVerticalMode::AlwaysOnStem) {
         return std::nullopt;
     }
-
-    result.selectedSymbol = def->calcSelectedSymbol(calcPlacementAbove(def, forStartEntry));
     if (!result.selectedSymbol.isShape) {
         return std::nullopt;
     }

--- a/src/musx/dom/Details.cpp
+++ b/src/musx/dom/Details.cpp
@@ -102,11 +102,16 @@ bool details::ArticulationAssign::calcPlacementAbove(const MusxInstance<others::
         case StemDirection::Default:
             return !stemUp;
         }
+        assert(false && "invalid enum value");
+        // defensive break should be unreachable
+        break;
     case AD::AutoVerticalMode::AutoNoteStem:
         return stemUp;
     case AD::AutoVerticalMode::AlwaysOnStem:
         return stemUp;
     }
+    assert(false && "invalid enum value");
+    return stemUp; // defensive fallback should be unreachable
 }
 
 VerticalPlacement details::ArticulationAssign::calcVerticalPlacement(

--- a/src/musx/dom/Details.cpp
+++ b/src/musx/dom/Details.cpp
@@ -120,6 +120,28 @@ details::ArticulationAssign::calcSelectedSymbolContext(const EntryInfoPtr& entry
     }
 
     result.symbol = result.definition->calcSelectedSymbol(calcPlacementAbove(result.definition, entryInfo));
+
+    if (result.definition->autoVert) {
+        using AD = others::ArticulationDef;
+        switch (result.definition->autoVertMode) {
+        case AD::AutoVerticalMode::AboveEntry:
+            result.placement = VerticalPlacement::Above;
+            break;
+        case AD::AutoVerticalMode::BelowEntry:
+            result.placement = VerticalPlacement::Below;
+            break;
+        case AD::AutoVerticalMode::AlwaysNoteheadSide:
+        case AD::AutoVerticalMode::AutoNoteStem:
+            result.placement = VerticalPlacement::Float;
+            break;
+        default:
+            result.placement = VerticalPlacement::NotApplicable;
+            break;
+        }
+    } else {
+        result.placement = vertOffset >= 0 ? VerticalPlacement::Above : VerticalPlacement::Below;
+    }
+
     return result;
 }
 

--- a/src/musx/dom/Details.cpp
+++ b/src/musx/dom/Details.cpp
@@ -71,6 +71,41 @@ namespace details {
 // ***** ArticulationAssign *****
 // ******************************
 
+bool details::ArticulationAssign::calcPlacementAbove(const MusxInstance<others::ArticulationDef>& definition,
+    const EntryInfoPtr& forStartEntry) const
+{
+    if (overridePlacement) {
+        return aboveEntry;
+    }
+
+    const bool stemUp = forStartEntry.calcUpStem();
+    if (!definition->autoVert) {
+        return vertOffset >= 0;
+    }
+
+    using AD = others::ArticulationDef;
+    switch (definition->autoVertMode) {
+    case AD::AutoVerticalMode::AboveEntry:
+        return true;
+    case AD::AutoVerticalMode::BelowEntry:
+        return false;
+    case AD::AutoVerticalMode::StemSide:
+        return stemUp;
+    case AD::AutoVerticalMode::AlwaysNoteheadSide:
+        switch (forStartEntry.calcStemDirectionForced()) {
+        case StemDirection::AlwaysUp:
+        case StemDirection::AlwaysDown:
+            return stemUp;
+        case StemDirection::Default:
+            return !stemUp;
+        }
+    case AD::AutoVerticalMode::AutoNoteStem:
+        return stemUp;
+    case AD::AutoVerticalMode::AlwaysOnStem:
+        return stemUp;
+    }
+}
+
 std::optional<details::ArticulationAssign::PseudoTieShapeContext>
 details::ArticulationAssign::calcPseudoTieShapeContext(const EntryInfoPtr& forStartEntry) const
 {
@@ -99,41 +134,14 @@ details::ArticulationAssign::calcPseudoTieShapeContext(const EntryInfoPtr& forSt
         return std::nullopt;
     }
 
-    const bool stemUp = forStartEntry.calcUpStem();
-    auto calcPlacementAbove = [&]() -> bool {
-        if (overridePlacement) {
-            return aboveEntry;
-        }
-        if (!def->autoVert) {
-            if (def->defVertPos > 0) {
-                return true;
-            }
-            if (def->defVertPos < 0) {
-                return false;
-            }
-            return stemUp;
-        }
-        switch (def->autoVertMode) {
-        case AD::AutoVerticalMode::AboveEntry:
-            return true;
-        case AD::AutoVerticalMode::BelowEntry:
-            return false;
-        default:
-            return stemUp;
-        }
-    };
-    result.placeAbove = calcPlacementAbove();
-    result.usesAlternateSymbol = result.placeAbove ? def->aboveSymbolAlt : def->belowSymbolAlt;
-
-    const bool usesShape = result.usesAlternateSymbol ? def->altIsShape : def->mainIsShape;
-    if (!usesShape) {
+    result.selectedSymbol = def->calcSelectedSymbol(calcPlacementAbove(def, forStartEntry));
+    if (!result.selectedSymbol.isShape) {
         return std::nullopt;
     }
-    const auto shapeId = result.usesAlternateSymbol ? def->altShape : def->mainShape;
-    if (!shapeId) {
+    if (!result.selectedSymbol.shapeId) {
         return std::nullopt;
     }
-    result.info.shape = doc->getOthers()->get<others::ShapeDef>(getRequestedPartId(), shapeId);
+    result.info.shape = doc->getOthers()->get<others::ShapeDef>(getRequestedPartId(), result.selectedSymbol.shapeId);
     if (!result.info.shape) {
         return std::nullopt;
     }
@@ -162,8 +170,7 @@ std::optional<utils::PseudoTieShapeInfo> details::ArticulationAssign::calcIsPseu
         return std::nullopt;
     }
 
-    const auto def = tieShapeContext->definition;
-    const auto offset = (tieShapeContext->usesAlternateSymbol ? def->xOffsetAlt : def->xOffsetMain) + horzOffset;
+    const auto offset = tieShapeContext->selectedSymbol.xOffset + horzOffset;
     const auto endOffset = offset + tieShapeContext->info.calcWidthOffset();
     switch (mode) {
     case utils::PseudoTieMode::LaissezVibrer:

--- a/src/musx/dom/Details.cpp
+++ b/src/musx/dom/Details.cpp
@@ -82,11 +82,13 @@ bool details::ArticulationAssign::calcPlacementAbove(const MusxInstance<others::
     if (!definition->autoVert) {
         return vertOffset >= 0;
     }
+    const bool stemSideInMultiLayer = definition->isStemSideWhenMultipleLayers
+        && entryInfo.getFrame()->getContext()->calcIsMultiLayer();
 
     using AD = others::ArticulationDef;
     switch (definition->autoVertMode) {
     case AD::AutoVerticalMode::AboveEntry:
-        return true;
+        return stemSideInMultiLayer ? stemUp : true;
     case AD::AutoVerticalMode::BelowEntry:
         return false;
     case AD::AutoVerticalMode::StemSide:
@@ -106,6 +108,34 @@ bool details::ArticulationAssign::calcPlacementAbove(const MusxInstance<others::
     }
 }
 
+VerticalPlacement details::ArticulationAssign::calcVerticalPlacement(
+    const MusxInstance<others::ArticulationDef>& definition,
+    const EntryInfoPtr& entryInfo) const
+{
+    if (overridePlacement) {
+        return aboveEntry ? VerticalPlacement::Above : VerticalPlacement::Below;
+    }
+    if (!definition->autoVert) {
+        return vertOffset >= 0 ? VerticalPlacement::Above : VerticalPlacement::Below;
+    }
+
+    const bool stemSideInMultiLayer = definition->isStemSideWhenMultipleLayers
+        && entryInfo.getFrame()->getContext()->calcIsMultiLayer();
+
+    using AD = others::ArticulationDef;
+    switch (definition->autoVertMode) {
+    case AD::AutoVerticalMode::AboveEntry:
+        return stemSideInMultiLayer ? VerticalPlacement::Float : VerticalPlacement::Above;
+    case AD::AutoVerticalMode::BelowEntry:
+        return VerticalPlacement::Below;
+    case AD::AutoVerticalMode::AlwaysNoteheadSide:
+    case AD::AutoVerticalMode::AutoNoteStem:
+        return VerticalPlacement::Float;
+    default:
+        return VerticalPlacement::NotApplicable;
+    }
+}
+
 std::optional<details::ArticulationAssign::SelectedSymbolContext>
 details::ArticulationAssign::calcSelectedSymbolContext(const EntryInfoPtr& entryInfo) const
 {
@@ -120,27 +150,7 @@ details::ArticulationAssign::calcSelectedSymbolContext(const EntryInfoPtr& entry
     }
 
     result.symbol = result.definition->calcSelectedSymbol(calcPlacementAbove(result.definition, entryInfo));
-
-    if (result.definition->autoVert) {
-        using AD = others::ArticulationDef;
-        switch (result.definition->autoVertMode) {
-        case AD::AutoVerticalMode::AboveEntry:
-            result.placement = VerticalPlacement::Above;
-            break;
-        case AD::AutoVerticalMode::BelowEntry:
-            result.placement = VerticalPlacement::Below;
-            break;
-        case AD::AutoVerticalMode::AlwaysNoteheadSide:
-        case AD::AutoVerticalMode::AutoNoteStem:
-            result.placement = VerticalPlacement::Float;
-            break;
-        default:
-            result.placement = VerticalPlacement::NotApplicable;
-            break;
-        }
-    } else {
-        result.placement = vertOffset >= 0 ? VerticalPlacement::Above : VerticalPlacement::Below;
-    }
+    result.placement = calcVerticalPlacement(result.definition, entryInfo);
 
     return result;
 }

--- a/src/musx/dom/Details.h
+++ b/src/musx/dom/Details.h
@@ -110,6 +110,12 @@ public:
 class ArticulationAssign : public EntryDetailsBase
 {
 private:
+    struct SelectedSymbolContext
+    {
+        MusxInstance<others::ArticulationDef> definition;
+        others::ArticulationDef::SelectedSymbol symbol;
+    };
+
     struct PseudoTieShapeContext
     {
         utils::PseudoTieShapeInfo info;
@@ -118,6 +124,8 @@ private:
     };
 
 public:
+    using SymbolInfo = others::ArticulationDef::SelectedSymbol;
+
     /**
      * @brief Constructor function
      * @param document A weak pointer to the associated document.
@@ -146,12 +154,26 @@ public:
     [[nodiscard]] std::optional<utils::PseudoTieShapeInfo> calcIsPseudoTie(utils::PseudoTieMode mode,
         const EntryInfoPtr& forStartEntry) const;
 
+    /// @brief Resolves the symbol information used by this articulation assignment on the specified entry.
+    /// @details The returned symbol reflects the assignment-level placement semantics used by this library. Manual placement
+    /// cases are evaluated exactly from the assignment data. Automatic placement cases use the best available policy-based
+    /// interpretation of Finale's settings and may differ from Finale's final rendered side after layout-dependent positioning
+    /// or manual dragging.
+    /// @return The resolved symbol information, or std::nullopt if the entry context or articulation definition cannot be resolved.
+    [[nodiscard]] std::optional<SymbolInfo> calcSymbolInfo(const EntryInfoPtr& entryInfo) const;
+
     static const xml::XmlElementArray<ArticulationAssign>& xmlMappingArray();   ///< Required for musx::factory::FieldPopulator.
     constexpr static std::string_view XmlNodeName = "articAssign"; ///< The XML node name for this type.
 
 private:
+    /// @brief Calculates whether the articulation should be treated as placed above the entry.
+    /// @details This returns the semantic placement used for articulation behavior, not a guaranteed reconstruction of
+    /// Finale's final rendered position in every automatic-layout scenario. Manual placement cases are evaluated exactly
+    /// from the assignment data. Automatic placement cases use the best available policy-based interpretation of Finale's
+    /// settings and may differ from Finale's final rendered side after layout-dependent positioning or manual dragging.
     [[nodiscard]] bool calcPlacementAbove(const MusxInstance<others::ArticulationDef>& definition,
-        const EntryInfoPtr& forStartEntry) const;
+        const EntryInfoPtr& entryInfo) const;
+    [[nodiscard]] std::optional<SelectedSymbolContext> calcSelectedSymbolContext(const EntryInfoPtr& entryInfo) const;
     [[nodiscard]] std::optional<PseudoTieShapeContext> calcPseudoTieShapeContext(const EntryInfoPtr& forStartEntry) const;
 };
 

--- a/src/musx/dom/Details.h
+++ b/src/musx/dom/Details.h
@@ -114,8 +114,7 @@ private:
     {
         utils::PseudoTieShapeInfo info;
         MusxInstance<others::ArticulationDef> definition;
-        bool placeAbove{};
-        bool usesAlternateSymbol{};
+        others::ArticulationDef::SelectedSymbol selectedSymbol;
     };
 
 public:
@@ -151,6 +150,8 @@ public:
     constexpr static std::string_view XmlNodeName = "articAssign"; ///< The XML node name for this type.
 
 private:
+    [[nodiscard]] bool calcPlacementAbove(const MusxInstance<others::ArticulationDef>& definition,
+        const EntryInfoPtr& forStartEntry) const;
     [[nodiscard]] std::optional<PseudoTieShapeContext> calcPseudoTieShapeContext(const EntryInfoPtr& forStartEntry) const;
 };
 

--- a/src/musx/dom/Details.h
+++ b/src/musx/dom/Details.h
@@ -109,13 +109,18 @@ public:
  */
 class ArticulationAssign : public EntryDetailsBase
 {
-private:
+public:
+    /// @class SelectedSymbolContext
+    /// @brief Provides information about the best analysis as to which articulation symbol in being used on this assignment.
+    /// @details The symbol may be the main or alternate symbol, and it may be either a codepoint or a shape id. For automatically
+    /// positioned articulations, see the caveats at #calcPlacementAbove.
     struct SelectedSymbolContext
     {
-        MusxInstance<others::ArticulationDef> definition;
-        others::ArticulationDef::SelectedSymbol symbol;
+        MusxInstance<others::ArticulationDef> definition;   ///< The associated articulation definition.
+        others::ArticulationDef::SelectedSymbol symbol;     ///< Information about the selected symbol.
     };
 
+private:
     struct PseudoTieShapeContext
     {
         utils::PseudoTieShapeInfo info;
@@ -124,8 +129,6 @@ private:
     };
 
 public:
-    using SymbolInfo = others::ArticulationDef::SelectedSymbol;
-
     /**
      * @brief Constructor function
      * @param document A weak pointer to the associated document.
@@ -155,12 +158,12 @@ public:
         const EntryInfoPtr& forStartEntry) const;
 
     /// @brief Resolves the symbol information used by this articulation assignment on the specified entry.
-    /// @details The returned symbol reflects the assignment-level placement semantics used by this library. Manual placement
+    /// @details The returned symbol context reflects the assignment-level placement semantics used by this library. Manual placement
     /// cases are evaluated exactly from the assignment data. Automatic placement cases use the best available policy-based
     /// interpretation of Finale's settings and may differ from Finale's final rendered side after layout-dependent positioning
     /// or manual dragging.
-    /// @return The resolved symbol information, or std::nullopt if the entry context or articulation definition cannot be resolved.
-    [[nodiscard]] std::optional<SymbolInfo> calcSymbolInfo(const EntryInfoPtr& entryInfo) const;
+    /// @return The resolved symbol context, or std::nullopt if the entry context or articulation definition cannot be resolved.
+    [[nodiscard]] std::optional<SelectedSymbolContext> calcSelectedSymbolContext(const EntryInfoPtr& entryInfo) const;
 
     static const xml::XmlElementArray<ArticulationAssign>& xmlMappingArray();   ///< Required for musx::factory::FieldPopulator.
     constexpr static std::string_view XmlNodeName = "articAssign"; ///< The XML node name for this type.
@@ -173,7 +176,6 @@ private:
     /// settings and may differ from Finale's final rendered side after layout-dependent positioning or manual dragging.
     [[nodiscard]] bool calcPlacementAbove(const MusxInstance<others::ArticulationDef>& definition,
         const EntryInfoPtr& entryInfo) const;
-    [[nodiscard]] std::optional<SelectedSymbolContext> calcSelectedSymbolContext(const EntryInfoPtr& entryInfo) const;
     [[nodiscard]] std::optional<PseudoTieShapeContext> calcPseudoTieShapeContext(const EntryInfoPtr& forStartEntry) const;
 };
 

--- a/src/musx/dom/Details.h
+++ b/src/musx/dom/Details.h
@@ -177,6 +177,11 @@ private:
     /// settings and may differ from Finale's final rendered side after layout-dependent positioning or manual dragging.
     [[nodiscard]] bool calcPlacementAbove(const MusxInstance<others::ArticulationDef>& definition,
         const EntryInfoPtr& entryInfo) const;
+    /// @brief Resolves the placement semantics for this articulation assignment on the specified entry.
+    /// @details This distinguishes fixed above/below placement from context-dependent floating placement and respects
+    /// assignment-level overrides and Finale's multi-layer stem-side modifier for otherwise fixed above/below modes.
+    [[nodiscard]] VerticalPlacement calcVerticalPlacement(const MusxInstance<others::ArticulationDef>& definition,
+        const EntryInfoPtr& entryInfo) const;
     [[nodiscard]] std::optional<PseudoTieShapeContext> calcPseudoTieShapeContext(const EntryInfoPtr& forStartEntry) const;
 };
 

--- a/src/musx/dom/Details.h
+++ b/src/musx/dom/Details.h
@@ -118,6 +118,7 @@ public:
     {
         MusxInstance<others::ArticulationDef> definition;   ///< The associated articulation definition.
         others::ArticulationDef::SelectedSymbol symbol;     ///< Information about the selected symbol.
+        VerticalPlacement placement = VerticalPlacement::NotApplicable; //< whether the symbol is fixed above, fixed below, or floats.
     };
 
 private:

--- a/src/musx/dom/Entries.cpp
+++ b/src/musx/dom/Entries.cpp
@@ -1025,52 +1025,20 @@ bool EntryInfoPtr::calcUpStemDefault() const
 
 bool EntryInfoPtr::calcUpStemImpl() const
 {
+    switch (calcStemDirectionForced()) {
+    case StemDirection::AlwaysUp:
+        return true;
+    case StemDirection::AlwaysDown:
+        return false;
+    case StemDirection::Default:
+        break;
+    }
+
     //stem direction is determined by the beam a note or rest is part of, if any, so
     //we must always look for a beam to calculate direction.
     auto beamStart = findBeamStartOrCurrent();
-    const auto frame = getFrame();
-
-    // This is the precedence as tested by RGP in ~2001.
-    // rhythmic slash notation
-    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
-        auto staff = next.createCurrentStaff(); // the staff is cached by createCurrentStaff after first retrieval.
-        if (staff->altNotation == others::Staff::AlternateNotation::Rhythmic) {
-            return staff->altRhythmStemsUp;
-        }
-    }
-    // manual override of stem direction
-    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
-        const auto [freezeStem, upStem] = next.calcEntryStemSettings();
-        if (freezeStem) {
-            return upStem;
-        }
-    }
-    // layer override of stem direction
-    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
-        if (auto layerAtts = frame->getLayerAttributes()) {
-            if (layerAtts->freezeLayer && calcIfLayerSettingsApply()) {
-                return layerAtts->freezeStemsUp;
-            }
-        }
-    }
-    // staff override of stem direction
-    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
-        auto staff = next.createCurrentStaff();
-        if (staff->stemDirection == others::Staff::StemDirection::AlwaysUp) {
-            return true;
-        } else if (staff->stemDirection == others::Staff::StemDirection::AlwaysDown) {
-            return false;
-        }
-    }
-    // v1/v2 direction
-    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
-        const auto& entry = next->getEntry();
-        if (entry->v2Launch || entry->voice2) {
-            return std::get<1>(next.calcEntryStemSettings());
-        }
-    }
     // cross-staff direction was not part of the 2001 testing, but this seems the right place for it for now.
-    const auto scrollViewStaves = frame->getDocument()->getScrollViewStaves(frame->getRequestedPartId());
+    const auto scrollViewStaves = getFrame()->getDocument()->getScrollViewStaves(getFrame()->getRequestedPartId());
     int foundCrossDirection = 0;
     for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
         const int currDirection = next.calcCrossStaffDirectionForAll(scrollViewStaves);
@@ -1088,6 +1056,47 @@ bool EntryInfoPtr::calcUpStemImpl() const
     }
 
     return calcUpStemDefault();
+}
+
+StemDirection EntryInfoPtr::calcStemDirectionForced() const
+{
+    auto beamStart = findBeamStartOrCurrent();
+    const auto frame = getFrame();
+
+    // This is the precedence as tested by RGP in ~2001.
+    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
+        auto staff = next.createCurrentStaff();
+        if (staff->altNotation == others::Staff::AlternateNotation::Rhythmic) {
+            return staff->altRhythmStemsUp ? StemDirection::AlwaysUp : StemDirection::AlwaysDown;
+        }
+    }
+    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
+        const auto [freezeStem, upStem] = next.calcEntryStemSettings();
+        if (freezeStem) {
+            return upStem ? StemDirection::AlwaysUp : StemDirection::AlwaysDown;
+        }
+    }
+    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
+        if (auto layerAtts = frame->getLayerAttributes()) {
+            if (layerAtts->freezeLayer && calcIfLayerSettingsApply()) {
+                return layerAtts->freezeStemsUp ? StemDirection::AlwaysUp : StemDirection::AlwaysDown;
+            }
+        }
+    }
+    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
+        auto staff = next.createCurrentStaff();
+        if (staff->stemDirection == StemDirection::AlwaysUp || staff->stemDirection == StemDirection::AlwaysDown) {
+            return staff->stemDirection;
+        }
+    }
+    for (auto next = beamStart; next; next = next.getNextInBeamGroup()) {
+        const auto& entry = next->getEntry();
+        if (entry->v2Launch || entry->voice2) {
+            return std::get<1>(next.calcEntryStemSettings()) ? StemDirection::AlwaysUp : StemDirection::AlwaysDown;
+        }
+    }
+
+    return StemDirection::Default;
 }
 
 bool EntryInfoPtr::calcUnbeamed() const

--- a/src/musx/dom/Entries.h
+++ b/src/musx/dom/Entries.h
@@ -743,6 +743,12 @@ public:
     /// @return True if the entry is upstem barring any other factors that would override the stem direction. False if it is downstem.
     [[nodiscard]] bool calcUpStemDefault() const;
 
+    /// @brief Returns the forced stem direction if any.
+    /// @details This uses the following precedence: rhythmic notation, manual freeze, layer override, staff override, 
+    /// and v1/v2 behavior. Cross-staff direction overrides are intentionally excluded.
+    /// @return The forced direction, or #StemDirection::Default if none applies.
+    [[nodiscard]] StemDirection calcStemDirectionForced() const;
+
     /// @brief Determines the effective stem direction of the entry, taking into account voices, layers, staff options, manual overrides,
     /// and cross-staff notation.
     ///

--- a/src/musx/dom/EnumClasses.h
+++ b/src/musx/dom/EnumClasses.h
@@ -168,6 +168,15 @@ enum class ShowClefMode
     Always      ///< Clef is always displayed. (xml value is "forced")
 };
 
+/// @enum StemDirection
+/// @brief Three-state stem direction setting or override.
+enum class StemDirection
+{
+    Default,    ///< No forced direction; use the default calculation.
+    AlwaysUp,   ///< Stems are forced up.
+    AlwaysDown  ///< Stems are forced down.
+};
+
 /**
  * @enum TieConnectStyleType
  * @brief Enumeration for tie connect style types

--- a/src/musx/dom/EnumClasses.h
+++ b/src/musx/dom/EnumClasses.h
@@ -197,5 +197,15 @@ enum class TieConnectStyleType
     UnderLowestNoteStemEndPosUnder
 };
 
+/// @enum VerticalPlacement
+/// @brief Specifies a vertical placement relationship for notation objects.
+enum class VerticalPlacement
+{
+    NotApplicable, ///< Above/below placement does not meaningfully apply.
+    Float,         ///< Above/below placement floats based on context (usually stem direction).
+    Below,         ///< Always positioned below the reference point or object.
+    Above          ///< Always positioned above the reference point or object.
+};
+
 } // namespace dom
 } // namespace musx

--- a/src/musx/dom/Fundamentals.h
+++ b/src/musx/dom/Fundamentals.h
@@ -121,7 +121,7 @@ constexpr char32_t fourStringTabClefSerif = 0xF40D;     ///< glyph "4stringTabCl
  */
 namespace symbol_glyph {
 // Use namespace instead of enum class due to comparison ugliness with enum class.
-constexpr char32_t unpitchedPercussionClef2 = 214;   ///< equivalen symbol glyph for "unpitchedPercussionClef2"
+constexpr char32_t unpitchedPercussionClef2 = 214;      ///< equivalent symbol glyph for "unpitchedPercussionClef2"
 } //namespace symbol_glyph
 
 } // namespace dom

--- a/src/musx/dom/Others.cpp
+++ b/src/musx/dom/Others.cpp
@@ -314,9 +314,40 @@ MusxInstance<ShapeExpressionDef> MeasureExprAssign::getShapeExpression() const
     return getDocument()->getOthers()->get<ShapeExpressionDef>(getRequestedPartId(), shapeExprId);
 }
 
+MusxInstance<MarkingCategory> MeasureExprAssign::getMarkingCategory() const
+{
+    Cmper categoryId = 0;
+    if (const auto textExpression = getTextExpression()) {
+        categoryId = textExpression->categoryId;
+    } else if (const auto shapeExpression = getShapeExpression()) {
+        categoryId = shapeExpression->categoryId;
+    }
+    if (!categoryId) {
+        return nullptr;
+    }
+    return getDocument()->getOthers()->get<MarkingCategory>(getRequestedPartId(), categoryId);
+}
+
 CategoryStaffListSet MeasureExprAssign::createStaffListSet() const
 {
-    return CategoryStaffListSet(getDocument(), getRequestedPartId(), staffList);
+    Cmper effectiveStaffList = staffList;
+    if (!effectiveStaffList) {
+        if (const auto category = getMarkingCategory(); category && category->usesStaffList) {
+            effectiveStaffList = category->staffList;
+        }
+    }
+    return CategoryStaffListSet(getDocument(), getRequestedPartId(), effectiveStaffList);
+}
+
+bool MeasureExprAssign::calcIsPartOfStaffListAssignment() const
+{
+    if (staffGroup != 0 || staffList != 0) {
+        return true;
+    }
+    if (const auto category = getMarkingCategory()) {
+        return category->usesStaffList && category->staffList != 0;
+    }
+    return false;
 }
 
 std::optional<HorizontalMeasExprAlign> MeasureExprAssign::calcEntryAlignmentType() const
@@ -413,7 +444,7 @@ MusxInstance<StaffComposite> MeasureExprAssign::createCurrentStaff(bool forPageV
 
 bool MeasureExprAssign::calcIsHiddenByAlternateNotation() const
 {
-    if (staffList != 0) {
+    if (calcIsPartOfStaffListAssignment()) {
         return false; // assignments with staff lists are never hidden by alternate notation: observed behavior
     }
     auto staff = createCurrentStaff();
@@ -1161,7 +1192,7 @@ bool StaffListSet<ScoreList, PartsList, ScoreForcedList, PartsForcedList>::conta
     return staffListContainsStaff(m_forcedStaffList);
 }
 
-template class StaffListSet< StaffListCategoryScore, StaffListCategoryParts>;
+template class StaffListSet<StaffListCategoryScore, StaffListCategoryParts>;
 template class StaffListSet<StaffListRepeatScore, StaffListRepeatParts, StaffListRepeatScoreForced, StaffListRepeatPartsForced>;
 
 // ***********************

--- a/src/musx/dom/Others.cpp
+++ b/src/musx/dom/Others.cpp
@@ -31,6 +31,25 @@ namespace musx {
 namespace dom {
 namespace others {
 
+// ***************************
+// ***** ArticulationDef *****
+// ***************************
+
+ArticulationDef::SelectedSymbol ArticulationDef::calcSelectedSymbol(bool placeAbove) const
+{
+    const bool usesAlternate = placeAbove ? aboveSymbolAlt : belowSymbolAlt;
+
+    SelectedSymbol result;
+    result.usesAlternate = usesAlternate;
+    result.isShape = usesAlternate ? altIsShape : mainIsShape;
+    result.shapeId = usesAlternate ? altShape : mainShape;
+    result.xOffset = usesAlternate ? xOffsetAlt : xOffsetMain;
+    result.yOffset = usesAlternate ? yOffsetAlt : yOffsetMain;
+    result.character = usesAlternate ? charAlt : charMain;
+    result.font = usesAlternate ? fontAlt : fontMain;
+    return result;
+}
+
 // *****************
 // ***** Frame *****
 // *****************

--- a/src/musx/dom/Others.cpp
+++ b/src/musx/dom/Others.cpp
@@ -330,13 +330,7 @@ MusxInstance<MarkingCategory> MeasureExprAssign::getMarkingCategory() const
 
 CategoryStaffListSet MeasureExprAssign::createStaffListSet() const
 {
-    Cmper effectiveStaffList = staffList;
-    if (!effectiveStaffList) {
-        if (const auto category = getMarkingCategory(); category && category->usesStaffList) {
-            effectiveStaffList = category->staffList;
-        }
-    }
-    return CategoryStaffListSet(getDocument(), getRequestedPartId(), effectiveStaffList);
+    return CategoryStaffListSet(getDocument(), getRequestedPartId(), staffList);
 }
 
 bool MeasureExprAssign::calcIsPartOfStaffListAssignment() const

--- a/src/musx/dom/Others.h
+++ b/src/musx/dom/Others.h
@@ -252,6 +252,18 @@ public:
         AvoidSlur
     };
 
+    /// @brief The resolved main or alternate symbol selection for an articulation definition.
+    struct SelectedSymbol
+    {
+        bool usesAlternate{};                    ///< True when the alternate symbol is selected.
+        bool isShape{};                          ///< Whether the selected symbol uses a shape definition.
+        Cmper shapeId{};                         ///< Shape ID for the selected symbol when #isShape is true.
+        Evpu xOffset{};                          ///< Horizontal offset for the selected symbol.
+        Evpu yOffset{};                          ///< Vertical offset for the selected symbol.
+        char32_t character{};                    ///< The selected symbol character.
+        std::shared_ptr<FontInfo> font;          ///< Font info for the selected symbol.
+    };
+
     /**
      * @brief Constructor.
      *
@@ -302,6 +314,11 @@ public:
     int ampTopNotePercent{};                       ///< Key velocity percentage for the top note.
     int ampBotNotePercent{};                       ///< Key velocity percentage for the bottom note.
     Evpu distanceFromStemEnd{};                    ///< "On-stem distance from stem end/flag/beam"
+
+    /// @brief Resolves which symbol data applies for the specified placement.
+    /// @param placeAbove True when the articulation is placed above the entry; false when below.
+    /// @return The selected main or alternate symbol data.
+    [[nodiscard]] SelectedSymbol calcSelectedSymbol(bool placeAbove) const;
 
     constexpr static std::string_view XmlNodeName = "articDef"; ///< The XML node name for this type.
     static const xml::XmlElementArray<ArticulationDef>& xmlMappingArray(); ///< Required for musx::factory::FieldPopulator.

--- a/src/musx/dom/Others.h
+++ b/src/musx/dom/Others.h
@@ -1400,9 +1400,19 @@ public:
     /// @return The shape expression or nullptr if this assignment is for a text expression or #shapeExprId not found.
     MusxInstance<ShapeExpressionDef> getShapeExpression() const;
 
+    /// @brief Gets the marking category for the assigned text or shape expression.
+    /// @return The marking category or nullptr if the definition or its category cannot be resolved.
+    MusxInstance<MarkingCategory> getMarkingCategory() const;
+
     /// @brief Create a @ref StaffListSet for the given instance. This can be used to interrogate whether a staff appears in the staff set.
-    /// @return The created staff list set. If #staffList is zero, it will never find any staves for the staff list.
+    /// @return The created staff list set. If #staffList is zero, the function falls back to the expression category's
+    /// staff list when that category uses staff lists. Otherwise it will never find any staves.
     CategoryStaffListSet createStaffListSet() const;
+
+    /// @brief Calculates if this assignment participates in a staff-list-based assignment group.
+    /// @details This checks the assignment-level grouping fields first, then falls back to the assigned expression
+    /// category when the category uses staff lists. This works for both text and shape expressions.
+    bool calcIsPartOfStaffListAssignment() const;
 
     /// @brief Calculates the effective staffId for the assignment, returning top or bottom staff if appropriate
     /// @param forPageView Return the top/bottom staff in page view (when appropriate). If the staff does not appear in page view, the function falls back to scroll view.

--- a/src/musx/dom/Others.h
+++ b/src/musx/dom/Others.h
@@ -294,6 +294,7 @@ public:
     Evpu defVertPos{};                             ///< Default vertical position.
     bool avoidStaffLines{};                        ///< Whether to avoid staff lines.
     bool isStemSideWhenMultipleLayers{};           ///< "Place stem side when multiple layers are present"
+                                                   ///< (Applicable only for #AutoVerticalMode::AboveEntry.)
     bool playArtic{};                              ///< Whether playback articulation is enabled.
     Evpu xOffsetAlt{};                             ///< Horizontal offset for the alternate symbol.
     Evpu yOffsetAlt{};                             ///< Vertical offset for the alternate symbol.

--- a/src/musx/dom/Staff.h
+++ b/src/musx/dom/Staff.h
@@ -65,17 +65,6 @@ public:
     };
 
     /**
-     * @enum StemDirection
-     * @brief Enum for staff-level stem direction override.
-     */
-    enum class StemDirection
-    {
-        Default,            ///< the default (may not occur in xml)
-        AlwaysUp,           ///< stems are always up on this staff
-        AlwaysDown          ///< stems are always down on this staff
-    };
-
-    /**
      * @enum NotationStyle
      * @brief Enum for notation style.
      */

--- a/src/musx/factory/FieldPopulatorsCommon.cpp
+++ b/src/musx/factory/FieldPopulatorsCommon.cpp
@@ -53,6 +53,12 @@ MUSX_XML_ENUM_MAPPING(ShowClefMode, {
     {"forced", ShowClefMode::Always}
 });
 
+MUSX_XML_ENUM_MAPPING(StemDirection, {
+    // {"default", StemDirection::Default}, // this is the default and may not occur in the XML
+    {"alwaysUp", StemDirection::AlwaysUp},
+    {"alwaysDown", StemDirection::AlwaysDown},
+});
+
 #ifndef DOXYGEN_SHOULD_IGNORE_THIS
 void populateFontEfx(const XmlElementPtr& e, const std::shared_ptr<dom::FontInfo>& i)
 {

--- a/src/musx/factory/FieldPopulatorsOthers.cpp
+++ b/src/musx/factory/FieldPopulatorsOthers.cpp
@@ -34,7 +34,7 @@ using namespace ::musx::dom::others;
 extern template const XmlEnumMappingElement<AlignJustify> XmlEnumMapping<AlignJustify>::mapping;
 extern template const XmlEnumMappingElement<LyricTextType> XmlEnumMapping<LyricTextType>::mapping;
 extern template const XmlEnumMappingElement<ShowClefMode> XmlEnumMapping<ShowClefMode>::mapping;
-extern template const XmlEnumMappingElement<ShowClefMode> XmlEnumMapping<StemDirection>::mapping;
+extern template const XmlEnumMappingElement<StemDirection> XmlEnumMapping<StemDirection>::mapping;
 extern template const XmlEnumMappingElement<options::TextOptions::HorizontalAlignment> XmlEnumMapping<options::TextOptions::HorizontalAlignment>::mapping;
 extern template const XmlEnumMappingElement<options::TextOptions::VerticalAlignment> XmlEnumMapping<options::TextOptions::VerticalAlignment>::mapping;
 extern template const XmlEnumMappingElement<options::TextOptions::TextJustify> XmlEnumMapping<options::TextOptions::TextJustify>::mapping;

--- a/src/musx/factory/FieldPopulatorsOthers.cpp
+++ b/src/musx/factory/FieldPopulatorsOthers.cpp
@@ -34,6 +34,7 @@ using namespace ::musx::dom::others;
 extern template const XmlEnumMappingElement<AlignJustify> XmlEnumMapping<AlignJustify>::mapping;
 extern template const XmlEnumMappingElement<LyricTextType> XmlEnumMapping<LyricTextType>::mapping;
 extern template const XmlEnumMappingElement<ShowClefMode> XmlEnumMapping<ShowClefMode>::mapping;
+extern template const XmlEnumMappingElement<ShowClefMode> XmlEnumMapping<StemDirection>::mapping;
 extern template const XmlEnumMappingElement<options::TextOptions::HorizontalAlignment> XmlEnumMapping<options::TextOptions::HorizontalAlignment>::mapping;
 extern template const XmlEnumMappingElement<options::TextOptions::VerticalAlignment> XmlEnumMapping<options::TextOptions::VerticalAlignment>::mapping;
 extern template const XmlEnumMappingElement<options::TextOptions::TextJustify> XmlEnumMapping<options::TextOptions::TextJustify>::mapping;
@@ -337,12 +338,6 @@ MUSX_XML_ENUM_MAPPING(Staff::NotationStyle, {
     // {"standard", Staff::NotationStyle::Standard}, // this is the default and may not occur in the xml
     {"percussion", Staff::NotationStyle::Percussion},
     {"tab", Staff::NotationStyle::Tablature},
-});
-
-MUSX_XML_ENUM_MAPPING(Staff::StemDirection, {
-    // {"default", Staff::StemDirection::Default}, // this is the default and may not occur in the XML
-    {"alwaysUp", Staff::StemDirection::AlwaysUp},
-    {"alwaysDown", Staff::StemDirection::AlwaysDown},
 });
 
 MUSX_XML_ENUM_MAPPING(Staff::HideMode, {
@@ -1382,7 +1377,7 @@ MUSX_XML_ELEMENT_ARRAY(Staff, {
     {"hideTuplets", [](const XmlElementPtr& e, const std::shared_ptr<Staff>& i) { i->hideTuplets = populateBoolean(e, i); }},
     {"fretInstID", [](const XmlElementPtr& e, const std::shared_ptr<Staff>& i) { i->fretInstId = e->getTextAs<Cmper>(); }},
     {"hideStems", [](const XmlElementPtr& e, const std::shared_ptr<Staff>& i) { i->hideStems = populateBoolean(e, i); }},
-    {"stemDir", [](const XmlElementPtr& e, const std::shared_ptr<Staff>& i) { i->stemDirection = toEnum<Staff::StemDirection>(e); }},
+    {"stemDir", [](const XmlElementPtr& e, const std::shared_ptr<Staff>& i) { i->stemDirection = toEnum<StemDirection>(e); }},
     {"hideBeams", [](const XmlElementPtr& e, const std::shared_ptr<Staff>& i) { i->hideBeams = populateBoolean(e, i); }},
     {"stemStartFromStaff",[] (const XmlElementPtr& e, const std::shared_ptr<Staff>& i){ i->stemStartFromStaff = populateBoolean(e, i); }},
     {"stemsFixedEnd",[] (const XmlElementPtr& e, const std::shared_ptr<Staff>& i){ i->stemsFixedEnd = populateBoolean(e, i); }},

--- a/tests/others/articulation.cpp
+++ b/tests/others/articulation.cpp
@@ -195,3 +195,141 @@ TEST(ArticulationAssignTest, Populate)
     auto articInvalid = details->get<details::ArticulationAssign>(SCORE_PARTID, 999, 0);
     EXPECT_FALSE(articInvalid) << "ArticulationAssign with entnum=999 found but does not exist";
 }
+
+TEST(ArticulationAssignTest, CalcSelectedSymbolContextHonorsOverridePlacement)
+{
+    std::vector<char> defXml;
+    musxtest::readFile(musxtest::getInputPath() / "finale_maestro_default.enigmaxml", defXml);
+    auto defDoc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(defXml);
+    ASSERT_TRUE(defDoc);
+
+    std::vector<char> entryXml;
+    musxtest::readFile(musxtest::getInputPath() / "stemdirection.enigmaxml", entryXml);
+    auto entryDoc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(entryXml);
+    ASSERT_TRUE(entryDoc);
+
+    auto gfhold = details::GFrameHoldContext(entryDoc, SCORE_PARTID, 3, 3);
+    ASSERT_TRUE(gfhold);
+    auto entryFrame = gfhold.createEntryFrame(0);
+    ASSERT_TRUE(entryFrame);
+
+    auto entryInfo = EntryInfoPtr(entryFrame, 0);
+    ASSERT_TRUE(entryInfo);
+    ASSERT_TRUE(entryInfo.calcUpStem());
+
+    details::ArticulationAssign assign(defDoc, SCORE_PARTID, Base::ShareMode::All, 0, 0);
+    assign.articDef = 8;
+    assign.overridePlacement = true;
+    assign.aboveEntry = false;
+
+    const auto context = assign.calcSelectedSymbolContext(entryInfo);
+    ASSERT_TRUE(context);
+    EXPECT_EQ(context->placement, VerticalPlacement::Below);
+    EXPECT_TRUE(context->definition->belowSymbolAlt);
+    EXPECT_TRUE(context->symbol.usesAlternate);
+    EXPECT_EQ(context->symbol.character, context->definition->charAlt);
+}
+
+TEST(ArticulationAssignTest, CalcSelectedSymbolContextFloatsAboveEntryInMultiLayerStemSideContexts)
+{
+    std::vector<char> defXml;
+    musxtest::readFile(musxtest::getInputPath() / "finale_maestro_default.enigmaxml", defXml);
+    auto defDoc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(defXml);
+    ASSERT_TRUE(defDoc);
+
+    std::vector<char> entryXml;
+    musxtest::readFile(musxtest::getInputPath() / "stemdirection.enigmaxml", entryXml);
+    auto entryDoc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(entryXml);
+    ASSERT_TRUE(entryDoc);
+
+    auto gfhold = details::GFrameHoldContext(entryDoc, SCORE_PARTID, 3, 3);
+    ASSERT_TRUE(gfhold);
+    auto upperFrame = gfhold.createEntryFrame(0);
+    auto lowerFrame = gfhold.createEntryFrame(1);
+    ASSERT_TRUE(upperFrame);
+    ASSERT_TRUE(lowerFrame);
+
+    auto upperEntry = EntryInfoPtr(upperFrame, 0);
+    auto lowerEntry = EntryInfoPtr(lowerFrame, 0);
+    ASSERT_TRUE(upperEntry);
+    ASSERT_TRUE(lowerEntry);
+    ASSERT_TRUE(upperEntry.calcUpStem());
+    ASSERT_FALSE(lowerEntry.calcUpStem());
+
+    details::ArticulationAssign assign(defDoc, SCORE_PARTID, Base::ShareMode::All, 0, 0);
+    assign.articDef = 8;
+
+    const auto upperContext = assign.calcSelectedSymbolContext(upperEntry);
+    ASSERT_TRUE(upperContext);
+    EXPECT_EQ(upperContext->placement, VerticalPlacement::Float);
+    EXPECT_FALSE(upperContext->symbol.usesAlternate);
+    EXPECT_EQ(upperContext->symbol.character, upperContext->definition->charMain);
+
+    const auto lowerContext = assign.calcSelectedSymbolContext(lowerEntry);
+    ASSERT_TRUE(lowerContext);
+    EXPECT_EQ(lowerContext->placement, VerticalPlacement::Float);
+    EXPECT_TRUE(lowerContext->symbol.usesAlternate);
+    EXPECT_EQ(lowerContext->symbol.character, lowerContext->definition->charAlt);
+}
+
+TEST(ArticulationAssignTest, CalcSelectedSymbolContextKeepsBelowEntryFixedInMultiLayerStemSideContexts)
+{
+    constexpr static musxtest::string_view defXml = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+  <others>
+    <articDef cmper="42">
+      <charMain>58960</charMain>
+      <sizeMain>24</sizeMain>
+      <autoHorz/>
+      <autoVert/>
+      <autoVertMode>belowEntry</autoVertMode>
+      <outsideStaff/>
+      <autoStack/>
+      <slurInteractionMode>avoidSlur</slurInteractionMode>
+      <charAlt>58961</charAlt>
+      <defVertPos>24</defVertPos>
+      <isStemSideWhenMultipleLayers/>
+      <sizeAlt>24</sizeAlt>
+    </articDef>
+  </others>
+</finale>
+    )xml";
+
+    auto defDoc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(defXml);
+    ASSERT_TRUE(defDoc);
+
+    std::vector<char> entryXml;
+    musxtest::readFile(musxtest::getInputPath() / "stemdirection.enigmaxml", entryXml);
+    auto entryDoc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(entryXml);
+    ASSERT_TRUE(entryDoc);
+
+    auto gfhold = details::GFrameHoldContext(entryDoc, SCORE_PARTID, 3, 3);
+    ASSERT_TRUE(gfhold);
+    auto upperFrame = gfhold.createEntryFrame(0);
+    auto lowerFrame = gfhold.createEntryFrame(1);
+    ASSERT_TRUE(upperFrame);
+    ASSERT_TRUE(lowerFrame);
+
+    auto upperEntry = EntryInfoPtr(upperFrame, 0);
+    auto lowerEntry = EntryInfoPtr(lowerFrame, 0);
+    ASSERT_TRUE(upperEntry);
+    ASSERT_TRUE(lowerEntry);
+    ASSERT_TRUE(upperEntry.calcUpStem());
+    ASSERT_FALSE(lowerEntry.calcUpStem());
+
+    details::ArticulationAssign assign(defDoc, SCORE_PARTID, Base::ShareMode::All, 0, 0);
+    assign.articDef = 42;
+
+    const auto upperContext = assign.calcSelectedSymbolContext(upperEntry);
+    ASSERT_TRUE(upperContext);
+    EXPECT_EQ(upperContext->placement, VerticalPlacement::Below);
+    EXPECT_FALSE(upperContext->symbol.usesAlternate);
+    EXPECT_EQ(upperContext->symbol.character, upperContext->definition->charMain);
+
+    const auto lowerContext = assign.calcSelectedSymbolContext(lowerEntry);
+    ASSERT_TRUE(lowerContext);
+    EXPECT_EQ(lowerContext->placement, VerticalPlacement::Below);
+    EXPECT_FALSE(lowerContext->symbol.usesAlternate);
+    EXPECT_EQ(lowerContext->symbol.character, lowerContext->definition->charMain);
+}

--- a/tests/others/articulation.cpp
+++ b/tests/others/articulation.cpp
@@ -111,6 +111,22 @@ TEST(ArticulationDefTest, PopulateFields)
     EXPECT_EQ(articDef->durBotNotePercent, 2);
     EXPECT_EQ(articDef->ampTopNoteDelta, 125);
     EXPECT_EQ(articDef->ampBotNoteDelta, 125);
+
+    const auto aboveSymbol = articDef->calcSelectedSymbol(true);
+    EXPECT_TRUE(aboveSymbol.usesAlternate);
+    EXPECT_FALSE(aboveSymbol.isShape);
+    EXPECT_EQ(aboveSymbol.character, articDef->charAlt);
+    EXPECT_EQ(aboveSymbol.font, articDef->fontAlt);
+    EXPECT_EQ(aboveSymbol.xOffset, articDef->xOffsetAlt);
+    EXPECT_EQ(aboveSymbol.yOffset, articDef->yOffsetAlt);
+
+    const auto belowSymbol = articDef->calcSelectedSymbol(false);
+    EXPECT_FALSE(belowSymbol.usesAlternate);
+    EXPECT_FALSE(belowSymbol.isShape);
+    EXPECT_EQ(belowSymbol.character, articDef->charMain);
+    EXPECT_EQ(belowSymbol.font, articDef->fontMain);
+    EXPECT_EQ(belowSymbol.xOffset, articDef->xOffsetMain);
+    EXPECT_EQ(belowSymbol.yOffset, articDef->yOffsetMain);
 }
 
 TEST(ArticulationAssignTest, Populate)

--- a/tests/others/expression.cpp
+++ b/tests/others/expression.cpp
@@ -344,6 +344,90 @@ TEST(MeasureExprAssign, Populate)
     EXPECT_FALSE(exprInvalid) << "MeasureExprAssign with cmper=3 found but does not exist";
 }
 
+TEST(MeasureExprAssign, CalcIsPartOfStaffListAssignment)
+{
+    constexpr static musxtest::string_view xml = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+  <others>
+    <measExprAssign cmper="1" inci="0">
+      <textExprID>1</textExprID>
+      <staffAssign>1</staffAssign>
+    </measExprAssign>
+    <measExprAssign cmper="1" inci="1">
+      <shapeExprID>2</shapeExprID>
+      <staffAssign>1</staffAssign>
+    </measExprAssign>
+    <measExprAssign cmper="1" inci="2">
+      <textExprID>3</textExprID>
+      <staffAssign>1</staffAssign>
+    </measExprAssign>
+    <measExprAssign cmper="1" inci="3">
+      <textExprID>3</textExprID>
+      <staffAssign>1</staffAssign>
+      <staffGroup>9</staffGroup>
+      <staffList>7</staffList>
+    </measExprAssign>
+
+    <textExprDef cmper="1">
+      <textIDKey>1</textIDKey>
+      <categoryID>2</categoryID>
+    </textExprDef>
+    <shapeExprDef cmper="2">
+      <shapeDef>1</shapeDef>
+      <categoryID>2</categoryID>
+    </shapeExprDef>
+    <textExprDef cmper="3">
+      <textIDKey>2</textIDKey>
+      <categoryID>1</categoryID>
+    </textExprDef>
+
+    <markingsCategory cmper="1">
+      <categoryType>dynamics</categoryType>
+      <textFont/>
+      <musicFont/>
+      <staffList>7</staffList>
+    </markingsCategory>
+    <markingsCategory cmper="2">
+      <categoryType>tempoMarks</categoryType>
+      <textFont/>
+      <musicFont/>
+      <usesStaffList/>
+      <staffList>7</staffList>
+    </markingsCategory>
+  </others>
+</finale>
+    )xml";
+
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(xml);
+    ASSERT_TRUE(doc);
+
+    auto others = doc->getOthers();
+    ASSERT_TRUE(others);
+
+    auto textStaffListExpr = others->get<others::MeasureExprAssign>(SCORE_PARTID, 1, 0);
+    ASSERT_TRUE(textStaffListExpr);
+    ASSERT_TRUE(textStaffListExpr->getMarkingCategory());
+    EXPECT_EQ(textStaffListExpr->getMarkingCategory()->getCmper(), 2);
+    EXPECT_TRUE(textStaffListExpr->calcIsPartOfStaffListAssignment());
+
+    auto shapeStaffListExpr = others->get<others::MeasureExprAssign>(SCORE_PARTID, 1, 1);
+    ASSERT_TRUE(shapeStaffListExpr);
+    ASSERT_TRUE(shapeStaffListExpr->getMarkingCategory());
+    EXPECT_EQ(shapeStaffListExpr->getMarkingCategory()->getCmper(), 2);
+    EXPECT_TRUE(shapeStaffListExpr->calcIsPartOfStaffListAssignment());
+
+    auto plainExpr = others->get<others::MeasureExprAssign>(SCORE_PARTID, 1, 2);
+    ASSERT_TRUE(plainExpr);
+    ASSERT_TRUE(plainExpr->getMarkingCategory());
+    EXPECT_EQ(plainExpr->getMarkingCategory()->getCmper(), 1);
+    EXPECT_FALSE(plainExpr->calcIsPartOfStaffListAssignment());
+
+    auto explicitGroupedExpr = others->get<others::MeasureExprAssign>(SCORE_PARTID, 1, 3);
+    ASSERT_TRUE(explicitGroupedExpr);
+    EXPECT_TRUE(explicitGroupedExpr->calcIsPartOfStaffListAssignment());
+}
+
 TEST(ShapeExpressionDef, Populate)
 {
     constexpr static musxtest::string_view xml = R"xml(

--- a/tests/others/staff.cpp
+++ b/tests/others/staff.cpp
@@ -160,7 +160,7 @@ TEST(StaffTest, PopulateFields)
     EXPECT_EQ(staff1->vertTabNumOff, -1024);
     EXPECT_TRUE(staff1->hideStems);
     EXPECT_FALSE(staff1->hideBeams);
-    EXPECT_EQ(staff1->stemDirection, others::Staff::StemDirection::AlwaysUp);
+    EXPECT_EQ(staff1->stemDirection, StemDirection::AlwaysUp);
     EXPECT_EQ(staff1->autoNumbering, others::Staff::AutoNumberingStyle::ArabicSuffix);
     EXPECT_EQ(staff1->useAutoNumbering, false);
 
@@ -188,7 +188,7 @@ TEST(StaffTest, PopulateFields)
     EXPECT_EQ(staff2->vertTabNumOff, -1024);
     EXPECT_FALSE(staff2->hideStems);
     EXPECT_TRUE(staff2->hideBeams);
-    EXPECT_EQ(staff2->stemDirection, others::Staff::StemDirection::AlwaysDown);
+    EXPECT_EQ(staff2->stemDirection, StemDirection::AlwaysDown);
     EXPECT_EQ(staff2->autoNumbering, others::Staff::AutoNumberingStyle::ArabicPrefix);
     EXPECT_EQ(staff2->fretInstId, 1);
     EXPECT_EQ(staff2->useAutoNumbering, true);
@@ -196,7 +196,7 @@ TEST(StaffTest, PopulateFields)
     auto staff3 = others->get<others::Staff>(SCORE_PARTID, 11);
     ASSERT_TRUE(staff2) << "Staff with cmper 11 not found";
 
-    EXPECT_EQ(staff3->stemDirection, others::Staff::StemDirection::Default);
+    EXPECT_EQ(staff3->stemDirection, StemDirection::Default);
 }
 
 TEST(StaffTest, AutoNumbering)

--- a/tests/others/staff_style.cpp
+++ b/tests/others/staff_style.cpp
@@ -129,7 +129,7 @@ TEST(StaffStyleTest, PopulateFields)
     EXPECT_TRUE(staffStyle->altHideOtherExpressions);
     EXPECT_EQ(staffStyle->topRepeatDotOff, -3);
     EXPECT_EQ(staffStyle->vertTabNumOff, -1024);
-    EXPECT_EQ(staffStyle->stemDirection, others::Staff::StemDirection::AlwaysUp);
+    EXPECT_EQ(staffStyle->stemDirection, StemDirection::AlwaysUp);
     EXPECT_EQ(staffStyle->styleName, "Names and Stems");
     EXPECT_TRUE(staffStyle->addToMenu);
 


### PR DESCRIPTION
- refactor articulation symbol context to separate it from pseudo-tie detection code.
- separated logic is now usable to determine articulation orientation (as well as continuing to be used by pseudo-tie detection).

