### PR TITLE
Let pool factories create from a filtered subset of children

### DIFF
--- a/src/musx/factory/PoolFactory.cpp
+++ b/src/musx/factory/PoolFactory.cpp
@@ -345,6 +345,7 @@ using RegisteredTexts = RegisteredTypes<
 template <typename ObjectBase, typename PoolType, typename Extractor>
 std::shared_ptr<PoolType> createPool(const xml::XmlElementPtr& element,
                                      const dom::DocumentPtr& document,
+                                     const NodeFilter& filter,
                                      Extractor&& extractor)
 {
     auto pool = std::make_shared<PoolType>(document);
@@ -356,6 +357,9 @@ std::shared_ptr<PoolType> createPool(const xml::XmlElementPtr& element,
     util::Logger::log(util::Logger::LogLevel::Verbose, "============");
 #endif
     for (auto child = element->getFirstChildElement(); child; child = child->getNextSibling()) {
+        if (filter && !filter(child)) {
+            continue;
+        }
         if (auto info = extractor(child, pool)) {
 #ifdef MUSX_DISPLAY_NODE_NAMES
             if (currentTag != child->getTagName()) {
@@ -412,18 +416,20 @@ dom::Cmper textTypeToCmper(const std::string& type)
 } // namespace
 
 dom::OptionsPoolPtr OptionsFactory::create(
-    const xml::XmlElementPtr& element, const dom::DocumentPtr& document)
+    const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+    const NodeFilter& filter)
 {
-    return createPool<dom::OptionsBase, dom::OptionsPool>(element, document,
+    return createPool<dom::OptionsBase, dom::OptionsPool>(element, document, filter,
         [&](const auto& child, const auto& pool) {
             return RegisteredOptions::createInstance(pool, child, document);
         });
 }
 
 dom::OthersPoolPtr OthersFactory::create(
-    const xml::XmlElementPtr& element, const dom::DocumentPtr& document)
+    const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+    const NodeFilter& filter)
 {
-    return createPool<dom::OthersBase, dom::OthersPool>(element, document,
+    return createPool<dom::OthersBase, dom::OthersPool>(element, document, filter,
         [&](const auto& child, const auto& pool) {
             auto cmper = child->findAttribute("cmper");
             if (!cmper) {
@@ -440,9 +446,10 @@ dom::OthersPoolPtr OthersFactory::create(
 }
 
 dom::DetailsPoolPtr DetailsFactory::create(
-    const xml::XmlElementPtr& element, const dom::DocumentPtr& document)
+    const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+    const NodeFilter& filter)
 {
-    return createPool<dom::DetailsBase, dom::DetailsPool>(element, document,
+    return createPool<dom::DetailsBase, dom::DetailsPool>(element, document, filter,
         [&](const auto& child, const auto& pool) {
             std::optional<dom::Inci> inci;
             if (auto attr = child->findAttribute("inci")) {
@@ -474,9 +481,10 @@ dom::DetailsPoolPtr DetailsFactory::create(
 }
 
 dom::EntryPoolPtr EntryFactory::create(
-    const xml::XmlElementPtr& element, const dom::DocumentPtr& document)
+    const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+    const NodeFilter& filter)
 {
-    return createPool<dom::Entry, dom::EntryPool>(element, document,
+    return createPool<dom::Entry, dom::EntryPool>(element, document, filter,
         [&](const auto& child, const auto& pool) {
             auto entnum = child->findAttribute("entnum");
             auto prev = child->findAttribute("prev");
@@ -492,9 +500,10 @@ dom::EntryPoolPtr EntryFactory::create(
 }
 
 dom::TextsPoolPtr TextsFactory::create(
-    const xml::XmlElementPtr& element, const dom::DocumentPtr& document)
+    const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+    const NodeFilter& filter)
 {
-    return createPool<dom::TextsBase, dom::TextsPool>(element, document,
+    return createPool<dom::TextsBase, dom::TextsPool>(element, document, filter,
         [&](const auto& child, const auto& pool) {
             const std::string attributeName = child->getTagName() == dom::texts::FileInfoText::XmlNodeName
                 ? "type" : "number";

--- a/src/musx/factory/PoolFactory.h
+++ b/src/musx/factory/PoolFactory.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -33,6 +34,19 @@
 
 namespace musx {
 namespace factory {
+
+/**
+ * @brief Selects which child elements a pool factory creates objects from.
+ * @details Returning `false` skips the element entirely, as if it were absent from the
+ * source. This lets a client seed a pool from an allowlisted subset of an element without
+ * editing or rebuilding the source XML. An empty (default-constructed) filter accepts every
+ * child, which is the behavior when no filter is supplied.
+ *
+ * Which nodes belong in a document is caller policy. A subset that omits nodes other nodes
+ * depend on produces a document that fails integrity validation when the construction
+ * session is finished, so the caller is responsible for selecting a self-consistent subset.
+ */
+using NodeFilter = std::function<bool(const xml::XmlElementPtr&)>;
 
 /** @brief Initializes a partially shared part object from its score object. */
 class PartSharingFactory
@@ -67,40 +81,60 @@ public:
 class OptionsFactory
 {
 public:
+    /// @param element The element whose children are created.
+    /// @param document The document that owns the created objects.
+    /// @param filter [optional] Restricts creation to the children it accepts. See @ref NodeFilter.
     [[nodiscard]] static dom::OptionsPoolPtr create(
-        const xml::XmlElementPtr& element, const dom::DocumentPtr& document);
+        const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+        const NodeFilter& filter = {});
 };
 
 /** @brief Creates an others pool from an XML `<others>` element. */
 class OthersFactory
 {
 public:
+    /// @param element The element whose children are created.
+    /// @param document The document that owns the created objects.
+    /// @param filter [optional] Restricts creation to the children it accepts. See @ref NodeFilter.
     [[nodiscard]] static dom::OthersPoolPtr create(
-        const xml::XmlElementPtr& element, const dom::DocumentPtr& document);
+        const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+        const NodeFilter& filter = {});
 };
 
 /** @brief Creates a details pool from an XML `<details>` element. */
 class DetailsFactory
 {
 public:
+    /// @param element The element whose children are created.
+    /// @param document The document that owns the created objects.
+    /// @param filter [optional] Restricts creation to the children it accepts. See @ref NodeFilter.
     [[nodiscard]] static dom::DetailsPoolPtr create(
-        const xml::XmlElementPtr& element, const dom::DocumentPtr& document);
+        const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+        const NodeFilter& filter = {});
 };
 
 /** @brief Creates an entry pool from an XML `<entries>` element. */
 class EntryFactory
 {
 public:
+    /// @param element The element whose children are created.
+    /// @param document The document that owns the created objects.
+    /// @param filter [optional] Restricts creation to the children it accepts. See @ref NodeFilter.
     [[nodiscard]] static dom::EntryPoolPtr create(
-        const xml::XmlElementPtr& element, const dom::DocumentPtr& document);
+        const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+        const NodeFilter& filter = {});
 };
 
 /** @brief Creates a texts pool from an XML `<texts>` element. */
 class TextsFactory
 {
 public:
+    /// @param element The element whose children are created.
+    /// @param document The document that owns the created objects.
+    /// @param filter [optional] Restricts creation to the children it accepts. See @ref NodeFilter.
     [[nodiscard]] static dom::TextsPoolPtr create(
-        const xml::XmlElementPtr& element, const dom::DocumentPtr& document);
+        const xml::XmlElementPtr& element, const dom::DocumentPtr& document,
+        const NodeFilter& filter = {});
 };
 
 } // namespace factory

--- a/tests/dom/document.cpp
+++ b/tests/dom/document.cpp
@@ -428,3 +428,59 @@ TEST(DocumentConstructionTest, SupportsNoneAndPartialSharing)
     EXPECT_TRUE(partLayer->getUnlinkedNodes().count("restOffset"));
     EXPECT_EQ(unshared->getShareMode(), EnigmaBase::ShareMode::None);
 }
+
+TEST(DocumentConstructionTest, NodeFilterRestrictsPoolToAllowlistedNodes)
+{
+    constexpr static musxtest::string_view xml = R"xml(
+<others>
+  <layerAtts cmper="0"><restOffset>7</restOffset></layerAtts>
+  <fontName cmper="1"><name>Finale Maestro</name></fontName>
+  <layerAtts cmper="1"/>
+  <measSpec cmper="1"><width>500</width></measSpec>
+  <layerAtts cmper="2"/>
+  <layerAtts cmper="3"/>
+</others>
+    )xml";
+    auto xmlDocument = std::make_unique<musx::xml::pugi::Document>();
+    xmlDocument->loadFromBuffer(xml.data(), xml.size());
+
+    auto session = musx::factory::DocumentFactory::begin();
+    auto document = session.getDocument();
+    document->getOthers() = musx::factory::OthersFactory::create(
+        xmlDocument->getRootElement(), document,
+        [](const musx::xml::XmlElementPtr& node) {
+            return node->getTagName() == musx::dom::others::LayerAttributes::XmlNodeName;
+        });
+
+    auto finished = std::move(session).finish();
+    EXPECT_EQ(finished->getOthers()->getArray<musx::dom::others::LayerAttributes>(SCORE_PARTID).size(), 4u);
+    EXPECT_TRUE(finished->getOthers()->getArray<musx::dom::others::FontDefinition>(SCORE_PARTID).empty());
+    EXPECT_TRUE(finished->getOthers()->getArray<musx::dom::others::Measure>(SCORE_PARTID).empty());
+    auto layer = finished->getOthers()->get<musx::dom::others::LayerAttributes>(SCORE_PARTID, 0);
+    ASSERT_TRUE(layer);
+    EXPECT_EQ(layer->restOffset, 7);
+}
+
+TEST(DocumentConstructionTest, AbsentNodeFilterCreatesEveryChild)
+{
+    constexpr static musxtest::string_view xml = R"xml(
+<others>
+  <layerAtts cmper="0"/>
+  <layerAtts cmper="1"/>
+  <layerAtts cmper="2"/>
+  <layerAtts cmper="3"/>
+  <fontName cmper="1"><name>Finale Maestro</name></fontName>
+</others>
+    )xml";
+    auto xmlDocument = std::make_unique<musx::xml::pugi::Document>();
+    xmlDocument->loadFromBuffer(xml.data(), xml.size());
+
+    auto session = musx::factory::DocumentFactory::begin();
+    auto document = session.getDocument();
+    document->getOthers() = musx::factory::OthersFactory::create(
+        xmlDocument->getRootElement(), document);
+
+    auto finished = std::move(session).finish();
+    EXPECT_EQ(finished->getOthers()->getArray<musx::dom::others::LayerAttributes>(SCORE_PARTID).size(), 4u);
+    EXPECT_EQ(finished->getOthers()->getArray<musx::dom::others::FontDefinition>(SCORE_PARTID).size(), 1u);
+}


### PR DESCRIPTION
## Summary

The pool factories create one object per child element of the element they are given. A client seeding a document from a reference file had no way to admit some children and reject others: `IXmlElement` is a read-only navigation interface, so there is no way to build a subtree containing only the wanted nodes.

This adds an optional `NodeFilter` to each `create()` entry point:

```cpp
using NodeFilter = std::function<bool(const xml::XmlElementPtr&)>;
```

Returning `false` skips the element as if it were absent from the source. The implementation is one skip in the shared `createPool` loop. Existing call sites are unaffected — an absent filter accepts every child.

## Motivation

The legacy Finale MUS reader seeds an imported document with a structurally complete options pool taken from a pinned Finale 27 baseline. That baseline's `<others>` element is a whole score: 127 direct children, of which only the four `layerAtts` are option-like. Handing it to `OthersFactory::create` would import fallback measures, staves, pages, and part definitions into a document that must contain none of them.

The reader had worked around this with a filtering `IXmlElement` decorator — about 110 lines of delegation that this change replaces with a lambda.

## Design notes

Which nodes belong in a document is caller policy, so the filter is a predicate rather than a node-name allowlist. The documentation states that a subset omitting nodes that other nodes depend on produces a document failing integrity validation when the construction session is finished; selecting a self-consistent subset is the caller's responsibility.

## Testing

Two tests in `tests/dom/document.cpp`:

- `NodeFilterRestrictsPoolToAllowlistedNodes` — a mixed `<others>` element creates only the allowlisted type, with field values intact.
- `AbsentNodeFilterCreatesEveryChild` — the default filter creates every child.

Full suite passes: 419/419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)