### PR TITLE
Move normalizeFontName to public API

### DIFF
--- a/src/musx/dom/CommonClasses.cpp
+++ b/src/musx/dom/CommonClasses.cpp
@@ -29,7 +29,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cctype>
-#include <cwctype>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -54,22 +53,6 @@ struct SmuflMetadataPathCacheEntry
     bool found{};
     std::filesystem::path path;
 };
-
-/// Normalizes a font name for comparison by removing whitespace and folding case. This lets a
-/// PostScript-style spelling ("FinaleMaestro") match the family name ("Finale Maestro").
-/// Matches normalizeFontKey() in the smufl-mapping project so the two agree on lookups.
-static std::string normalizeFontName(std::string_view name)
-{
-    std::string result;
-    result.reserve(name.size());
-    for (const char ch : name) {
-        const auto uch = static_cast<unsigned char>(ch);
-        if (!std::isspace(uch)) {
-            result.push_back(static_cast<char>(std::tolower(uch)));
-        }
-    }
-    return result;
-}
 
 static bool looksLikeSmuflDefaultMusicFont(const FontInfo& fontInfo)
 {
@@ -108,6 +91,22 @@ static bool looksLikeSmuflDefaultMusicFont(const FontInfo& fontInfo)
 }
 
 } // namespace
+
+std::string normalizeFontName(std::string_view name)
+{
+    std::string result;
+    result.reserve(name.size());
+    for (unsigned char ch : name) {
+        if (ch < 0x80) {
+            if (std::isspace(ch)) {
+                continue;
+            }
+            ch = static_cast<unsigned char>(std::tolower(ch));
+        }
+        result.push_back(static_cast<char>(ch));
+    }
+    return result;
+}
 
 // ********************
 // ***** FontInfo *****

--- a/src/musx/dom/CommonClasses.h
+++ b/src/musx/dom/CommonClasses.h
@@ -24,6 +24,8 @@
 #include <numeric>
 #include <filesystem>
 #include <array>
+#include <string>
+#include <string_view>
 
 #include "musx/util/Fraction.h"
 #include "BaseClasses.h"
@@ -55,6 +57,17 @@ class Staff;
 using Duration = std::pair<NoteType, unsigned>;
 
 // This file contains common classes that are shared among Options, Others, and Details.
+
+/// @brief Normalizes a font name for comparison by removing ASCII whitespace and folding ASCII case.
+///
+/// Whitespace removal and case folding are applied only to bytes below `0x80`; all non-ASCII
+/// bytes pass through unchanged. This prevents locale-sensitive character classification from
+/// modifying bytes within a UTF-8 sequence.
+///
+/// @param name The font name to normalize.
+/// @return The normalized font name.
+[[nodiscard]]
+std::string normalizeFontName(std::string_view name);
 
 /**
  * @struct FontInfo

--- a/tests/others/fonts.cpp
+++ b/tests/others/fonts.cpp
@@ -129,6 +129,14 @@ constexpr static musxtest::string_view knownSmuflFontNameSpellings = R"xml(
 </finale>
     )xml";
 
+TEST(FontTest, NormalizesFontNamesWithAsciiRules)
+{
+    EXPECT_EQ(normalizeFontName(" \t\n\v\f\rFinale Maestro"), "finalemaestro");
+    EXPECT_EQ(normalizeFontName("Maestro, Times"), "maestro,times");
+    EXPECT_EQ(normalizeFontName("ÉLAN"), "Élan");
+    EXPECT_EQ(normalizeFontName("finalemaestro"), "finalemaestro");
+}
+
 TEST(FontTest, MatchesKnownSmuflFontNamesIgnoringSpacesAndCase)
 {
     auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(knownSmuflFontNameSpellings);


### PR DESCRIPTION
Move normalizeFontName to public API so that finale-mus-reader can share it.