### PR TITLE
Expand known SMuFL font names and match them normalized

### DIFF
--- a/src/musx/dom/CommonClasses.cpp
+++ b/src/musx/dom/CommonClasses.cpp
@@ -28,6 +28,7 @@
 #include <numeric>
 #include <algorithm>
 #include <cmath>
+#include <cctype>
 #include <cwctype>
 #include <string_view>
 #include <unordered_map>
@@ -53,6 +54,22 @@ struct SmuflMetadataPathCacheEntry
     bool found{};
     std::filesystem::path path;
 };
+
+/// Normalizes a font name for comparison by removing whitespace and folding case. This lets a
+/// PostScript-style spelling ("FinaleMaestro") match the family name ("Finale Maestro").
+/// Matches normalizeFontKey() in the smufl-mapping project so the two agree on lookups.
+static std::string normalizeFontName(std::string_view name)
+{
+    std::string result;
+    result.reserve(name.size());
+    for (const char ch : name) {
+        const auto uch = static_cast<unsigned char>(ch);
+        if (!std::isspace(uch)) {
+            result.push_back(static_cast<char>(std::tolower(uch)));
+        }
+    }
+    return result;
+}
 
 static bool looksLikeSmuflDefaultMusicFont(const FontInfo& fontInfo)
 {
@@ -165,26 +182,48 @@ bool FontInfo::calcIsSMuFL() const
         return cached.value();
     }
 
-   static const std::set<std::string_view> knownSmuflFontNames =
+    // Mirrors the SMuFL fonts configured in source_json/smufl_fonts.json of the smufl-mapping
+    // project (https://github.com/rpatters1/smufl-mapping). That project is deliberately not a
+    // dependency of musxdom, so this list is maintained by hand and may need updating when
+    // smufl-mapping adds fonts. Entries are stored pre-normalized (see normalizeFontName), i.e.
+    // the family name lowercased with whitespace removed: add new fonts in that form. The comment
+    // on each line is the canonical family spelling, to make re-syncing with smufl_fonts.json easier.
+    static const std::unordered_set<std::string_view> knownSmuflFontNames =
     {
-        "Bravura",
-        "Leland",
-        "Emmentaler",
-        "Finale Ash",
-        "Finale Broadway",
-        "Finale Engraver",
-        "Finale Jazz",
-        "Finale Legacy",
-        "Finale Maestro",
-        "Gonville",
-        "MuseJazz",
-        "Petaluma",
+        "bravura",                   // Bravura
+        "bravuratext",               // Bravura Text
+        "chaconneex",                // Chaconne Ex
+        "emmentaler",                // Emmentaler
+        "emmentalertext",            // Emmentaler Text
+        "finaleash",                 // Finale Ash
+        "finaleashtext",             // Finale Ash Text
+        "finalebroadway",            // Finale Broadway
+        "finalebroadwaylegacytext",  // Finale Broadway Legacy Text
+        "finalebroadwaytext",        // Finale Broadway Text
+        "finaleengraver",            // Finale Engraver
+        "finalejazz",                // Finale Jazz
+        "finalejazztext",            // Finale Jazz Text
+        "finalejazztextlowercase",   // Finale Jazz Text Lowercase
+        "finalelegacy",              // Finale Legacy
+        "finalemaestro",             // Finale Maestro
+        "finalemaestrotext",         // Finale Maestro Text
+        "gonville",                  // Gonville
+        "gonvilletext",              // Gonville Text
+        "leland",                    // Leland
+        "lelandtext",                // Leland Text
+        "musejazz",                  // MuseJazz
+        "musejazztext",              // MuseJazz Text
+        "petaluma",                  // Petaluma
+        "petalumascript",            // Petaluma Script
+        "petalumatext",              // Petaluma Text
+        "sebastian",                 // Sebastian
+        "sebastiantext",             // Sebastian Text
     };
 
     bool result;
     if (calcSMuFLMetaDataPath().has_value()) {
         result = true;
-    } else if (auto it = knownSmuflFontNames.find(getName()); it != knownSmuflFontNames.end()) {
+    } else if (knownSmuflFontNames.count(normalizeFontName(getName())) > 0) {
         result = true;
     } else {
         result = looksLikeSmuflDefaultMusicFont(*this);

--- a/tests/others/fonts.cpp
+++ b/tests/others/fonts.cpp
@@ -103,6 +103,50 @@ constexpr static musxtest::string_view unknownSmuflFontProperties = R"xml(
 </finale>
     )xml";
 
