### PR TITLE
Preserve nested data in partially shared part records

### DIFF
--- a/src/musx/dom/BaseClasses.h
+++ b/src/musx/dom/BaseClasses.h
@@ -53,6 +53,12 @@ public:
 };
 
 #ifndef DOXYGEN_SHOULD_IGNORE_THIS
+template <typename T>
+struct PartContextRebinder
+{
+    static void rebind(const std::shared_ptr<T>&) {}
+};
+
 class PartContextCloner {
 public:
     template <typename T>
@@ -66,6 +72,7 @@ public:
     {
         auto result = std::make_shared<T>(*obj);
         setRequestedPartId(result, partId);
+        PartContextRebinder<T>::rebind(result);
         return result;
     }
 };
@@ -184,6 +191,29 @@ protected:
 class ContainedClassBase : public EnigmaBase
 {
     Cmper getSourcePartId() const = delete; ///< meaningless for this base class (always SCORE_PARTID)
+
+protected:
+    // A shallow copy of an owning OthersBase or DetailsBase leaves contained objects parented to
+    // the source instance. If that distinction matters, the owner must use PartContextRebinder.
+    // PartContextRebinder<details::CenterShape> is a simple example.
+
+    /// @brief Assignment preserves the destination's parent while allowing subclasses to copy their values.
+    ContainedClassBase& operator=(const ContainedClassBase& other)
+    {
+        if (this != &other) {
+            this->EnigmaBase::operator=(other);
+        }
+        return *this;
+    }
+
+    /// @brief Move assignment preserves the destination's parent while allowing subclasses to move their values.
+    ContainedClassBase& operator=(ContainedClassBase&& other) noexcept
+    {
+        if (this != &other) {
+            this->EnigmaBase::operator=(std::move(other));
+        }
+        return *this;
+    }
 
 public:
     /**

--- a/src/musx/dom/Details.cpp
+++ b/src/musx/dom/Details.cpp
@@ -31,6 +31,15 @@
 namespace musx {
 namespace dom {
 
+void PartContextRebinder<details::MeasureNumberIndividualPositioning>::rebind(
+    const std::shared_ptr<details::MeasureNumberIndividualPositioning>& positioning)
+{
+    if (positioning->enclosure) {
+        positioning->enclosure = PartContextCloner::copyWithPartId<others::Enclosure>(
+            positioning->enclosure, positioning->getRequestedPartId());
+    }
+}
+
 // ****************************
 // ***** EntryDetailsBase *****
 // ****************************

--- a/src/musx/dom/Details.h
+++ b/src/musx/dom/Details.h
@@ -1444,8 +1444,8 @@ public:
     /**
      * @brief Constructor
      * @param document A weak pointer to the associated document.
-     * @param partId The part that this is for (probably always 0).
-     * @param shareMode The sharing mode for this #MeasureNumberIndividualPositioning (probably always #ShareMode::All).
+     * @param partId The source part for this instance.
+     * @param shareMode The sharing mode for this #MeasureNumberIndividualPositioning.
      * @param staffId The staff ID for this instance.
      * @param meas The measure ID for this instance.
      * @param inci The 0-based incident.
@@ -2278,5 +2278,14 @@ public:
 };
 
 } // namespace details
+
+#ifndef DOXYGEN_SHOULD_IGNORE_THIS
+template <>
+struct PartContextRebinder<details::MeasureNumberIndividualPositioning>
+{
+    static void rebind(const std::shared_ptr<details::MeasureNumberIndividualPositioning>& positioning);
+};
+#endif
+
 } // namespace dom
 } // namespace entries

--- a/src/musx/dom/ObjectPool.h
+++ b/src/musx/dom/ObjectPool.h
@@ -513,7 +513,6 @@ class DetailsPool
 public:
     /// @brief Constructor
     DetailsPool(const DocumentWeakPtr& document) : m_pool(document, {
-        { details::CenterShape::XmlNodeName, EnigmaBase::ShareMode::None },
         { details::StaffGroup::XmlNodeName, EnigmaBase::ShareMode::None },
         { details::StaffSize::XmlNodeName, EnigmaBase::ShareMode::None },
         // add other known sharemode none items as they are identified.

--- a/src/musx/dom/Others.h
+++ b/src/musx/dom/Others.h
@@ -1574,6 +1574,10 @@ public:
         static const xml::XmlElementArray<ScorePartData>& xmlMappingArray(); ///< Required for musx::factory::FieldPopulator.
     };
 
+    // No fixture has a part-specific MeasureNumberRegion. If partial sharing is observed,
+    // scoreData and partData must be copied and rebound before their nested fields are overlaid.
+    // See PartContextRebinder<details::CenterShape> and the CenterShape field mappings for the pattern.
+
     // Public properties
     std::shared_ptr<ScorePartData> scoreData; ///< Score-wide measure number data.
     std::shared_ptr<ScorePartData> partData;  ///< Part-specific measure number data.

--- a/src/musx/dom/SmartShape.cpp
+++ b/src/musx/dom/SmartShape.cpp
@@ -28,6 +28,51 @@
 namespace musx {
 namespace dom {
 
+namespace {
+
+template <typename T, typename Parent>
+std::shared_ptr<T> copyContained(
+    const std::shared_ptr<T>& source, const std::shared_ptr<Parent>& parent)
+{
+    if (!source) {
+        return nullptr;
+    }
+    auto result = std::make_shared<T>(parent);
+    *result = *source;
+    return result;
+}
+
+} // namespace
+
+std::shared_ptr<others::SmartShape::TerminationSeg> PartContextRebinder<others::SmartShape>::copyTerminationSeg(
+    const std::shared_ptr<others::SmartShape::TerminationSeg>& source,
+    const std::shared_ptr<others::SmartShape>& parent)
+{
+    auto result = std::make_shared<others::SmartShape::TerminationSeg>(parent);
+    if (source) {
+        *result = *source;
+        result->endPoint = copyContained(source->endPoint, parent);
+        result->endPointAdj = copyContained(source->endPointAdj, parent);
+        result->ctlPtAdj = copyContained(source->ctlPtAdj, parent);
+        result->breakAdj = copyContained(source->breakAdj, parent);
+    }
+    return result;
+}
+
+void PartContextRebinder<others::SmartShape>::rebind(const std::shared_ptr<others::SmartShape>& shape)
+{
+    shape->startTermSeg = copyTerminationSeg(shape->startTermSeg, shape);
+    shape->endTermSeg = copyTerminationSeg(shape->endTermSeg, shape);
+    shape->fullCtlPtAdj = copyContained(shape->fullCtlPtAdj, shape);
+}
+
+void PartContextRebinder<details::CenterShape>::rebind(const std::shared_ptr<details::CenterShape>& shape)
+{
+    shape->startBreakAdj = copyContained(shape->startBreakAdj, shape);
+    shape->endBreakAdj = copyContained(shape->endBreakAdj, shape);
+    shape->ctlPtAdj = copyContained(shape->ctlPtAdj, shape);
+}
+
 // ********************
 // ***** EndPoint *****
 // ********************

--- a/src/musx/dom/SmartShape.h
+++ b/src/musx/dom/SmartShape.h
@@ -534,6 +534,9 @@ public:
     };
 
     LineStyle lineStyle{};                                ///< Line style
+    // No fixture has a part-specific SmartShapeCustomLine. If partial sharing is observed, its
+    // applicable parameter object must be copied and rebound before nested fields are overlaid.
+    // See PartContextRebinder<details::CenterShape> and the CenterShape field mappings for the pattern.
     std::shared_ptr<CharParams> charParams;               ///< Parameters for char line style. Only allocated if lineStyle is LineStyle::Char.
     std::shared_ptr<SolidParams> solidParams;             ///< Parameters for solid line style. Only allocated if lineStyle is LineStyle::Solid.
     std::shared_ptr<DashedParams> dashedParams;           ///< Parameters for dashed line style. Only allocated if lineStyle is LineStyle::Dashed.
@@ -662,6 +665,17 @@ public:
 
 } // namespace others
 
+#ifndef DOXYGEN_SHOULD_IGNORE_THIS
+template <>
+struct PartContextRebinder<others::SmartShape>
+{
+    static std::shared_ptr<others::SmartShape::TerminationSeg> copyTerminationSeg(
+        const std::shared_ptr<others::SmartShape::TerminationSeg>& source,
+        const std::shared_ptr<others::SmartShape>& parent);
+    static void rebind(const std::shared_ptr<others::SmartShape>& shape);
+};
+#endif
+
 namespace details {
 
 /**
@@ -738,6 +752,14 @@ public:
 };
 
 } // namespace details
+
+#ifndef DOXYGEN_SHOULD_IGNORE_THIS
+template <>
+struct PartContextRebinder<details::CenterShape>
+{
+    static void rebind(const std::shared_ptr<details::CenterShape>& shape);
+};
+#endif
 
 } // namespace dom
 } // namespace musx

--- a/src/musx/dom/Staff.h
+++ b/src/musx/dom/Staff.h
@@ -198,6 +198,9 @@ public:
     bool hasStyles{};               ///< Indicates that this staff has staff style assignments
     bool showNameInParts{};         ///< "Display Staff Name in Parts" (xml node is `<showNameParts>`)
     bool showNoteColors{};          ///< "Color Noteheads" (Score Manager)
+    // No fixture has a partially shared Staff (part-specific staffSpec records are fully unshared).
+    // If one is found, Transposition must be copied and rebound before overlaying its nested fields.
+    // See PartContextRebinder<details::CenterShape> and the CenterShape field mappings for the pattern.
     std::shared_ptr<Transposition> transposition; ///< Transposition details, if non-null.
     bool hideNameInScore{};         ///< Inverse of "Display Staff Name in Score" (xml node is `<hideStfNameInScore>`)
     Evpu botBarlineOffset{};        ///< Offset for the bottom barline.
@@ -631,6 +634,9 @@ public:
     std::string styleName;              ///< name of staff style
     bool copyable{};                    ///< whether the staff style assignments for this style should be copied when copy/pasting music
     bool addToMenu{};                   ///< add this staff style to the context menu for staff styles
+    // No fixture has a part-specific StaffStyle. If partial sharing is observed, both Masks and the
+    // inherited Transposition will need part-context rebinding and copy-overlay population.
+    // See PartContextRebinder<details::CenterShape> and the CenterShape field mappings for the pattern.
     std::shared_ptr<Masks> masks;       ///< override masks: guaranteed to exist by #integrityCheck, which is called by the factory
                                         ///< (xml node is `<mask>`)
 

--- a/src/musx/factory/FactoryBase.h
+++ b/src/musx/factory/FactoryBase.h
@@ -321,6 +321,18 @@ struct FieldPopulator : public FactoryBase
        return FieldPopulator<T>::createAndPopulateImpl(element, std::forward<Args>(args)...);
     }
 
+    /// @brief Populates an existing contained instance, or creates it first if it does not exist.
+    template <typename... Args>
+    static std::shared_ptr<T> populateExistingOrCreate(
+        const XmlElementPtr& element, std::shared_ptr<T> instance, Args&&... args)
+    {
+        if (!instance) {
+            instance = std::make_shared<T>(std::forward<Args>(args)...);
+        }
+        FieldPopulator<T>::populate(instance, element);
+        return instance;
+    }
+
 private:
     static const std::unordered_map<std::string_view, XmlElementPopulator<T>>& elementXref()
     {

--- a/src/musx/factory/FieldPopulatorsDetails.cpp
+++ b/src/musx/factory/FieldPopulatorsDetails.cpp
@@ -186,11 +186,11 @@ MUSX_XML_ELEMENT_ARRAY(Bracket, {
 
 MUSX_XML_ELEMENT_ARRAY(CenterShape, {
     {"startBreakAdj", [](const XmlElementPtr& e, const std::shared_ptr<CenterShape>& i)
-        { i->startBreakAdj = FieldPopulator<smartshape::EndPointAdjustment>::createAndPopulate(e, i); }},
+        { i->startBreakAdj = FieldPopulator<smartshape::EndPointAdjustment>::populateExistingOrCreate(e, i->startBreakAdj, i); }},
     {"endBreakAdj", [](const XmlElementPtr& e, const std::shared_ptr<CenterShape>& i)
-        { i->endBreakAdj = FieldPopulator<smartshape::EndPointAdjustment>::createAndPopulate(e, i); }},
+        { i->endBreakAdj = FieldPopulator<smartshape::EndPointAdjustment>::populateExistingOrCreate(e, i->endBreakAdj, i); }},
     {"ctlPtAdj", [](const XmlElementPtr& e, const std::shared_ptr<CenterShape>& i)
-        { i->ctlPtAdj = FieldPopulator<smartshape::ControlPointAdjustment>::createAndPopulate(e, i); }},
+        { i->ctlPtAdj = FieldPopulator<smartshape::ControlPointAdjustment>::populateExistingOrCreate(e, i->ctlPtAdj, i); }},
 });
 
 MUSX_XML_ELEMENT_ARRAY(ChordAssign, {
@@ -365,7 +365,7 @@ MUSX_XML_ELEMENT_ARRAY(MeasureNumberIndividualPositioning, {
         { i->forceVisibility = toEnum<MeasureNumberIndividualPositioning::ForceVisibility>(e); }},
     {"useEncl", [](const XmlElementPtr& e, const std::shared_ptr<MeasureNumberIndividualPositioning>& i) { i->useEnclosure = populateBoolean(e, i); }},
     {"encl", [](const XmlElementPtr& e, const std::shared_ptr<MeasureNumberIndividualPositioning>& i)
-        { i->enclosure = FieldPopulator<others::Enclosure>::createAndPopulate(e, i->getDocument()); }}
+        { i->enclosure = FieldPopulator<others::Enclosure>::populateExistingOrCreate(e, i->enclosure, i->getDocument()); }}
 });
 
 MUSX_XML_ELEMENT_ARRAY(MeasureOssiaAssign, {

--- a/src/musx/factory/FieldPopulatorsOthers.cpp
+++ b/src/musx/factory/FieldPopulatorsOthers.cpp
@@ -1176,13 +1176,13 @@ MUSX_XML_ELEMENT_ARRAY(ShapeInstructionList, {
 
 MUSX_XML_ELEMENT_ARRAY(SmartShape::TerminationSeg, {
     {"endPt", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape::TerminationSeg>& i)
-        { i->endPoint = FieldPopulator<smartshape::EndPoint>::createAndPopulate(e, i->getParent()); }},
+        { i->endPoint = FieldPopulator<smartshape::EndPoint>::populateExistingOrCreate(e, i->endPoint, i->getParent()); }},
     {"endPtAdj", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape::TerminationSeg>& i)
-        { i->endPointAdj = FieldPopulator<smartshape::EndPointAdjustment>::createAndPopulate(e, i->getParent()); }},
+        { i->endPointAdj = FieldPopulator<smartshape::EndPointAdjustment>::populateExistingOrCreate(e, i->endPointAdj, i->getParent()); }},
     {"ctlPtAdj", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape::TerminationSeg>& i)
-        { i->ctlPtAdj = FieldPopulator<smartshape::ControlPointAdjustment>::createAndPopulate(e, i->getParent()); }},
+        { i->ctlPtAdj = FieldPopulator<smartshape::ControlPointAdjustment>::populateExistingOrCreate(e, i->ctlPtAdj, i->getParent()); }},
     {"breakAdj", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape::TerminationSeg>& i)
-        { i->breakAdj = FieldPopulator<smartshape::EndPointAdjustment>::createAndPopulate(e, i->getParent()); }},
+        { i->breakAdj = FieldPopulator<smartshape::EndPointAdjustment>::populateExistingOrCreate(e, i->breakAdj, i->getParent()); }},
 });
 
 MUSX_XML_ELEMENT_ARRAY(SmartShape, {
@@ -1197,11 +1197,11 @@ MUSX_XML_ELEMENT_ARRAY(SmartShape, {
     {"slurAvoidAcciState", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape>& i) { i->slurAvoidAcciState = toEnum<SmartShape::SlurAvoidAccidentalsState>(e); }},
     {"yBreakType", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape>& i) { i->yBreakType = toEnum<SmartShape::SystemBreakType>(e); }},
     {"startTermSeg", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape>& i)
-        { i->startTermSeg = FieldPopulator<SmartShape::TerminationSeg>::createAndPopulate(e, i); }},
+        { i->startTermSeg = FieldPopulator<SmartShape::TerminationSeg>::populateExistingOrCreate(e, i->startTermSeg, i); }},
     {"endTermSeg", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape>& i)
-        { i->endTermSeg = FieldPopulator<SmartShape::TerminationSeg>::createAndPopulate(e, i); }},
+        { i->endTermSeg = FieldPopulator<SmartShape::TerminationSeg>::populateExistingOrCreate(e, i->endTermSeg, i); }},
     {"fullCtlPtAdj", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape>& i)
-        { i->fullCtlPtAdj = FieldPopulator<smartshape::ControlPointAdjustment>::createAndPopulate(e, i); }},
+        { i->fullCtlPtAdj = FieldPopulator<smartshape::ControlPointAdjustment>::populateExistingOrCreate(e, i->fullCtlPtAdj, i); }},
     {"hidden", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape>& i) { i->hidden = populateBoolean(e, i); }},
     {"startNoteID", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape>& i) { i->startNoteId= e->getTextAs<NoteNumber>(); }},
     {"endNoteID", [](const XmlElementPtr& e, const std::shared_ptr<SmartShape>& i) { i->endNoteId = e->getTextAs<NoteNumber>(); }},

--- a/src/musx/factory/TypeRegistry.h
+++ b/src/musx/factory/TypeRegistry.h
@@ -174,6 +174,7 @@ public:
                             auto scoreValue = getScoreValue<T>(pool, std::forward<Args>(args)...);
                             if (scoreValue) {
                                 *instance = *scoreValue;
+                                PartContextRebinder<T>::rebind(instance);
                             } else {
                                 throw std::invalid_argument("Score instance not found for partially linked part instance");
                             }

--- a/tests/others/measure_number_region.cpp
+++ b/tests/others/measure_number_region.cpp
@@ -238,6 +238,9 @@ TEST(MeasureNumberIndividualPositioningTest, PopulateFields)
       <x1add>131</x1add>
       <y1add>-44</y1add>
       <x2add>201</x2add>
+      <encl>
+        <xAdd>13</xAdd>
+      </encl>
     </measNumbIndivPos>
   </details>
 </finale>
@@ -271,7 +274,24 @@ TEST(MeasureNumberIndividualPositioningTest, PopulateFields)
     EXPECT_EQ(pos2->xOffset2, Evpu{201});
     EXPECT_EQ(pos2->forceVisibility, details::MeasureNumberIndividualPositioning::ForceVisibility::Show);
     EXPECT_TRUE(pos2->useEnclosure); // not present -> shared from score.
-    EXPECT_TRUE(bool(pos2->enclosure)); // not present -> shared from score.
+    ASSERT_TRUE(pos2->enclosure);
+    EXPECT_EQ(pos2->enclosure->getRequestedPartId(), 1);
+    EXPECT_EQ(pos2->enclosure->xAdd, 13);
+    EXPECT_EQ(pos2->enclosure->yAdd, 5);
+    EXPECT_EQ(pos2->enclosure->xMargin, 21);
+    EXPECT_EQ(pos2->enclosure->cornerRadius, 768);
+    EXPECT_TRUE(pos2->enclosure->fixedSize);
+    EXPECT_NE(pos2->enclosure.get(), pos1->enclosure.get());
+
+    EXPECT_EQ(pos1->enclosure->xAdd, 3);
+
+    auto pos3 = details->get<details::MeasureNumberIndividualPositioning>(2, 1, 8, 0);
+    ASSERT_TRUE(pos3);
+    ASSERT_TRUE(pos3->enclosure);
+    EXPECT_EQ(pos3->getRequestedPartId(), 2);
+    EXPECT_EQ(pos3->enclosure->getRequestedPartId(), 2);
+    EXPECT_EQ(pos3->enclosure->xAdd, 3);
+    EXPECT_NE(pos3->enclosure.get(), pos1->enclosure.get());
 }
 
 TEST(MeasureNumberRegionTest, CalcDisplayNumberText)

--- a/tests/others/smart_shape.cpp
+++ b/tests/others/smart_shape.cpp
@@ -225,6 +225,151 @@ TEST(SmartShape, Populate)
     }
 }
 
+TEST(SmartShape, PartiallySharedTerminationSegments)
+{
+    constexpr static musxtest::string_view xml = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+  <others>
+    <frameSpec cmper="1" inci="0">
+      <startEntry>1</startEntry>
+      <endEntry>1</endEntry>
+    </frameSpec>
+    <measSpec cmper="1">
+      <beats>4</beats>
+      <divbeat>1024</divbeat>
+      <hasSmartShape/>
+    </measSpec>
+    <smartShape cmper="3034">
+      <shapeType>octaveUp</shapeType>
+      <startTermSeg>
+        <endPt>
+          <inst>1</inst>
+          <meas>1</meas>
+        </endPt>
+        <endPtAdj>
+          <x>12</x>
+          <on/>
+        </endPtAdj>
+      </startTermSeg>
+      <endTermSeg>
+        <endPt>
+          <inst>1</inst>
+          <meas>1</meas>
+          <edu>2048</edu>
+        </endPt>
+      </endTermSeg>
+      <hidden/>
+    </smartShape>
+    <smartShape cmper="3034" part="1" shared="true">
+      <startTermSeg>
+        <endPt>
+          <edu>0</edu>
+        </endPt>
+      </startTermSeg>
+      <endTermSeg>
+        <endPt>
+          <edu>2048</edu>
+        </endPt>
+      </endTermSeg>
+      <hidden>
+        <offInPart/>
+      </hidden>
+    </smartShape>
+    <smartShapeMeasMark cmper="1" inci="0">
+      <shapeNum>3034</shapeNum>
+    </smartShapeMeasMark>
+    <staffSpec cmper="1">
+      <staffLines>5</staffLines>
+      <lineSpace>24</lineSpace>
+    </staffSpec>
+  </others>
+  <details>
+    <gfhold cmper1="1" cmper2="1">
+      <clefID>0</clefID>
+      <frame1>1</frame1>
+    </gfhold>
+  </details>
+  <entries>
+    <entry entnum="1" prev="0" next="0">
+      <dura>1024</dura>
+      <numNotes>0</numNotes>
+      <isValid/>
+      <floatRest/>
+      <sorted/>
+    </entry>
+  </entries>
+</finale>
+)xml";
+
+    auto document = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(xml);
+    ASSERT_TRUE(document);
+
+    const auto scoreShape = document->getOthers()->get<others::SmartShape>(SCORE_PARTID, 3034);
+    const auto partShape = document->getOthers()->get<others::SmartShape>(1, 3034);
+    ASSERT_TRUE(scoreShape);
+    ASSERT_TRUE(partShape);
+
+    EXPECT_EQ(partShape->getRequestedPartId(), 1);
+    EXPECT_FALSE(partShape->hidden);
+
+    ASSERT_TRUE(partShape->startTermSeg);
+    ASSERT_TRUE(partShape->startTermSeg->endPoint);
+    EXPECT_EQ(partShape->startTermSeg->endPoint->staffId, 1);
+    EXPECT_EQ(partShape->startTermSeg->endPoint->measId, 1);
+    EXPECT_EQ(partShape->startTermSeg->endPoint->eduPosition, 0);
+
+    ASSERT_TRUE(partShape->endTermSeg);
+    ASSERT_TRUE(partShape->endTermSeg->endPoint);
+    EXPECT_EQ(partShape->endTermSeg->endPoint->staffId, 1);
+    EXPECT_EQ(partShape->endTermSeg->endPoint->measId, 1);
+    EXPECT_EQ(partShape->endTermSeg->endPoint->eduPosition, 2048);
+
+    ASSERT_TRUE(partShape->startTermSeg->endPointAdj);
+    EXPECT_EQ(partShape->startTermSeg->endPointAdj->horzOffset, 12);
+    EXPECT_TRUE(partShape->startTermSeg->endPointAdj->active);
+
+    EXPECT_NE(partShape->startTermSeg.get(), scoreShape->startTermSeg.get());
+    EXPECT_NE(partShape->startTermSeg->endPoint.get(), scoreShape->startTermSeg->endPoint.get());
+    EXPECT_NE(partShape->startTermSeg->endPointAdj.get(), scoreShape->startTermSeg->endPointAdj.get());
+    EXPECT_EQ(partShape->startTermSeg->endPoint->getParent<others::SmartShape>()->getRequestedPartId(), 1);
+    EXPECT_EQ(partShape->endTermSeg->endPoint->getParent<others::SmartShape>()->getRequestedPartId(), 1);
+
+    EXPECT_TRUE(scoreShape->hidden);
+    EXPECT_EQ(scoreShape->startTermSeg->endPoint->staffId, 1);
+    EXPECT_EQ(scoreShape->startTermSeg->endPoint->measId, 1);
+    EXPECT_EQ(scoreShape->endTermSeg->endPoint->staffId, 1);
+    EXPECT_EQ(scoreShape->endTermSeg->endPoint->measId, 1);
+
+    const auto sharedPartShape = document->getOthers()->get<others::SmartShape>(2, 3034);
+    ASSERT_TRUE(sharedPartShape);
+    EXPECT_EQ(sharedPartShape->getRequestedPartId(), 2);
+    EXPECT_TRUE(sharedPartShape->hidden);
+    EXPECT_NE(sharedPartShape->startTermSeg.get(), scoreShape->startTermSeg.get());
+    EXPECT_NE(sharedPartShape->startTermSeg->endPoint.get(), scoreShape->startTermSeg->endPoint.get());
+    EXPECT_NE(sharedPartShape->endTermSeg.get(), scoreShape->endTermSeg.get());
+    EXPECT_NE(sharedPartShape->endTermSeg->endPoint.get(), scoreShape->endTermSeg->endPoint.get());
+    EXPECT_EQ(sharedPartShape->startTermSeg->endPoint->getParent<others::SmartShape>()->getRequestedPartId(), 2);
+    EXPECT_EQ(sharedPartShape->endTermSeg->endPoint->getParent<others::SmartShape>()->getRequestedPartId(), 2);
+
+    const details::GFrameHoldContext partContext(document, 1, 1, 1);
+    ASSERT_TRUE(partContext);
+    const auto entryFrame = partContext.createEntryFrame(0);
+    ASSERT_TRUE(entryFrame);
+    ASSERT_EQ(entryFrame->getEntries().size(), 1);
+    const EntryInfoPtr entryInfo(entryFrame, 0);
+    EXPECT_TRUE(partShape->startTermSeg->endPoint->calcAssociatedEntry(true));
+    EXPECT_TRUE(partShape->calcAppliesTo(entryInfo));
+
+    const details::GFrameHoldContext sharedPartContext(document, 2, 1, 1);
+    ASSERT_TRUE(sharedPartContext);
+    const auto sharedPartEntryFrame = sharedPartContext.createEntryFrame(0);
+    ASSERT_TRUE(sharedPartEntryFrame);
+    const EntryInfoPtr sharedPartEntryInfo(sharedPartEntryFrame, 0);
+    EXPECT_TRUE(sharedPartShape->startTermSeg->endPoint->calcAssociatedEntry(true));
+    EXPECT_TRUE(sharedPartShape->calcAppliesTo(sharedPartEntryInfo));
+}
+
 TEST(SmartShapeCustomLine, Populate)
 {
     constexpr static musxtest::string_view xml = R"xml(
@@ -401,6 +546,91 @@ TEST(CenterShape, Populate)
     EXPECT_EQ(centerShape->endBreakAdj->horzOffset, -68);
     EXPECT_EQ(centerShape->endBreakAdj->vertOffset, -199);
     EXPECT_TRUE(centerShape->endBreakAdj->active);
+}
+
+TEST(CenterShape, PartiallySharedAdjustments)
+{
+    constexpr static musxtest::string_view xml = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+  <details>
+    <centerShape cmper1="1" cmper2="7">
+      <startBreakAdj>
+        <x>37</x>
+        <y>-199</y>
+        <on/>
+      </startBreakAdj>
+      <endBreakAdj>
+        <x>-68</x>
+        <y>-201</y>
+        <on/>
+      </endBreakAdj>
+      <ctlPtAdj>
+        <startCtlPtX>11</startCtlPtX>
+        <startCtlPtY>136</startCtlPtY>
+        <endCtlPtX>22</endCtlPtX>
+        <endCtlPtY>44</endCtlPtY>
+        <on/>
+      </ctlPtAdj>
+    </centerShape>
+    <centerShape cmper1="1" cmper2="7" part="1" shared="true">
+      <startBreakAdj>
+        <x>50</x>
+      </startBreakAdj>
+      <ctlPtAdj>
+        <startCtlPtY>200</startCtlPtY>
+      </ctlPtAdj>
+    </centerShape>
+  </details>
+</finale>
+)xml";
+
+    const auto document = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(xml);
+    ASSERT_TRUE(document);
+
+    const auto scoreShape = document->getDetails()->get<details::CenterShape>(SCORE_PARTID, 1, 7);
+    const auto partShape = document->getDetails()->get<details::CenterShape>(1, 1, 7);
+    ASSERT_TRUE(scoreShape);
+    ASSERT_TRUE(partShape);
+
+    EXPECT_EQ(partShape->getRequestedPartId(), 1);
+
+    ASSERT_TRUE(partShape->startBreakAdj);
+    EXPECT_EQ(partShape->startBreakAdj->horzOffset, 50);
+    EXPECT_EQ(partShape->startBreakAdj->vertOffset, -199);
+    EXPECT_TRUE(partShape->startBreakAdj->active);
+
+    ASSERT_TRUE(partShape->endBreakAdj);
+    EXPECT_EQ(partShape->endBreakAdj->horzOffset, -68);
+    EXPECT_EQ(partShape->endBreakAdj->vertOffset, -201);
+    EXPECT_TRUE(partShape->endBreakAdj->active);
+
+    ASSERT_TRUE(partShape->ctlPtAdj);
+    EXPECT_EQ(partShape->ctlPtAdj->startCtlPtX, 11);
+    EXPECT_EQ(partShape->ctlPtAdj->startCtlPtY, 200);
+    EXPECT_EQ(partShape->ctlPtAdj->endCtlPtX, 22);
+    EXPECT_EQ(partShape->ctlPtAdj->endCtlPtY, 44);
+    EXPECT_TRUE(partShape->ctlPtAdj->active);
+
+    EXPECT_NE(partShape->startBreakAdj.get(), scoreShape->startBreakAdj.get());
+    EXPECT_NE(partShape->endBreakAdj.get(), scoreShape->endBreakAdj.get());
+    EXPECT_NE(partShape->ctlPtAdj.get(), scoreShape->ctlPtAdj.get());
+    EXPECT_EQ(partShape->startBreakAdj->getParent<details::CenterShape>()->getRequestedPartId(), 1);
+    EXPECT_EQ(partShape->endBreakAdj->getParent<details::CenterShape>()->getRequestedPartId(), 1);
+    EXPECT_EQ(partShape->ctlPtAdj->getParent<details::CenterShape>()->getRequestedPartId(), 1);
+
+    EXPECT_EQ(scoreShape->startBreakAdj->horzOffset, 37);
+    EXPECT_EQ(scoreShape->ctlPtAdj->startCtlPtY, 136);
+
+    const auto sharedPartShape = document->getDetails()->get<details::CenterShape>(2, 1, 7);
+    ASSERT_TRUE(sharedPartShape);
+    EXPECT_EQ(sharedPartShape->getRequestedPartId(), 2);
+    EXPECT_NE(sharedPartShape->startBreakAdj.get(), scoreShape->startBreakAdj.get());
+    EXPECT_NE(sharedPartShape->endBreakAdj.get(), scoreShape->endBreakAdj.get());
+    EXPECT_NE(sharedPartShape->ctlPtAdj.get(), scoreShape->ctlPtAdj.get());
+    EXPECT_EQ(sharedPartShape->startBreakAdj->getParent<details::CenterShape>()->getRequestedPartId(), 2);
+    EXPECT_EQ(sharedPartShape->endBreakAdj->getParent<details::CenterShape>()->getRequestedPartId(), 2);
+    EXPECT_EQ(sharedPartShape->ctlPtAdj->getParent<details::CenterShape>()->getRequestedPartId(), 2);
 }
 
 TEST(SmartShapes, IndependentTimeSigs)


### PR DESCRIPTION
## Summary

This PR fixes partial sharing of nested DOM objects when resolving score data in a linked-part context.

Finale may store a complete object in the score and include only changed nested fields in a partially shared part record. Previously, musxdom copied the top-level score object but replaced complete nested objects when processing the part XML. Fields omitted from the part record consequently reverted to defaults instead of retaining their score values. Nested objects could also retain pointers to their score-context parent after the top-level object was copied for a part.

## Implementation

- Added a PartContextRebinder customization point to the existing part-context copy process.
    - The top-level object receives its requested part ID first.
    - Type-specific rebinding then copies nested objects and associates them with the new context.

- Rebind inherited nested objects immediately after copying score data into a partially shared part instance.
    - Part XML can then populate the rebound object directly.
    - Only explicitly present fields are changed.
    - Omitted nested fields retain their inherited score values.
    - Score data is not mutated or aliased where contextual identity matters.

- Added FieldPopulator::populateExistingOrCreate.
    - It populates an inherited, already-rebound object when one exists.
    - It creates the object for ordinary score records or when no inherited value exists.
    - This avoids separate and potentially duplicated cloning logic in factory mappings.

- Added assignment support to ContainedClassBase that copies derived values while preserving the destination object’s parent identity.

## Supported types

### SmartShape

- Deep-copies and rebinds:
    - startTermSeg
    - endTermSeg
    - fullCtlPtAdj
    - Termination-segment endpoints and adjustment objects

- Partial startTermSeg and endTermSeg XML now overlays inherited segment data independently.
- Endpoint staff, measure, and position fields omitted from a part record remain inherited from the score.
- Endpoint methods such as entry association and calcAppliesTo() now operate using the requested linked-part context.

### CenterShape

- Rebinds:
    - startBreakAdj
    - endBreakAdj
    - ctlPtAdj

- Partial adjustment records preserve omitted score fields.
- Removed CenterShape from the table of types assumed to be completely unshared. Its sharing behavior is now learned from the actual instances, allowing both fully shared and partially shared records.

### MeasureNumberIndividualPositioning

- Rebinds its embedded Enclosure.
- Partial <encl> records overlay inherited enclosure values instead of replacing the complete enclosure.
- Fully shared fallback enclosures receive the requested part context.

## Future-facing documentation

Added non-Doxygen comments at ContainedClassBase and other classes owning contained objects:
- Staff
- StaffStyle
- SmartShapeCustomLine
- MeasureNumberRegion

The comments explain the shallow-copy parent-identity hazard, record that current fixtures do not demonstrate partial sharing for those types, and point to CenterShape as the simplest implementation example if future Finale data requires similar treatment.

Other historically embedded classes were reviewed. No additional changes were made where owners are explicitly unshared or no partial-sharing evidence exists.

## Tests

Added or expanded regression coverage for:

- Partially shared SmartShape termination segments
- Preservation of omitted endpoint staff and measure fields
- Requested-part identity on nested endpoints
- Score visibility versus part visibility
- Endpoint entry association and calcAppliesTo()
- Fully shared SmartShape fallback into another part
- Partially shared CenterShape adjustments
- Entirely omitted inherited CenterShape adjustments
- Partially shared measure-number enclosures
- Preservation of omitted enclosure fields
- Score-data isolation
- Fully shared fallback into another requested part

Verification completed successfully:

- Full project build passed.
- All 408 tests passed.
- git diff --check passed.
