### PR TITLE
Helper functions

### DIFF
--- a/src/musx/dom/CommonClasses.cpp
+++ b/src/musx/dom/CommonClasses.cpp
@@ -63,19 +63,15 @@ static bool looksLikeSmuflDefaultMusicFont(const FontInfo& fontInfo)
         return false;
     }
 
-    const auto sameFontFace = [](const FontInfo& lhs, const FontInfo& rhs) {
-        return lhs.fontId == rhs.fontId || lhs.getName() == rhs.getName();
-    };
-
     const auto defaultMusicFontIt = fontOptions->fontOptions.find(options::FontOptions::FontType::Music);
     if (defaultMusicFontIt == fontOptions->fontOptions.end() || !defaultMusicFontIt->second
-        || !sameFontFace(fontInfo, *defaultMusicFontIt->second)) {
+        || !fontInfo.calcIsSameTypeface(*defaultMusicFontIt->second)) {
         return false;
     }
 
     const auto categoryUsesCandidateFont = [&](options::FontOptions::FontType type) {
         const auto it = fontOptions->fontOptions.find(type);
-        return it != fontOptions->fontOptions.end() && it->second && sameFontFace(fontInfo, *it->second);
+        return it != fontOptions->fontOptions.end() && it->second && fontInfo.calcIsSameTypeface(*it->second);
     };
 
     size_t matches{};
@@ -118,6 +114,25 @@ void FontInfo::setFontIdByName(const std::string& name)
         }
     }
     throw std::invalid_argument("font definition not found for font \"" + name + "\"");
+}
+
+bool FontInfo::calcIsSameTypeface(const FontInfo& src) const
+{
+    if (fontId == src.fontId) {
+        return true;
+    }
+    // The default music font is the only font duplicated by design, so it is the only case where
+    // differing ids can still name the same typeface.
+    if (!calcIsDefaultMusic() && !src.calcIsDefaultMusic()) {
+        return false;
+    }
+    return getName() == src.getName();
+}
+
+bool FontInfo::isSame(const FontInfo& src) const
+{
+    return calcIsSameTypeface(src) && fontSize == src.fontSize && m_sizeIsPercent == src.m_sizeIsPercent
+        && getEnigmaStyles() == src.getEnigmaStyles();
 }
 
 std::optional<std::filesystem::path> FontInfo::calcSMuFLMetaDataPath(const std::string& fontName)

--- a/src/musx/dom/CommonClasses.h
+++ b/src/musx/dom/CommonClasses.h
@@ -85,13 +85,31 @@ public:
     bool absolute{};    ///< Fixed size effect.
     bool hidden{};      ///< Hidden effect.
 
-    /// @brief Return true if the two fonts represent the same font.
+    /// @brief Return true if the two fonts specify the same typeface, ignoring size and effects.
+    ///
+    /// A #fontId of 0 is the document's default music font. Finale rewrites that
+    /// @ref others::FontDefinition's name whenever the default music font changes, so anything
+    /// storing id 0 follows the change while a concrete id keeps whatever typeface it was set to.
+    /// The same typeface therefore routinely appears under both id 0 and a concrete id, and those
+    /// compare equal here by name.
+    ///
+    /// Two distinct non-zero ids are never compared by name. The default music font is the only
+    /// font duplicated by design, so duplicate names elsewhere indicate a malformed document.
+    ///
     /// @param src The input font to compare with.
-    bool isSame(const FontInfo& src) const
-    {
-        return fontId == src.fontId && fontSize == src.fontSize && m_sizeIsPercent == src.m_sizeIsPercent
-            && getEnigmaStyles() == src.getEnigmaStyles();
-    }
+    /// @throws std::invalid_argument if either font id has no @ref others::FontDefinition.
+    bool calcIsSameTypeface(const FontInfo& src) const;
+
+    /// @brief Return true if the two fonts represent the same font.
+    ///
+    /// Compares typeface (see #calcIsSameTypeface), size, and style effects. To distinguish a
+    /// #fontId of 0 from the concrete id naming the same typeface - which matters only when the
+    /// source encoding itself is the subject, such as round-tripping, or reporting that a font
+    /// option pins a concrete font instead of following the document default - compare #fontId
+    /// directly.
+    ///
+    /// @param src The input font to compare with.
+    bool isSame(const FontInfo& src) const;
 
     /// @brief If true, the size of this font is calculated as a percent of the preceding font size (in an Enigma string)
     bool getSizeIsPercent() const { return m_sizeIsPercent; }

--- a/src/musx/dom/Others.cpp
+++ b/src/musx/dom/Others.cpp
@@ -935,6 +935,15 @@ std::optional<int> MeasureNumberRegion::calcLastDisplayNumber() const
     return std::nullopt;
 }
 
+// ****************************
+// ***** MultimeasureRest *****
+// ****************************
+
+bool MultimeasureRest::calcUsesSymbols() const
+{
+    return useSymbols && calcNumberOfMeasures() < symbolThreshold;
+}
+
 // *************************************
 // ***** MultiStaffInstrumentGroup *****
 // *************************************

--- a/src/musx/dom/Others.h
+++ b/src/musx/dom/Others.h
@@ -1690,6 +1690,9 @@ public:
     /// @brief Calculates the number of measures spanned by this multimeasure rest
     int calcNumberOfMeasures() const { return (std::max)(nextMeas - getStartMeasure(), 0); }
 
+    /// @brief Calculates whether rest symbols are used instead of the multimeasure rest shape.
+    bool calcUsesSymbols() const;
+
     /// @brief Calculates if the number on this multimeasure rest is visible.
     bool calcIsNumberVisible() const { return calcNumberOfMeasures() >= numStart; }
 

