### PR TITLE
Use graceIndex to find correct grace note entry

### DIFF
--- a/src/musx/dom/Entries.cpp
+++ b/src/musx/dom/Entries.cpp
@@ -32,6 +32,53 @@
 namespace musx {
 namespace dom {
 
+namespace {
+
+EntryInfoPtr calcNearestEntryInFrame(const EntryFrame& frame, util::Fraction position, bool findExact, MatchVoice matchVoice,
+    const std::function<bool(const EntryInfoPtr&)>& matchesEntry)
+{
+    EntryInfoPtr result;
+    util::Fraction bestDiff = (std::numeric_limits<util::Fraction>::max)();
+
+    auto iterator = [&](const EntryInfoPtr& entryInfo) {
+        if (!matchesEntry(entryInfo)) {
+            return true; // iterate past non-matching entries
+        }
+        const bool entryVoice2 = entryInfo->getEntry()->voice2;
+        bool matchesVoice = true;
+        switch (matchVoice) {
+            case MatchVoice::Any:
+                matchesVoice = true;
+                break;
+            case MatchVoice::Voice1:
+                matchesVoice = !entryVoice2;
+                break;
+            case MatchVoice::Voice2:
+                matchesVoice = entryVoice2;
+                break;
+        }
+        if (!matchesVoice) {
+            return true; // iterate past non-matching v1/v2 values
+        }
+        using std::abs;
+        auto posDiff = abs(position - entryInfo->elapsedDuration);
+        if (posDiff <= util::Fraction::fromEdu(1)) {
+            result = entryInfo;
+            return false; // stop iterating
+        }
+        if (!findExact && posDiff < bestDiff) {
+            bestDiff = posDiff;
+            result = entryInfo;
+        }
+        return true;
+    };
+
+    frame.iterateEntries(iterator);
+    return result;
+}
+
+} // namespace
+
 #ifndef DOXYGEN_SHOULD_IGNORE_THIS
 static bool forVoice2(int voice)
 {
@@ -242,44 +289,9 @@ bool EntryFrame::calcAreAllEntriesHiddenInFrame() const
 
 EntryInfoPtr EntryFrame::calcNearestEntry(util::Fraction position, bool findExact, MatchVoice matchVoice, util::Fraction atGraceNoteDuration) const
 {
-    EntryInfoPtr result;
-    util::Fraction bestDiff = (std::numeric_limits<util::Fraction>::max)();
-
-    auto iterator = [&](const EntryInfoPtr& entryInfo) {
-        if (entryInfo.calcGraceElapsedDuration() != atGraceNoteDuration) {
-            return true; // iterate past non-matching grace notes
-        }
-        const bool entryVoice2 = entryInfo->getEntry()->voice2;
-        bool matchesVoice = true;
-        switch (matchVoice) {
-            case MatchVoice::Any:
-                matchesVoice = true;
-                break;
-            case MatchVoice::Voice1:
-                matchesVoice = !entryVoice2;
-                break;
-            case MatchVoice::Voice2:
-                matchesVoice = entryVoice2;
-                break;
-        }
-        if (!matchesVoice) {
-            return true; // iterate past non-matching v1/v2 values
-        }
-        using std::abs;
-        auto posDiff = abs(position - entryInfo->elapsedDuration);
-        if (posDiff <= util::Fraction::fromEdu(1)) {
-            result = entryInfo;
-            return false; // stop iterating
-        }
-        if (!findExact && posDiff < bestDiff) {
-            bestDiff = posDiff;
-            result = entryInfo;
-        }
-        return true;
-    };
-
-    iterateEntries(iterator);
-    return result;
+    return calcNearestEntryInFrame(*this, position, findExact, matchVoice, [atGraceNoteDuration](const EntryInfoPtr& entryInfo) {
+        return entryInfo.calcGraceElapsedDuration() == atGraceNoteDuration;
+    });
 }
 
 bool EntryFrame::iterateEntries(std::function<bool(const EntryInfoPtr&)> iterator) const
@@ -2102,6 +2114,17 @@ bool EntryInfoPtr::calcIsSingletonGrace() const
     return false;
 }
 
+bool EntryInfoPtr::calcHasGraceNote() const
+{
+    if ((*this)->getEntry()->graceNote) {
+        return false;
+    }
+    if (const auto prev = getPreviousSameV()) {
+        return prev->getEntry()->graceNote;
+    }
+    return false;
+}
+
 int EntryInfoPtr::calcIsAuxiliaryPitchMarker() const
 {
     if (!calcIsSingletonGrace()) {
@@ -2605,13 +2628,29 @@ bool details::GFrameHoldContext::scanCueLayers(bool includeVisibleInScore, std::
 EntryInfoPtr details::GFrameHoldContext::calcNearestEntry(util::Fraction position, bool findExact, std::optional<LayerIndex> matchLayer,
     MatchVoice matchVoice, util::Fraction atGraceNoteDuration) const
 {
+    return calcNearestEntryMatching(position, findExact, matchLayer, matchVoice, [atGraceNoteDuration](const EntryInfoPtr& entryInfo) {
+        return entryInfo.calcGraceElapsedDuration() == atGraceNoteDuration;
+    });
+}
+
+EntryInfoPtr details::GFrameHoldContext::calcNearestEntryAtGraceIndex(util::Fraction position, unsigned graceNoteIndex, bool findExact,
+    std::optional<LayerIndex> matchLayer, MatchVoice matchVoice) const
+{
+    return calcNearestEntryMatching(position, findExact, matchLayer, matchVoice, [graceNoteIndex](const EntryInfoPtr& entryInfo) {
+        return entryInfo->graceIndex == graceNoteIndex;
+    });
+}
+
+EntryInfoPtr details::GFrameHoldContext::calcNearestEntryMatching(util::Fraction position, bool findExact, std::optional<LayerIndex> matchLayer,
+    MatchVoice matchVoice, const std::function<bool(const EntryInfoPtr&)>& matchesEntry) const
+{
     EntryInfoPtr bestResult;
     util::Fraction bestDiff = (std::numeric_limits<util::Fraction>::max)();
 
     LayerIndex startLayer = matchLayer.value_or(0);
     for (LayerIndex layerIndex = startLayer; layerIndex < m_hold->frames.size(); layerIndex++) {
         if (auto entryFrame = createEntryFrame(layerIndex)) {
-            if (auto result = entryFrame->calcNearestEntry(position, findExact, matchVoice, atGraceNoteDuration)) {
+            if (auto result = calcNearestEntryInFrame(*entryFrame, position, findExact, matchVoice, matchesEntry)) {
                 if (findExact) {
                     return result;
                 }

--- a/src/musx/dom/Entries.h
+++ b/src/musx/dom/Entries.h
@@ -204,6 +204,18 @@ public:
     EntryInfoPtr calcNearestEntry(util::Fraction position, bool findExact = true, std::optional<LayerIndex> matchLayer = std::nullopt,
         MatchVoice matchVoice = MatchVoice::Any, util::Fraction atGraceNoteDuration = 0) const;
 
+    /// @brief Calculates the nearest entry at the given @p position and @p graceNoteIndex.
+    /// @param position The measure position to find.
+    /// @param graceNoteIndex The Finale grace note index to match, counting from 1 starting from the leftmost grace note.
+    /// @param findExact If true, only find an entry that matches to within 1 evpu. Otherwise find the closest entry in the measure.
+    /// @param matchLayer If specified, only find entries in this 0-based layer index. (Values 0..3)
+    /// @param matchVoice Determines which voice(s) are candidates. Use #MatchVoice::Any (the default) to accept either voice,
+    /// #MatchVoice::Voice1 for voice 1 only, or #MatchVoice::Voice2 for voice 2 only.
+    /// @return The entry if found, otherwise `nullptr`.
+    [[nodiscard]]
+    EntryInfoPtr calcNearestEntryAtGraceIndex(util::Fraction position, unsigned graceNoteIndex, bool findExact = true,
+        std::optional<LayerIndex> matchLayer = std::nullopt, MatchVoice matchVoice = MatchVoice::Any) const;
+
     /// @brief Snaps a measure position to the nearest entry if possible.
     /// @param location The measure location to snap.
     /// @param findExact If true, only snap to an entry that matches to within 1 evpu.
@@ -241,6 +253,9 @@ private:
     /// @brief Scans non-rest content layers and calls @p visitor with whether each layer is a cue layer.
     /// @return true if all content layers were scanned, false if @p visitor stopped the scan.
     bool scanCueLayers(bool includeVisibleInScore, std::function<bool(LayerIndex, bool)> visitor) const;
+
+    EntryInfoPtr calcNearestEntryMatching(util::Fraction position, bool findExact, std::optional<LayerIndex> matchLayer,
+        MatchVoice matchVoice, const std::function<bool(const EntryInfoPtr&)>& matchesEntry) const;
 
     MusxInstance<GFrameHold> m_hold;                    ///< The resolved GFrameHold object, or null if not found.
     Cmper m_requestedPartId{};                          ///< The requested part context.
@@ -943,6 +958,9 @@ public:
 
     /// @brief Return true if this entry is a grace note and the only grace in the sequence at this location.
     [[nodiscard]] bool calcIsSingletonGrace() const;
+
+    /// @brief Return true if this entry is a main note with one or more grace notes.
+    [[nodiscard]] bool calcHasGraceNote() const;
 
     /// @brief Return true if this entry is an auxiliary pitch marker (specifically, a trill-to or gliss-to pitch marker.)
     ///

--- a/src/musx/dom/Others.cpp
+++ b/src/musx/dom/Others.cpp
@@ -383,6 +383,12 @@ std::optional<HorizontalMeasExprAlign> MeasureExprAssign::calcEntryAlignmentType
 
 EntryInfoPtr MeasureExprAssign::calcAssociatedEntry() const
 {
+    // Finale at least sometimes uses large sentinel-like values for graceNoteIndex
+    // at the end of measures that end with grace notes. kMaxExpectedGraceNoteIndex
+    // allows us to treat such values as a main note (by converting them to 0) and
+    // not find any trailing grace note as an associated entry.
+    constexpr unsigned kMaxExpectedGraceNoteIndex = 0x3fff;
+
     constexpr bool findExact = true;
     if (staffAssign > 0) {
         if (!calcEntryAlignmentType()) {
@@ -391,7 +397,20 @@ EntryInfoPtr MeasureExprAssign::calcAssociatedEntry() const
         if (auto gfHold = details::GFrameHoldContext(getDocument(), getRequestedPartId(), staffAssign, getCmper())) {
             const auto matchLayer = layer ? std::make_optional(LayerIndex(layer - 1)) : std::nullopt;
             const auto matchVoice = voice2 ? MatchVoice::Voice2 : MatchVoice::Voice1;
-            return gfHold.calcNearestEntry(util::Fraction::fromEdu(eduPosition), findExact, matchLayer, matchVoice);
+            const auto position = util::Fraction::fromEdu(eduPosition);
+            const auto graceIndex = this->graceNoteIndex <= kMaxExpectedGraceNoteIndex ? this->graceNoteIndex : 0u;
+            if (const auto result = gfHold.calcNearestEntryAtGraceIndex(position, graceIndex, findExact, matchLayer, matchVoice)) {
+                return result;
+            }
+            if (graceIndex > 0) {
+                if (const auto mainEntry = gfHold.calcNearestEntry(position, findExact, matchLayer, matchVoice)) {
+                    util::Logger::log(util::Logger::LogLevel::Info,
+                        "Dangling graceNoteIndex " + std::to_string(this->graceNoteIndex) +
+                        " on expression assignment in measure " + std::to_string(getCmper()) +
+                        ". Falling back to the main entry.");
+                    return mainEntry;
+                }
+            }
         }
     }
     return {};

--- a/src/musx/dom/Others.h
+++ b/src/musx/dom/Others.h
@@ -1371,7 +1371,7 @@ public:
     Cmper textExprId{};                     ///< The @ref Cmper of a text expression (xml node is `<textExprID>`)
     Cmper shapeExprId{};                    ///< The @ref Cmper of a shape expression (xml node is `<shapeExprID>`)
     Evpu horzEvpuOff{};                     ///< Horizontal Evpu offset from the default position.
-    Edu eduPosition{};                      ///< Horizontal Edu position (xml node is `<horzEduOff>`)
+    Edu eduPosition{};                      ///< Horizontal Edu position in staff edu (xml node is `<horzEduOff>`)
     Evpu vertEvpuOff{};                     ///< Vertical Evpu offset from the default position (xml node is `<vertOff>`)
     StaffCmper staffAssign{};               ///< The staff to which this expression is assigned, or -1 if it is assigned to top staff and -2 if assigned to bottom staff.
     int layer{};                            ///< The 1-based layer number (1..4) to which this expression is assigned. (0 = all layers.)
@@ -1387,7 +1387,7 @@ public:
     int staffGroup{};                       ///< Assignment is part of a group of assignments associated with a staff list and should be modified as a group.
     Cmper staffList{};                      ///< The cmper of the marking category staff list that is controlling this assignment (if any).
                                             ///< There will be a separate #MeasureExprAssign instance for every staff in the staff list.
-    int graceNoteIndex{};                   ///< 1-based index from leftmost grace note. 0 = main note.
+    unsigned graceNoteIndex{};              ///< 1-based index from leftmost grace note. 0 = main note.
     int rehearsalMarkOffset{};              ///< Restarts the rehearsal mark sequence at this 1-based sequence value. If this is zero, the sequence continues normally.
 
     /// @brief Returns true if this shape expression is likely acting as a pseudo tie for the specified mode.

--- a/src/musx/factory/FieldPopulatorsOthers.cpp
+++ b/src/musx/factory/FieldPopulatorsOthers.cpp
@@ -815,7 +815,7 @@ MUSX_XML_ELEMENT_ARRAY(MeasureExprAssign, {
     {"hidden", [](const XmlElementPtr& e, const std::shared_ptr<MeasureExprAssign>& i) { i->hidden = populateBoolean(e, i); }},
     {"staffGroup", [](const XmlElementPtr& e, const std::shared_ptr<MeasureExprAssign>& i) { i->staffGroup = e->getTextAs<int>(); }},
     {"staffList", [](const XmlElementPtr& e, const std::shared_ptr<MeasureExprAssign>& i) { i->staffList = e->getTextAs<Cmper>(); }},
-    {"graceNoteIndex", [](const XmlElementPtr& e, const std::shared_ptr<MeasureExprAssign>& i) { i->graceNoteIndex = e->getTextAs<int>(); }},
+    {"graceNoteIndex", [](const XmlElementPtr& e, const std::shared_ptr<MeasureExprAssign>& i) { i->graceNoteIndex = e->getTextAs<unsigned>(); }},
     {"rehearsalMarkOffset", [](const XmlElementPtr& e, const std::shared_ptr<MeasureExprAssign>& i) { i->rehearsalMarkOffset = e->getTextAs<int>(); }},
 });
 

--- a/tests/others/expression.cpp
+++ b/tests/others/expression.cpp
@@ -573,6 +573,28 @@ TEST(ExpressionAssignments, CalcAssociatedEntry)
     }
 }
 
+TEST(ExpressionAssignments, CalcAssociatedGraceEntry)
+{
+    std::vector<char> xml;
+    musxtest::readFile(musxtest::getInputPath() / "grace_notes.enigmaxml", xml);
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::pugi::Document>(xml);
+    ASSERT_TRUE(doc);
+
+    auto others = doc->getOthers();
+    ASSERT_TRUE(others);
+
+    auto expr = others->get<others::MeasureExprAssign>(SCORE_PARTID, 1, 0);
+    ASSERT_TRUE(expr);
+    ASSERT_EQ(expr->graceNoteIndex, 3u);
+
+    auto entryInfo = expr->calcAssociatedEntry();
+    ASSERT_TRUE(entryInfo);
+    EXPECT_TRUE(entryInfo->getEntry()->graceNote);
+    EXPECT_EQ(entryInfo->graceIndex, 3);
+    EXPECT_EQ(entryInfo->elapsedDuration, musx::util::Fraction::fromEdu(2048));
+    EXPECT_EQ(entryInfo->getEntry()->getEntryNumber(), 7);
+}
+
 TEST(ExpressionAssignments, Voice2Entries)
 {
     std::vector<char> xml;


### PR DESCRIPTION
Enhance `MeasureExprAssign::calcAssociatedEntry` to find grace notes by `graceNoteIndex`.