+constexpr static musxtest::string_view knownSmuflFontNameSpellings = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+  <others>
+    <fontName cmper="1">
+      <name>Finale Maestro</name>
+    </fontName>
+    <fontName cmper="2">
+      <name>FinaleMaestro</name>
+    </fontName>
+    <fontName cmper="3">
+      <name>finale maestro text</name>
+    </fontName>
+    <fontName cmper="4">
+      <name>BRAVURATEXT</name>
+    </fontName>
+    <fontName cmper="5">
+      <name>Times New Roman</name>
+    </fontName>
+    <fontName cmper="6">
+      <name>Maestro</name>
+    </fontName>
+  </others>
+</finale>
+    )xml";
+
+TEST(FontTest, MatchesKnownSmuflFontNamesIgnoringSpacesAndCase)
+{
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(knownSmuflFontNameSpellings);
+
+    const auto isSmufl = [&doc](Cmper fontId) {
+        auto fontInfo = std::make_shared<FontInfo>(doc);
+        fontInfo->fontId = fontId;
+        return fontInfo->calcIsSMuFL();
+    };
+
+    EXPECT_TRUE(isSmufl(1));    // family name as spelled
+    EXPECT_TRUE(isSmufl(2));    // PostScript-style spelling with spaces removed
+    EXPECT_TRUE(isSmufl(3));    // lowercase
+    EXPECT_TRUE(isSmufl(4));    // uppercase and space-free
+    EXPECT_FALSE(isSmufl(5));   // not a music font
+    EXPECT_FALSE(isSmufl(6));   // legacy (non-SMuFL) Finale music font
+}
+
 TEST(FontTest, FontInfoPropertiesTest)
 {
     auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(fontProperties);


### PR DESCRIPTION
## Summary

`FontInfo::calcIsSMuFL()` falls back to a hardcoded list of font names when no SMuFL metadata file is found on disk. That fallback is the *only* signal under WASM, where `calcSMuFLPaths()` returns nothing by design — so gaps in the list surface as music fonts misreported as non-SMuFL.

Two changes:

**Full coverage.** The list grows from 12 to all 28 fonts configured in `source_json/smufl_fonts.json` of [smufl-mapping](https://github.com/rpatters1/smufl-mapping). New entries are the text companions (`Bravura Text`, `Leland Text`, `MuseJazz Text`, the four Finale text faces, `Petaluma Script`/`Petaluma Text`, `Gonville Text`, `Emmentaler Text`, `Sebastian Text`) plus `Chaconne Ex` and `Sebastian`. The legacy non-SMuFL fonts under `source_json/legacy/` are correctly excluded — only `smufl_fonts.json` feeds this list.

smufl-mapping is deliberately **not** a dependency of musxdom and does not become one here. The list stays hand-maintained; the block comment names the upstream source file and repo, and each entry carries its canonical family spelling as a trailing comment so re-syncing is a readable diff.

**Normalized matching.** Names are compared with whitespace removed and case folded, matching `normalizeFontKey()` upstream. This handles a document that stores the PostScript name (`FinaleMaestro`, `BravuraText`) instead of the family name — the realistic failure mode for exact matching, since the PostScript name (`name` ID 6) drops spaces by construction. Entries are stored pre-normalized in an `unordered_set<string_view>`, so lookup remains a single hash find and the only per-call work is normalizing the incoming name.

## Verification

- The 28 stored keys are an exact set match against `smufl_fonts.json`; every key is in normalized form, and every trailing comment both normalizes back to its own key and is an exact key in the JSON. No drift in any of the three directions.
- New test `FontTest.MatchesKnownSmuflFontNamesIgnoringSpacesAndCase` covers the family spelling, the PostScript spelling, lowercase, and uppercase-and-space-free, plus two negatives: `Times New Roman` and legacy `Maestro`, which must stay non-SMuFL.
- Full suite passes, 412/412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)