--- a/tests/others/fonts.cpp
+++ b/tests/others/fonts.cpp
@@ -201,3 +201,101 @@ TEST(FontTest, ChangingFontIdUsesSeparateSmuflCacheEntry)
 
     EXPECT_TRUE(fontInfo->calcIsSMuFL());
 }
+
+constexpr static musxtest::string_view defaultMusicFontProperties = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+  <others>
+    <fontName cmper="0">
+      <charsetBank>Mac</charsetBank>
+      <charsetVal>4095</charsetVal>
+      <pitch>0</pitch>
+      <family>0</family>
+      <name>Finale Maestro</name>
+    </fontName>
+    <fontName cmper="12">
+      <charsetBank>Mac</charsetBank>
+      <charsetVal>4095</charsetVal>
+      <pitch>0</pitch>
+      <family>0</family>
+      <name>Maestro</name>
+    </fontName>
+    <fontName cmper="13">
+      <charsetBank>Mac</charsetBank>
+      <charsetVal>4095</charsetVal>
+      <pitch>0</pitch>
+      <family>0</family>
+      <name>Finale Maestro</name>
+    </fontName>
+  </others>
+</finale>
+    )xml";
+
+TEST(FontTest, SameTypefaceMatchesDefaultMusicFontIdWithConcreteId)
+{
+    // Font id 0 is the default music font. The same typeface also exists under a concrete id, which
+    // is how Finale records a font option that was set explicitly rather than left on the default.
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(defaultMusicFontProperties);
+
+    auto defaultMusic = std::make_shared<FontInfo>(doc);
+    defaultMusic->fontId = 0;
+    auto concrete = std::make_shared<FontInfo>(doc);
+    concrete->fontId = 13;
+
+    EXPECT_TRUE(defaultMusic->calcIsSameTypeface(*concrete));
+    EXPECT_TRUE(concrete->calcIsSameTypeface(*defaultMusic));
+}
+
+TEST(FontTest, SameTypefaceRejectsFontPinnedToADifferentTypeface)
+{
+    // A font option pinned to legacy Maestro keeps that typeface after the document default music
+    // font is changed to Finale Maestro.
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(defaultMusicFontProperties);
+
+    auto defaultMusic = std::make_shared<FontInfo>(doc);
+    defaultMusic->fontId = 0;
+    auto pinned = std::make_shared<FontInfo>(doc);
+    pinned->fontId = 12;
+
+    EXPECT_FALSE(defaultMusic->calcIsSameTypeface(*pinned));
+}
+
+TEST(FontTest, IsSameComparesTypefaceSizeAndEffects)
+{
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(defaultMusicFontProperties);
+
+    auto defaultMusic = std::make_shared<FontInfo>(doc);
+    defaultMusic->fontId = 0;
+    defaultMusic->fontSize = 24;
+
+    auto concrete = std::make_shared<FontInfo>(doc);
+    concrete->fontId = 13;
+    concrete->fontSize = 24;
+
+    EXPECT_TRUE(defaultMusic->isSame(*concrete));
+
+    concrete->fontSize = 18;
+    EXPECT_FALSE(defaultMusic->isSame(*concrete));
+
+    concrete->fontSize = 24;
+    concrete->bold = true;
+    EXPECT_FALSE(defaultMusic->isSame(*concrete));
+}
+
+TEST(FontTest, SameTypefaceDoesNotCompareNamesOfTwoConcreteIds)
+{
+    // Only the default music font is duplicated by design. Two distinct non-zero ids that happen to
+    // share a name indicate a malformed document and are not treated as the same typeface.
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(unknownSmuflFontProperties);
+
+    // Ids 0 and 2 both name "Unknown SMuFL Font"; id 1 names a different font.
+    auto sentinel = std::make_shared<FontInfo>(doc);
+    sentinel->fontId = 0;
+    auto duplicate = std::make_shared<FontInfo>(doc);
+    duplicate->fontId = 2;
+    auto other = std::make_shared<FontInfo>(doc);
+    other->fontId = 1;
+
+    EXPECT_TRUE(sentinel->calcIsSameTypeface(*duplicate));
+    EXPECT_FALSE(other->calcIsSameTypeface(*duplicate));
+}

--- a/tests/others/mmrest.cpp
+++ b/tests/others/mmrest.cpp
@@ -69,6 +69,25 @@ TEST(MultimeasureRestTest, PopulateFields)
     EXPECT_TRUE(mmRest->useSymbols);
 }
 
+TEST(MultimeasureRestTest, CalculatesUseSymbols)
+{
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::pugi::Document>(mmRestXml);
+    auto mmRest = std::make_shared<others::MultimeasureRest>(
+        doc, 1, EnigmaBase::ShareMode::None, 27);
+    mmRest->nextMeas = 32;
+    mmRest->symbolThreshold = 2;
+    mmRest->useSymbols = true;
+
+    EXPECT_FALSE(mmRest->calcUsesSymbols());
+    mmRest->symbolThreshold = 6;
+    EXPECT_TRUE(mmRest->calcUsesSymbols());
+    mmRest->symbolThreshold = mmRest->calcNumberOfMeasures();
+    EXPECT_FALSE(mmRest->calcUsesSymbols());
+    mmRest->useSymbols = false;
+    mmRest->symbolThreshold = 6;
+    EXPECT_FALSE(mmRest->calcUsesSymbols());
+}
+
 
 TEST(MultimeasureRestTest, IntegrityCheckFailure)
 {


### PR DESCRIPTION
- helper to determine if a multimeasure rests uses symbols rather than the multimeasure rest shape (usually an H-bar)
- loosen `FontInfo::isSame` to match the Default Music Font with its "real" counterpart (by name).
- added `FontInfo::calcIsSameTypeface` to handle detect when Default Music Font and real font are the same.
