### PR TITLE
Import fonts and shapes between documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,19 @@ This repository implements a C++ document object model for Finale `musx` / Enigm
 - Follow the surrounding C++ style in the file being edited.
 - Keep changes focused. Avoid unrelated refactors while fixing or adding a behavior.
 - Prefer existing DOM helper APIs such as `Document`, `ObjectPool`, `MusxInstance`, `StaffComposite`, and `GFrameHoldContext` over duplicating traversal logic.
+- Doxygen comments document the contract, not its history. State what a caller must know:
+  behavior, parameters, return values, and what is thrown. Do not explain why a function or
+  property was added, what it replaced, or which problem prompted it. A reader arriving at the
+  published API has none of that context, and the rationale ages badly once the surrounding code
+  moves on. Such explanation belongs in an ordinary implementation comment, a commit message, or
+  a design note.
+- Null-check anything that should never be null short of a program bug, input parameters
+  especially, with `MUSX_ASSERT_IF`, and throw from its body. The assertion halts a debug build at
+  the fault, and the throw stops a release build from continuing on a bad pointer. Reserve a
+  sentinel or an empty `std::optional` for outcomes a caller can legitimately encounter; a
+  violated precondition is not one of them. A parameter that genuinely accepts null is the
+  exception and must say so at the declaration, so that the absence of a check reads as deliberate
+  rather than forgotten.
 - Use `MUSX_INTEGRITY_ERROR` for malformed document relationships that existing code treats as integrity failures.
 - For future variable, parameter, field, and method-local names representing `...Cmper` identifiers, prefer names ending in `Id`, such as `measureId`, `partId`, `staffId`, `systemId`, and `pageId`.
 

--- a/src/musx/dom/CommonClasses.cpp
+++ b/src/musx/dom/CommonClasses.cpp
@@ -118,8 +118,11 @@ namespace {
 MusxInstance<others::FontDefinition> cloneFontDefinition(const DocumentPtr& target,
     const MusxInstance<others::FontDefinition>& source, Cmper cmper)
 {
+    // SCORE_PARTID and ShareMode::All are correct for anything newly created: no linked part can
+    // reference an object that did not exist a moment ago, so there is nothing to unshare from.
+    // An importer for a ShareMode::None class would know to say so.
     auto clone = std::make_shared<others::FontDefinition>(
-        target, SCORE_PARTID, source->getShareMode(), cmper);
+        target, SCORE_PARTID, EnigmaBase::ShareMode::All, cmper);
     clone->charsetBank = source->charsetBank;
     clone->charsetVal = source->charsetVal;
     clone->pitch = source->pitch;
@@ -137,28 +140,22 @@ std::optional<Cmper> importNonZeroFontDefinition(const DocumentPtr& target,
 {
     // Match on typeface, never on cmper. Cmper 0 is excluded: its name follows whatever the
     // document's default music font currently is, so matching a concrete typeface onto it would
-    // make that element track later changes to the music font. Lowest cmper wins so that
-    // repeated imports are stable.
+    // make that element track later changes to the music font.
+    //
+    // At most one non-zero definition should name a given typeface; more than one means the
+    // document is malformed, and which of them is picked then does not matter.
     const auto wanted = normalizeFontName(source->name);
-    std::optional<Cmper> matched;
-    Cmper highest = 0;
     for (const auto& font : target->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID)) {
         const auto cmper = font->getCmper();
-        highest = (std::max)(highest, cmper);
-        if (cmper == 0 || normalizeFontName(font->name) != wanted) {
-            continue;
-        }
-        if (!matched || cmper < *matched) {
-            matched = cmper;
+        if (cmper != 0 && normalizeFontName(font->name) == wanted) {
+            return cmper;
         }
     }
-    if (matched) {
-        return *matched;
-    }
-    if (highest == (std::numeric_limits<Cmper>::max)()) {
+    const auto available = target->getOthers()->nextFreeCmper<others::FontDefinition>(SCORE_PARTID);
+    if (!available) {
         return std::nullopt;
     }
-    return cloneFontDefinition(target, source, static_cast<Cmper>(highest + 1))->getCmper();
+    return cloneFontDefinition(target, source, *available)->getCmper();
 }
 
 /// @brief The definition naming @p target's own default music font, when it can be determined.

--- a/src/musx/dom/CommonClasses.cpp
+++ b/src/musx/dom/CommonClasses.cpp
@@ -112,6 +112,106 @@ std::string normalizeFontName(std::string_view name)
 // ***** FontInfo *****
 // ********************
 
+namespace {
+
+/// @brief Copies every stored field of a font definition onto a fresh instance in @p target.
+MusxInstance<others::FontDefinition> cloneFontDefinition(const DocumentPtr& target,
+    const MusxInstance<others::FontDefinition>& source, Cmper cmper)
+{
+    auto clone = std::make_shared<others::FontDefinition>(
+        target, SCORE_PARTID, source->getShareMode(), cmper);
+    clone->charsetBank = source->charsetBank;
+    clone->charsetVal = source->charsetVal;
+    clone->pitch = source->pitch;
+    clone->family = source->family;
+    // The source spelling is retained deliberately. Normalization decides whether two names
+    // mean the same typeface; it is not a canonical form to store.
+    clone->name = source->name;
+    target->getOthers()->add(others::FontDefinition::XmlNodeName, clone);
+    return clone;
+}
+
+/// @brief The non-zero cmper in @p target naming @p source's typeface, cloning when absent.
+std::optional<Cmper> importNonZeroFontDefinition(const DocumentPtr& target,
+    const MusxInstance<others::FontDefinition>& source)
+{
+    // Match on typeface, never on cmper. Cmper 0 is excluded: its name follows whatever the
+    // document's default music font currently is, so matching a concrete typeface onto it would
+    // make that element track later changes to the music font. Lowest cmper wins so that
+    // repeated imports are stable.
+    const auto wanted = normalizeFontName(source->name);
+    std::optional<Cmper> matched;
+    Cmper highest = 0;
+    for (const auto& font : target->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID)) {
+        const auto cmper = font->getCmper();
+        highest = (std::max)(highest, cmper);
+        if (cmper == 0 || normalizeFontName(font->name) != wanted) {
+            continue;
+        }
+        if (!matched || cmper < *matched) {
+            matched = cmper;
+        }
+    }
+    if (matched) {
+        return *matched;
+    }
+    if (highest == (std::numeric_limits<Cmper>::max)()) {
+        return std::nullopt;
+    }
+    return cloneFontDefinition(target, source, static_cast<Cmper>(highest + 1))->getCmper();
+}
+
+/// @brief The definition naming @p target's own default music font, when it can be determined.
+MusxInstance<others::FontDefinition> findDefaultMusicFont(const DocumentPtr& target)
+{
+    const auto music = options::FontOptions::getFontInfoOrNull(
+        target, options::FontOptions::FontType::Music);
+    // A music font stored as 0 says nothing here: it is the very reference being resolved.
+    if (!music || music->fontId == 0) {
+        return nullptr;
+    }
+    return target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, music->fontId);
+}
+
+} // namespace
+
+std::optional<Cmper> importFontDefinitionInto(const DocumentPtr& target,
+    const MusxInstance<others::FontDefinition>& source)
+{
+    MUSX_ASSERT_IF(!target) {
+        throw std::invalid_argument("importFontDefinitionInto received a null target document");
+    }
+    MUSX_ASSERT_IF(!source) {
+        throw std::invalid_argument("importFontDefinitionInto received a null font definition");
+    }
+
+    if (source->getCmper() != 0) {
+        return importNonZeroFontDefinition(target, source);
+    }
+
+    // Id 0 names the destination's own default music font rather than a typeface, so it is passed
+    // through. The definition is still created when missing, because the returned id has to
+    // resolve: a reference naming nothing is the defect this function exists to avoid.
+    const auto existing = target->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID);
+    const auto hasZero = std::any_of(existing.begin(), existing.end(),
+        [](const MusxInstance<others::FontDefinition>& font) { return font->getCmper() == 0; });
+    if (!hasZero) {
+        if (const auto music = findDefaultMusicFont(target)) {
+            // The target's own FontOptions already say which typeface id 0 stands for, and that
+            // answer outranks the source's.
+            cloneFontDefinition(target, music, 0);
+        } else {
+            cloneFontDefinition(target, source, 0);
+            // The same typeface must also be reachable by a concrete cmper. Id 0 tracks whatever
+            // the music font later becomes, and matching never selects it, so without this the
+            // typeface would be unaddressable as itself. Failing that leaves 0 resolvable, which
+            // is what was asked for, so the result still stands.
+            static_cast<void>(importNonZeroFontDefinition(target, source));
+        }
+    }
+    return 0;
+}
+
 std::string FontInfo::getName() const
 {
     if (auto fontDef = getDocument()->getOthers()->get<others::FontDefinition>(SCORE_PARTID, fontId)) {

--- a/src/musx/dom/CommonClasses.cpp
+++ b/src/musx/dom/CommonClasses.cpp
@@ -206,7 +206,9 @@ std::optional<Cmper> importFontDefinitionInto(const DocumentPtr& target,
             static_cast<void>(importNonZeroFontDefinition(target, source));
         }
     }
-    return 0;
+    // Cmper rather than a bare 0: constructing the optional from an int narrows, which MSVC
+    // reports under /W4 and the build treats as an error.
+    return Cmper(0);
 }
 
 std::string FontInfo::getName() const

--- a/src/musx/dom/CommonClasses.h
+++ b/src/musx/dom/CommonClasses.h
@@ -26,6 +26,7 @@
 #include <array>
 #include <string>
 #include <string_view>
+#include <optional>
 
 #include "musx/util/Fraction.h"
 #include "BaseClasses.h"
@@ -48,6 +49,7 @@ class LyricAssign;
 } // namespace details
 
 namespace others { // forward declarations
+class FontDefinition;
 class Measure;
 class OssiaHeader;
 class Staff;
@@ -68,6 +70,29 @@ using Duration = std::pair<NoteType, unsigned>;
 /// @return The normalized font name.
 [[nodiscard]]
 std::string normalizeFontName(std::string_view name);
+
+/// @brief Copies a font definition into another document, reusing an equivalent one when present.
+///
+/// A @ref Cmper is meaningful only within the document that issued it. A non-zero definition is
+/// therefore matched against @p target by normalized name (see @ref normalizeFontName) and never by
+/// cmper. The definition at cmper 0 is excluded from matching, and the lowest matching cmper wins.
+/// When nothing matches, the definition is copied to the next free cmper, retaining @p source's
+/// exact spelling.
+///
+/// Font id 0 is a sentinel for the document's default music font rather than an index to a
+/// typeface. It is returned unchanged, and a definition is created at 0 in @p target when absent,
+/// so that the returned id always resolves. The typeface for a created definition comes from
+/// @p target's own @ref options::FontOptions music font, falling back to @p source's definition
+/// at 0, which is then also given a non-zero cmper in @p target.
+///
+/// @param target The document to import into. May be the same document as @p source's.
+/// @param source The definition to import.
+/// @return The cmper naming the typeface within @p target, or std::nullopt when @p target has no
+/// free cmper left for a new definition. A returned 0 always means the default music font.
+/// @throws std::invalid_argument if @p target or @p source is null. Debug builds assert instead.
+[[nodiscard]]
+std::optional<Cmper> importFontDefinitionInto(const DocumentPtr& target,
+    const MusxInstance<others::FontDefinition>& source);
 
 /**
  * @struct FontInfo

--- a/src/musx/dom/CommonClasses.h
+++ b/src/musx/dom/CommonClasses.h
@@ -75,9 +75,8 @@ std::string normalizeFontName(std::string_view name);
 ///
 /// A @ref Cmper is meaningful only within the document that issued it. A non-zero definition is
 /// therefore matched against @p target by normalized name (see @ref normalizeFontName) and never by
-/// cmper. The definition at cmper 0 is excluded from matching, and the lowest matching cmper wins.
-/// When nothing matches, the definition is copied to the next free cmper, retaining @p source's
-/// exact spelling.
+/// cmper. The definition at cmper 0 is excluded from matching. When nothing matches, the
+/// definition is copied to the next free cmper, retaining @p source's exact spelling.
 ///
 /// Font id 0 is a sentinel for the document's default music font rather than an index to a
 /// typeface. It is returned unchanged, and a definition is created at 0 in @p target when absent,

--- a/src/musx/dom/ObjectPool.h
+++ b/src/musx/dom/ObjectPool.h
@@ -548,7 +548,7 @@ public:
         if (highest == (std::numeric_limits<Cmper>::max)()) {
             return std::nullopt;
         }
-        return static_cast<Cmper>(highest + 1);
+        return Cmper(highest + 1);
     }
 };
 /** @brief Shared `OthersPool` pointer */

--- a/src/musx/dom/ObjectPool.h
+++ b/src/musx/dom/ObjectPool.h
@@ -529,6 +529,27 @@ public:
         static_assert(is_pool_type_v<OthersPool, T>, "Type T is not registered in OthersPool");
         return m_pool.getEffectiveForPart<T>({ T::XmlNodeName, partId, cmper, std::nullopt, inci });
     }
+
+    /// @brief The cmper one past the highest currently used for @c T.
+    ///
+    /// Each type numbers independently, so a cmper free for one type says nothing about another.
+    ///
+    /// @tparam T The type whose cmpers are being counted.
+    /// @param partId The part to search.
+    /// @return The next free cmper, or std::nullopt when the cmper space for @c T is exhausted.
+    template <typename T>
+    std::optional<Cmper> nextFreeCmper(Cmper partId) const
+    {
+        static_assert(is_pool_type_v<OthersPool, T>, "Type T is not registered in OthersPool");
+        Cmper highest = 0;
+        for (const auto& item : getArray<T>(partId)) {
+            highest = (std::max)(highest, item->getCmper());
+        }
+        if (highest == (std::numeric_limits<Cmper>::max)()) {
+            return std::nullopt;
+        }
+        return static_cast<Cmper>(highest + 1);
+    }
 };
 /** @brief Shared `OthersPool` pointer */
 using OthersPoolPtr = std::shared_ptr<OthersPool>;

--- a/src/musx/dom/Options.cpp
+++ b/src/musx/dom/Options.cpp
@@ -133,26 +133,39 @@ MusxInstance<FontInfo> ClefOptions::ClefDef::calcFont() const
 // ***** FontOptions *****
 // ***********************
 
-MusxInstance<FontInfo> FontOptions::getFontInfo(FontOptions::FontType type) const
+MusxInstance<FontInfo> FontOptions::getFontInfoOrNull(FontOptions::FontType type) const
 {
     auto it = fontOptions.find(type);
-    if (it == fontOptions.end()) {
-        throw std::invalid_argument("Font type " + std::to_string(int(type)) + " not found in document");
+    return it == fontOptions.end() ? nullptr : it->second;
+}
+
+MusxInstance<FontInfo> FontOptions::getFontInfoOrNull(const DocumentPtr& document, FontOptions::FontType type)
+{
+    auto options = document->getOptions();
+    if (!options) {
+        return nullptr;
     }
-    return it->second;
+    auto fontOptions = options->get<FontOptions>();
+    if (!fontOptions) {
+        return nullptr;
+    }
+    return fontOptions->getFontInfoOrNull(type);
+}
+
+MusxInstance<FontInfo> FontOptions::getFontInfo(FontOptions::FontType type) const
+{
+    if (auto result = getFontInfoOrNull(type)) {
+        return result;
+    }
+    throw std::invalid_argument("Font type " + std::to_string(int(type)) + " not found in document");
 }
 
 MusxInstance<FontInfo> FontOptions::getFontInfo(const DocumentPtr& document, FontOptions::FontType type)
 {
-    auto options = document->getOptions();
-    if (!options) {
-        throw std::invalid_argument("No options found in document");
+    if (auto result = getFontInfoOrNull(document, type)) {
+        return result;
     }
-    auto fontOptions = options->get<FontOptions>();
-    if (!fontOptions) {
-        throw std::invalid_argument("Default fonts not found in document");
-    }
-    return fontOptions->getFontInfo(type);
+    throw std::invalid_argument("Font type " + std::to_string(int(type)) + " not found in document");
 }
 
 // *****************************

--- a/src/musx/dom/Options.h
+++ b/src/musx/dom/Options.h
@@ -465,10 +465,26 @@ public:
     std::unordered_map<FontType, MusxInstance<FontInfo>> fontOptions;
 
     /**
+     * @brief get the `FontInfo` for a particular type, if the document has one
+     * @param type the `FontType` to retrieve
+     * @return a shared pointer to the font info for that type, or nullptr if the document has none
+     */
+    MusxInstance<FontInfo> getFontInfoOrNull(FontType type) const;
+
+    /**
+     * @brief get the `FontInfo` for a particular type from the document pool, if there is one
+     * @param document the `Document` to search
+     * @param type the `FontType` to retrieve
+     * @return a shared pointer to the font info for that type, or nullptr if the document has no
+     * options, no default fonts, or no font of that type
+     */
+    static MusxInstance<FontInfo> getFontInfoOrNull(const DocumentPtr& document, FontType type);
+
+    /**
      * @brief get the `FontInfo` for a particular type
      * @param type the `FontType` to retrieve
      * @return a shared pointer to the font info for that type
-     * @throws std::invalid_paremter if the type is not found in the document
+     * @throws std::invalid_argument if the type is not found in the document
      */
     MusxInstance<FontInfo> getFontInfo(FontType type) const;
 
@@ -477,7 +493,7 @@ public:
      * @param document the `Document` to search
      * @param type the `FontType` to retrieve
      * @return a shared pointer to the font info for that type
-     * @throws std::invalid_paremter if the type is not found in the document
+     * @throws std::invalid_argument if the type is not found in the document
      */
     static MusxInstance<FontInfo> getFontInfo(const DocumentPtr& document, FontType type);
 

--- a/src/musx/dom/ShapeDesigner.cpp
+++ b/src/musx/dom/ShapeDesigner.cpp
@@ -219,6 +219,17 @@ ShapeDefInstruction::parseSetFont(const DocumentWeakPtr& document, const std::ve
     return std::nullopt;
 }
 
+std::vector<int> ShapeDefInstruction::encodeSetFont(const FontInfo& font)
+{
+    // Kept beside parseSetFont so the stored order is stated once. A caller rewriting a font
+    // reference in place would otherwise have to restate which item holds the id.
+    return {
+        int(font.fontId),
+        font.fontSize,
+        int(font.getEnigmaStyles())
+    };
+}
+
 std::optional<ShapeDefInstruction::SetGray>
 ShapeDefInstruction::parseSetGray(const std::vector<int>& data)
 {
@@ -631,6 +642,119 @@ bool ShapeDef::iterateInstructions(std::function<bool(const ShapeDefInstruction:
 
         return result;
     });
+}
+
+
+std::optional<Cmper> importShapeDefInto(const DocumentPtr& target,
+    const MusxInstance<ShapeDef>& source)
+{
+    MUSX_ASSERT_IF(!target) {
+        throw std::invalid_argument("importShapeDefInto received a null target document");
+    }
+    MUSX_ASSERT_IF(!source) {
+        throw std::invalid_argument("importShapeDefInto received a null shape");
+    }
+
+    const auto sourceDocument = source->getDocument();
+    const auto newShapeId = target->getOthers()->nextFreeCmper<ShapeDef>(SCORE_PARTID);
+    if (!newShapeId) {
+        return std::nullopt;
+    }
+
+    // SCORE_PARTID and ShareMode::All are correct for anything newly created: no linked part can
+    // reference an object that did not exist a moment ago, so there is nothing to unshare from.
+    // An importer for a ShareMode::None class would know to say so.
+    auto shape = std::make_shared<ShapeDef>(
+        target, SCORE_PARTID, EnigmaBase::ShareMode::All, *newShapeId);
+    shape->shapeType = source->shapeType;
+
+    // A shape that draws nothing owns no lists to copy.
+    if (source->instructionList == 0 && source->dataList == 0) {
+        target->getOthers()->add(ShapeDef::XmlNodeName, shape);
+        return *newShapeId;
+    }
+
+    const auto instructions = sourceDocument->getOthers()->get<ShapeInstructionList>(
+        source->getRequestedPartId(), source->instructionList);
+    const auto data = sourceDocument->getOthers()->get<ShapeData>(
+        source->getRequestedPartId(), source->dataList);
+    if (!instructions || !data) {
+        return std::nullopt;
+    }
+
+    // Every reference the instructions carry is resolved against the target before anything is
+    // added, so a shape that cannot be copied faithfully leaves no partial shape behind.
+    std::vector<int> values = data->values;
+    std::size_t dataIndex = 0;
+    for (const auto& instruction : instructions->instructions) {
+        const auto count = static_cast<std::size_t>(instruction->numData);
+        if (dataIndex + count > values.size()) {
+            return std::nullopt;
+        }
+        if (instruction->type == ShapeDefInstructionType::ExternalGraphic) {
+            /// @todo Copy the embedded graphic and remap the cmper, as is done for fonts below.
+            // Until then the instruction names a graphic by a cmper meaningful only in the source
+            // document, and refusing is the only answer that does not produce a shape pointing at
+            // the wrong thing.
+            return std::nullopt;
+        }
+        if (instruction->type == ShapeDefInstructionType::SetFont) {
+            const std::vector<int> stored(values.begin() + dataIndex,
+                values.begin() + dataIndex + count);
+            const auto parsed = ShapeDefInstruction::parseSetFont(sourceDocument, stored);
+            if (!parsed) {
+                return std::nullopt;
+            }
+            FontInfo font = parsed->font;
+            if (const auto sourceFont = sourceDocument->getOthers()->get<FontDefinition>(
+                    SCORE_PARTID, font.fontId)) {
+                const auto resolved = importFontDefinitionInto(target, sourceFont);
+                if (!resolved) {
+                    return std::nullopt;
+                }
+                font.fontId = *resolved;
+            } else if (font.fontId != 0) {
+                // The source names a font it does not itself define, so there is nothing to
+                // resolve and the number cannot be carried across.
+                return std::nullopt;
+            }
+            const auto encoded = ShapeDefInstruction::encodeSetFont(font);
+            for (std::size_t i = 0; i < encoded.size() && i < count; ++i) {
+                values[dataIndex + i] = encoded[i];
+            }
+        }
+        dataIndex += count;
+    }
+
+    const auto newInstructionsId =
+        target->getOthers()->nextFreeCmper<ShapeInstructionList>(SCORE_PARTID);
+    const auto newDataId = target->getOthers()->nextFreeCmper<ShapeData>(SCORE_PARTID);
+    if (!newInstructionsId || !newDataId) {
+        return std::nullopt;
+    }
+
+    auto newInstructions = std::make_shared<ShapeInstructionList>(
+        target, SCORE_PARTID, EnigmaBase::ShareMode::All, *newInstructionsId);
+    for (const auto& instruction : instructions->instructions) {
+        auto copy = std::make_shared<ShapeInstructionList::InstructionInfo>();
+        copy->numData = instruction->numData;
+        copy->type = instruction->type;
+        newInstructions->instructions.push_back(std::move(copy));
+    }
+
+    auto newData = std::make_shared<ShapeData>(
+        target, SCORE_PARTID, EnigmaBase::ShareMode::All, *newDataId);
+    newData->values = std::move(values);
+
+    // The three pools number independently, so the copied ShapeDef is rewired rather than
+    // assuming the source's numbers travel together.
+    shape->instructionList = *newInstructionsId;
+    shape->dataList = *newDataId;
+
+    target->getOthers()->add(ShapeInstructionList::XmlNodeName, newInstructions);
+    target->getOthers()->add(ShapeData::XmlNodeName, newData);
+    target->getOthers()->add(ShapeDef::XmlNodeName, shape);
+    return *newShapeId;
 }
 
 } // namespace others

--- a/src/musx/dom/ShapeDesigner.h
+++ b/src/musx/dom/ShapeDesigner.h
@@ -470,6 +470,11 @@ struct ShapeDefInstruction
     /// @brief Attempts to parse a SetFont instruction.
     static std::optional<SetFont> parseSetFont(const DocumentWeakPtr& document, const std::vector<int>& data);
 
+    /// @brief Builds the instruction data for a SetFont instruction.
+    /// @param font The font to encode.
+    /// @return The data items a SetFont instruction consumes, in stored order.
+    static std::vector<int> encodeSetFont(const FontInfo& font);
+
     /// @brief Attempts to parse a SetGray instruction.
     static std::optional<SetGray> parseSetGray(const std::vector<int>& data);
 
@@ -615,6 +620,30 @@ public:
     constexpr static std::string_view XmlNodeName = "shapeList"; ///< The XML node name for this type.
     static const xml::XmlElementArray<ShapeInstructionList>& xmlMappingArray(); ///< Required for musx::factory::FieldPopulator.
 };
+
+/// @brief Copies a shape and everything it owns into another document.
+///
+/// A shape is more than its @ref ShapeDef: the instruction list and data list it names are
+/// separate objects in their own pools, and a SetFont instruction inside the data names a font.
+/// Each is copied to the next free cmper in its own pool of @p target, and the copied
+/// @ref ShapeDef is rewired to the new numbers. Font references are resolved by
+/// @ref importFontDefinitionInto, so a copied shape never names a font by @p source's cmper.
+///
+/// Nothing is added to @p target unless the whole shape can be copied. Font definitions resolved
+/// along the way are an exception and may remain, which is harmless: an unreferenced definition
+/// changes no rendering.
+///
+/// @param target The document to import into. May be the same document as @p source's.
+/// @param source The shape to import.
+/// @return The @ref ShapeDef cmper within @p target, or std::nullopt when a pool has no free
+/// cmper left, when the source is missing its instruction or data list, or when a font it names
+/// cannot be resolved.
+/// @throws std::invalid_argument if @p target or @p source is null. Debug builds assert instead.
+/// @todo Copy embedded graphics, so that a shape containing an ExternalGraphic instruction can be
+/// imported rather than refused.
+[[nodiscard]]
+std::optional<Cmper> importShapeDefInto(const DocumentPtr& target,
+    const MusxInstance<ShapeDef>& source);
 
 } // namespace others
 } // namespace dom

--- a/tests/others/fonts.cpp
+++ b/tests/others/fonts.cpp
@@ -370,13 +370,6 @@ constexpr static musxtest::string_view importTargetProperties = R"xml(
       <family>0</family>
       <name>Times New Roman</name>
     </fontName>
-    <fontName cmper="7">
-      <charsetBank>Mac</charsetBank>
-      <charsetVal>0</charsetVal>
-      <pitch>0</pitch>
-      <family>0</family>
-      <name>timesnewroman</name>
-    </fontName>
   </others>
 </finale>
     )xml";
@@ -414,16 +407,15 @@ TEST(FontTest, ImportFontDefinitionMatchesByNameNotCmper)
 {
     auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importTargetProperties);
     auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importSourceProperties);
-    auto sourceFonts = source->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID);
+    const auto before = target->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID).size();
 
     auto times = source->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 1);
     ASSERT_TRUE(times);
-    // The same typeface sits at cmper 1 in the source and 3 in the target, and the source spells it
-    // with extra whitespace. Matching is by normalized name, and the lowest matching cmper wins:
-    // the target holds it at both 3 and 7.
+    // The same typeface sits at cmper 1 in the source and 3 in the target, and the source spells
+    // it with extra whitespace, so only a normalized comparison finds it.
     EXPECT_EQ(importFontDefinitionInto(target, times), std::optional<Cmper>(3));
-    EXPECT_EQ(target->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID).size(),
-        sourceFonts.size());
+    // Matching reuses what is there; nothing is added.
+    EXPECT_EQ(target->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID).size(), before);
 }
 
 TEST(FontTest, ImportFontDefinitionClonesWhenAbsentAndKeepsSpelling)
@@ -435,7 +427,7 @@ TEST(FontTest, ImportFontDefinitionClonesWhenAbsentAndKeepsSpelling)
     ASSERT_TRUE(seville);
     const auto imported = importFontDefinitionInto(target, seville);
     ASSERT_TRUE(imported);
-    EXPECT_EQ(*imported, 8); // one past the target's highest existing cmper, which is 7
+    EXPECT_EQ(*imported, 4); // one past the target's highest existing cmper, which is 3
 
     auto added = target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, *imported);
     ASSERT_TRUE(added);

--- a/tests/others/fonts.cpp
+++ b/tests/others/fonts.cpp
@@ -413,7 +413,7 @@ TEST(FontTest, ImportFontDefinitionMatchesByNameNotCmper)
     ASSERT_TRUE(times);
     // The same typeface sits at cmper 1 in the source and 3 in the target, and the source spells
     // it with extra whitespace, so only a normalized comparison finds it.
-    EXPECT_EQ(importFontDefinitionInto(target, times), std::optional<Cmper>(3));
+    EXPECT_EQ(importFontDefinitionInto(target, times), std::optional<Cmper>(Cmper(3)));
     // Matching reuses what is there; nothing is added.
     EXPECT_EQ(target->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID).size(), before);
 }
@@ -448,7 +448,7 @@ TEST(FontTest, ImportFontDefinitionPassesZeroThroughWithoutMatchingByName)
     ASSERT_TRUE(music);
     // Id 0 names the destination's own music font. Returning the source's typeface, or matching
     // "Maestro" into the target, would change what every element storing 0 renders as.
-    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(0));
+    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(Cmper(0)));
     auto zero = target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
     ASSERT_TRUE(zero);
     EXPECT_EQ(zero->name, "Jazz");
@@ -464,7 +464,7 @@ TEST(FontTest, ImportFontDefinitionCreatesZeroWhenTargetLacksIt)
 
     auto music = source->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
     ASSERT_TRUE(music);
-    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(0));
+    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(Cmper(0)));
 
     auto created = target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
     ASSERT_TRUE(created);
@@ -503,7 +503,7 @@ TEST(FontTest, ImportFontDefinitionTakesZeroFromTargetsOwnMusicFont)
     ASSERT_TRUE(music);
     EXPECT_EQ(music->name, "Maestro");
 
-    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(0));
+    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(Cmper(0)));
 
     // The target's own FontOptions name Broadway Copyist as its music font, so that is what id 0
     // stands for here. Taking the source's Maestro would have changed the typeface of everything
@@ -523,7 +523,7 @@ TEST(FontTest, ImportFontDefinitionFallbackAlsoGivesTheTypefaceANonZeroCmper)
 
     auto music = source->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
     ASSERT_TRUE(music);
-    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(0));
+    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(Cmper(0)));
 
     auto created = target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
     ASSERT_TRUE(created);

--- a/tests/others/fonts.cpp
+++ b/tests/others/fonts.cpp
@@ -351,3 +351,226 @@ TEST(FontTest, SameTypefaceDoesNotCompareNamesOfTwoConcreteIds)
     EXPECT_TRUE(sentinel->calcIsSameTypeface(*duplicate));
     EXPECT_FALSE(other->calcIsSameTypeface(*duplicate));
 }
+
+constexpr static musxtest::string_view importTargetProperties = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+  <others>
+    <fontName cmper="0">
+      <charsetBank>Mac</charsetBank>
+      <charsetVal>4095</charsetVal>
+      <pitch>0</pitch>
+      <family>0</family>
+      <name>Jazz</name>
+    </fontName>
+    <fontName cmper="3">
+      <charsetBank>Mac</charsetBank>
+      <charsetVal>0</charsetVal>
+      <pitch>0</pitch>
+      <family>0</family>
+      <name>Times New Roman</name>
+    </fontName>
+    <fontName cmper="7">
+      <charsetBank>Mac</charsetBank>
+      <charsetVal>0</charsetVal>
+      <pitch>0</pitch>
+      <family>0</family>
+      <name>timesnewroman</name>
+    </fontName>
+  </others>
+</finale>
+    )xml";
+
+constexpr static musxtest::string_view importSourceProperties = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+  <others>
+    <fontName cmper="0">
+      <charsetBank>Win</charsetBank>
+      <charsetVal>2</charsetVal>
+      <pitch>0</pitch>
+      <family>0</family>
+      <name>Maestro</name>
+    </fontName>
+    <fontName cmper="1">
+      <charsetBank>Win</charsetBank>
+      <charsetVal>0</charsetVal>
+      <pitch>1</pitch>
+      <family>2</family>
+      <name>  Times   New Roman </name>
+    </fontName>
+    <fontName cmper="4">
+      <charsetBank>Win</charsetBank>
+      <charsetVal>0</charsetVal>
+      <pitch>0</pitch>
+      <family>0</family>
+      <name>Seville</name>
+    </fontName>
+  </others>
+</finale>
+    )xml";
+
+TEST(FontTest, ImportFontDefinitionMatchesByNameNotCmper)
+{
+    auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importTargetProperties);
+    auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importSourceProperties);
+    auto sourceFonts = source->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID);
+
+    auto times = source->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 1);
+    ASSERT_TRUE(times);
+    // The same typeface sits at cmper 1 in the source and 3 in the target, and the source spells it
+    // with extra whitespace. Matching is by normalized name, and the lowest matching cmper wins:
+    // the target holds it at both 3 and 7.
+    EXPECT_EQ(importFontDefinitionInto(target, times), std::optional<Cmper>(3));
+    EXPECT_EQ(target->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID).size(),
+        sourceFonts.size());
+}
+
+TEST(FontTest, ImportFontDefinitionClonesWhenAbsentAndKeepsSpelling)
+{
+    auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importTargetProperties);
+    auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importSourceProperties);
+
+    auto seville = source->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 4);
+    ASSERT_TRUE(seville);
+    const auto imported = importFontDefinitionInto(target, seville);
+    ASSERT_TRUE(imported);
+    EXPECT_EQ(*imported, 8); // one past the target's highest existing cmper, which is 7
+
+    auto added = target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, *imported);
+    ASSERT_TRUE(added);
+    EXPECT_EQ(added->name, "Seville");
+    EXPECT_EQ(added->charsetBank, others::FontDefinition::CharacterSetBank::Windows);
+    EXPECT_EQ(added->charsetVal, 0);
+
+    // A second import of the same typeface finds the copy rather than making another.
+    EXPECT_EQ(importFontDefinitionInto(target, seville), imported);
+}
+
+TEST(FontTest, ImportFontDefinitionPassesZeroThroughWithoutMatchingByName)
+{
+    auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importTargetProperties);
+    auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importSourceProperties);
+
+    auto music = source->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
+    ASSERT_TRUE(music);
+    // Id 0 names the destination's own music font. Returning the source's typeface, or matching
+    // "Maestro" into the target, would change what every element storing 0 renders as.
+    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(0));
+    auto zero = target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
+    ASSERT_TRUE(zero);
+    EXPECT_EQ(zero->name, "Jazz");
+}
+
+TEST(FontTest, ImportFontDefinitionCreatesZeroWhenTargetLacksIt)
+{
+    auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(fontProperties);
+    auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importSourceProperties);
+
+    // This target defines only cmper 1, so the returned id would otherwise name nothing.
+    EXPECT_FALSE(target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0));
+
+    auto music = source->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
+    ASSERT_TRUE(music);
+    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(0));
+
+    auto created = target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
+    ASSERT_TRUE(created);
+    EXPECT_EQ(created->name, "Maestro");
+}
+
+constexpr static musxtest::string_view targetWithMusicFontButNoZero = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+  <options>
+    <fontOptions>
+      <font type="music">
+        <fontID>5</fontID>
+        <fontSize>24</fontSize>
+      </font>
+    </fontOptions>
+  </options>
+  <others>
+    <fontName cmper="5">
+      <charsetBank>Mac</charsetBank>
+      <charsetVal>4095</charsetVal>
+      <pitch>0</pitch>
+      <family>0</family>
+      <name>Broadway Copyist</name>
+    </fontName>
+  </others>
+</finale>
+    )xml";
+
+TEST(FontTest, ImportFontDefinitionTakesZeroFromTargetsOwnMusicFont)
+{
+    auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(targetWithMusicFontButNoZero);
+    auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importSourceProperties);
+
+    auto music = source->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
+    ASSERT_TRUE(music);
+    EXPECT_EQ(music->name, "Maestro");
+
+    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(0));
+
+    // The target's own FontOptions name Broadway Copyist as its music font, so that is what id 0
+    // stands for here. Taking the source's Maestro would have changed the typeface of everything
+    // in the target that stores 0.
+    auto created = target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
+    ASSERT_TRUE(created);
+    EXPECT_EQ(created->name, "Broadway Copyist");
+}
+
+TEST(FontTest, ImportFontDefinitionFallbackAlsoGivesTheTypefaceANonZeroCmper)
+{
+    // This target has no FontOptions, so it cannot say what its music font is, and no definition
+    // at 0. The source's own default music font is the only remaining answer.
+    auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(fontProperties);
+    auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importSourceProperties);
+    EXPECT_FALSE(target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0));
+
+    auto music = source->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
+    ASSERT_TRUE(music);
+    EXPECT_EQ(importFontDefinitionInto(target, music), std::optional<Cmper>(0));
+
+    auto created = target->getOthers()->get<others::FontDefinition>(SCORE_PARTID, 0);
+    ASSERT_TRUE(created);
+    EXPECT_EQ(created->name, "Maestro");
+
+    // Id 0 tracks whatever the music font later becomes and is never selected by matching, so the
+    // typeface must also be addressable under a concrete cmper.
+    auto fonts = target->getOthers()->getArray<others::FontDefinition>(SCORE_PARTID);
+    const auto named = std::count_if(fonts.begin(), fonts.end(),
+        [](const MusxInstance<others::FontDefinition>& font) {
+            return font->getCmper() != 0 && normalizeFontName(font->name) == "maestro";
+        });
+    EXPECT_EQ(named, 1);
+}
+
+TEST(FontTest, GetFontInfoOrNullReportsAbsenceInsteadOfThrowing)
+{
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(fontProperties);
+    auto fontOptions = doc->getOptions()->get<options::FontOptions>();
+    ASSERT_TRUE(fontOptions);
+
+    // Present: both forms agree with the throwing accessor.
+    auto music = fontOptions->getFontInfoOrNull(options::FontOptions::FontType::Music);
+    ASSERT_TRUE(music);
+    EXPECT_EQ(music->fontId, 13);
+    EXPECT_EQ(options::FontOptions::getFontInfoOrNull(doc, options::FontOptions::FontType::Music)->fontId, 13);
+    EXPECT_EQ(fontOptions->getFontInfo(options::FontOptions::FontType::Music)->fontId, 13);
+
+    // Absent: null rather than an exception, while the throwing accessor still throws.
+    EXPECT_FALSE(fontOptions->getFontInfoOrNull(options::FontOptions::FontType::Tablature));
+    EXPECT_FALSE(options::FontOptions::getFontInfoOrNull(doc, options::FontOptions::FontType::Tablature));
+    EXPECT_THROW(static_cast<void>(fontOptions->getFontInfo(options::FontOptions::FontType::Tablature)),
+        std::invalid_argument);
+}
+
+TEST(FontTest, GetFontInfoOrNullHandlesADocumentWithNoFontOptions)
+{
+    // A document whose options pool has no FontOptions at all must not throw from the static form.
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(importTargetProperties);
+    EXPECT_FALSE(doc->getOptions()->get<options::FontOptions>());
+    EXPECT_FALSE(options::FontOptions::getFontInfoOrNull(doc, options::FontOptions::FontType::Music));
+}

--- a/tests/others/shape.cpp
+++ b/tests/others/shape.cpp
@@ -590,3 +590,195 @@ TEST(ShapeDefTest, CalculateSlurContourDirection)
         EXPECT_EQ(direction, expectedDirections[i]) << "contour mismatch for cmper " << shapes[i]->getCmper();
     }
 }
+
+constexpr static musxtest::string_view shapeImportSourceXml = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+    <others>
+        <fontName cmper="9">
+            <charsetBank>Mac</charsetBank>
+            <charsetVal>4095</charsetVal>
+            <pitch>0</pitch>
+            <family>0</family>
+            <name>Seville</name>
+        </fontName>
+        <shapeData cmper="3">
+            <data>9</data>
+            <data>24</data>
+            <data>1</data>
+            <data>57</data>
+        </shapeData>
+        <shapeDef cmper="2">
+            <instList>4</instList>
+            <dataList>3</dataList>
+            <shapeType>clef</shapeType>
+        </shapeDef>
+        <shapeList cmper="4">
+            <instruct>
+                <numData>3</numData>
+                <tag>setFont</tag>
+            </instruct>
+            <instruct>
+                <numData>1</numData>
+                <tag>drawChar</tag>
+            </instruct>
+        </shapeList>
+    </others>
+</finale>
+    )xml";
+
+constexpr static musxtest::string_view shapeImportTargetXml = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+    <others>
+        <fontName cmper="1">
+            <charsetBank>Mac</charsetBank>
+            <charsetVal>0</charsetVal>
+            <pitch>0</pitch>
+            <family>0</family>
+            <name>Times New Roman</name>
+        </fontName>
+        <shapeData cmper="8">
+            <data>0</data>
+        </shapeData>
+        <shapeDef cmper="6">
+            <instList>7</instList>
+            <dataList>8</dataList>
+            <shapeType>articulation</shapeType>
+        </shapeDef>
+        <shapeList cmper="7">
+            <instruct>
+                <numData>1</numData>
+                <tag>lineWidth</tag>
+            </instruct>
+        </shapeList>
+    </others>
+</finale>
+    )xml";
+
+TEST(ShapeTest, ImportShapeDefCopiesListsAndRemapsItsFont)
+{
+    auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(shapeImportSourceXml);
+    auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(shapeImportTargetXml);
+
+    auto shape = source->getOthers()->get<others::ShapeDef>(SCORE_PARTID, 2);
+    ASSERT_TRUE(shape);
+
+    const auto imported = others::importShapeDefInto(target, shape);
+    ASSERT_TRUE(imported);
+    // Each pool numbers independently, so the copy takes the next free cmper in each.
+    EXPECT_EQ(*imported, 7);
+
+    auto copied = target->getOthers()->get<others::ShapeDef>(SCORE_PARTID, *imported);
+    ASSERT_TRUE(copied);
+    EXPECT_EQ(copied->shapeType, others::ShapeDef::ShapeType::Clef);
+    EXPECT_EQ(copied->instructionList, 8);
+    EXPECT_EQ(copied->dataList, 9);
+    // The source numbered its lists 4 and 3; carrying those across would have named the target's
+    // own unrelated shapeList 4 and shapeData 3.
+    EXPECT_NE(copied->instructionList, shape->instructionList);
+    EXPECT_NE(copied->dataList, shape->dataList);
+
+    // Seville is absent from the target, so it is cloned; the setFont data must name the new
+    // cmper rather than the source's 9.
+    bool sawFont = false;
+    copied->iterateInstructions([&](const ShapeDefInstruction::Decoded& decoded) {
+        if (const auto setFont = std::get_if<ShapeDefInstruction::SetFont>(&decoded.data)) {
+            sawFont = true;
+            EXPECT_NE(setFont->font.fontId, 9);
+            EXPECT_EQ(setFont->font.getName(), "Seville");
+            EXPECT_EQ(setFont->font.fontSize, 24);
+            EXPECT_TRUE(setFont->font.bold);
+        }
+        return true;
+    });
+    EXPECT_TRUE(sawFont);
+
+    // The instruction stream and the non-font data are copied verbatim.
+    auto copiedData = target->getOthers()->get<others::ShapeData>(SCORE_PARTID, copied->dataList);
+    ASSERT_TRUE(copiedData);
+    ASSERT_EQ(copiedData->values.size(), 4u);
+    EXPECT_EQ(copiedData->values[1], 24);
+    EXPECT_EQ(copiedData->values[3], 57);
+}
+
+constexpr static musxtest::string_view shapeWithGraphicXml = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+    <others>
+        <shapeData cmper="1">
+            <data>100</data>
+            <data>200</data>
+            <data>12</data>
+        </shapeData>
+        <shapeDef cmper="1">
+            <instList>1</instList>
+            <dataList>1</dataList>
+            <shapeType>expression</shapeType>
+        </shapeDef>
+        <shapeList cmper="1">
+            <instruct>
+                <numData>3</numData>
+                <tag>extGraphic</tag>
+            </instruct>
+        </shapeList>
+        <shapeDef cmper="2">
+            <shapeType>other</shapeType>
+        </shapeDef>
+    </others>
+</finale>
+    )xml";
+
+TEST(ShapeTest, ImportShapeDefRefusesAShapeNamingAGraphic)
+{
+    auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(shapeWithGraphicXml);
+    auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(shapeImportTargetXml);
+
+    auto shape = source->getOthers()->get<others::ShapeDef>(SCORE_PARTID, 1);
+    ASSERT_TRUE(shape);
+
+    // The graphic is named by a cmper that means nothing in the target, and graphics are not
+    // copied yet, so the shape cannot be imported faithfully.
+    EXPECT_FALSE(others::importShapeDefInto(target, shape));
+
+    // Nothing partial is left behind: the target keeps only the shape it already had.
+    EXPECT_EQ(target->getOthers()->getArray<others::ShapeDef>(SCORE_PARTID).size(), 1u);
+    EXPECT_EQ(target->getOthers()->getArray<others::ShapeData>(SCORE_PARTID).size(), 1u);
+    EXPECT_EQ(target->getOthers()->getArray<others::ShapeInstructionList>(SCORE_PARTID).size(), 1u);
+}
+
+TEST(ShapeTest, ImportShapeDefCopiesABlankShapeWithoutLists)
+{
+    auto source = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(shapeWithGraphicXml);
+    auto target = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(shapeImportTargetXml);
+
+    auto blank = source->getOthers()->get<others::ShapeDef>(SCORE_PARTID, 2);
+    ASSERT_TRUE(blank);
+    ASSERT_TRUE(blank->isBlank());
+
+    const auto imported = others::importShapeDefInto(target, blank);
+    ASSERT_TRUE(imported);
+    auto copied = target->getOthers()->get<others::ShapeDef>(SCORE_PARTID, *imported);
+    ASSERT_TRUE(copied);
+    EXPECT_TRUE(copied->isBlank());
+    EXPECT_EQ(copied->instructionList, 0);
+    EXPECT_EQ(copied->dataList, 0);
+    // A shape that draws nothing owns no lists, so none were created.
+    EXPECT_EQ(target->getOthers()->getArray<others::ShapeData>(SCORE_PARTID).size(), 1u);
+}
+
+TEST(ShapeTest, NextFreeCmperIsPerType)
+{
+    auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(shapeImportTargetXml);
+    auto others = doc->getOthers();
+
+    // Each type numbers independently: this document holds shapeDef 6, shapeList 7, shapeData 8
+    // and fontName 1, so no single answer serves all four.
+    EXPECT_EQ(others->nextFreeCmper<others::ShapeDef>(SCORE_PARTID), std::optional<Cmper>(7));
+    EXPECT_EQ(others->nextFreeCmper<others::ShapeInstructionList>(SCORE_PARTID), std::optional<Cmper>(8));
+    EXPECT_EQ(others->nextFreeCmper<others::ShapeData>(SCORE_PARTID), std::optional<Cmper>(9));
+    EXPECT_EQ(others->nextFreeCmper<others::FontDefinition>(SCORE_PARTID), std::optional<Cmper>(2));
+
+    // An empty pool starts at 1, leaving 0 for whatever sentinel meaning the type gives it.
+    EXPECT_EQ(others->nextFreeCmper<others::TextExpressionDef>(SCORE_PARTID), std::optional<Cmper>(1));
+}

--- a/tests/others/shape.cpp
+++ b/tests/others/shape.cpp
@@ -774,11 +774,11 @@ TEST(ShapeTest, NextFreeCmperIsPerType)
 
     // Each type numbers independently: this document holds shapeDef 6, shapeList 7, shapeData 8
     // and fontName 1, so no single answer serves all four.
-    EXPECT_EQ(others->nextFreeCmper<others::ShapeDef>(SCORE_PARTID), std::optional<Cmper>(7));
-    EXPECT_EQ(others->nextFreeCmper<others::ShapeInstructionList>(SCORE_PARTID), std::optional<Cmper>(8));
-    EXPECT_EQ(others->nextFreeCmper<others::ShapeData>(SCORE_PARTID), std::optional<Cmper>(9));
-    EXPECT_EQ(others->nextFreeCmper<others::FontDefinition>(SCORE_PARTID), std::optional<Cmper>(2));
+    EXPECT_EQ(others->nextFreeCmper<others::ShapeDef>(SCORE_PARTID), std::optional<Cmper>(Cmper(7)));
+    EXPECT_EQ(others->nextFreeCmper<others::ShapeInstructionList>(SCORE_PARTID), std::optional<Cmper>(Cmper(8)));
+    EXPECT_EQ(others->nextFreeCmper<others::ShapeData>(SCORE_PARTID), std::optional<Cmper>(Cmper(9)));
+    EXPECT_EQ(others->nextFreeCmper<others::FontDefinition>(SCORE_PARTID), std::optional<Cmper>(Cmper(2)));
 
     // An empty pool starts at 1, leaving 0 for whatever sentinel meaning the type gives it.
-    EXPECT_EQ(others->nextFreeCmper<others::TextExpressionDef>(SCORE_PARTID), std::optional<Cmper>(1));
+    EXPECT_EQ(others->nextFreeCmper<others::TextExpressionDef>(SCORE_PARTID), std::optional<Cmper>(Cmper(1)));
 }


### PR DESCRIPTION
A `Cmper` is meaningful only inside the document that issued it, so a client copying an object between documents cannot carry its references across as numbers. These two entry points resolve them instead.

`finale-mus-reader` needs both: it completes a legacy document's `ClefOptions` from a pinned Finale 27 baseline, and the two tablature clef definitions it takes from there are drawn as shapes.

## `importFontDefinitionInto`

Matches a non-zero definition against the target by normalized name, never by cmper, and otherwise copies it to the next free cmper while retaining the source's exact spelling.

Font id 0 is a sentinel for the document's own default music font rather than an index to a typeface, so it is returned unchanged: resolving it against the source would bind the destination to the source's music font and silently change the typeface of everything storing 0. The definition is still created when the target lacks one, because the returned id has to resolve. Its typeface comes from the target's own `FontOptions` music font, which outranks the source's answer, falling back to the source's definition at 0 — which is then also given a non-zero cmper, since matching never selects 0 and it would otherwise be unaddressable as itself.

## `importShapeDefInto`

Copies the `ShapeDef`, its `ShapeInstructionList` and its `ShapeData`, each to the next free cmper in its own pool, and rewires the copy. `setFont` instructions resolve through `importFontDefinitionInto`, so a copied shape never names a font by the source's comparator.

That needed `encodeSetFont`, since the font lives in an untyped data array only `parseSetFont` can interpret. It sits beside the parser so the stored order is stated once.

Nothing is added to the target unless the whole shape can be copied. An instruction naming an embedded graphic is refused and marked `@todo`; graphics are not copied yet, and a copy carrying the source's graphic comparator would point at whatever shared that number.

## Supporting changes

- `FontOptions::getFontInfoOrNull`, member and static, with `getFontInfo` implemented as a throwing wrapper. The static form threw three different ways — no options pool, no `FontOptions`, no such type — none of which a caller asking whether a font exists wants as an exception.
- `OthersPool::nextFreeCmper`, which had been written twice.
- Two `AGENTS.md` style rules: Doxygen documents the contract rather than its history, and null checks that catch program bugs use `MUSX_ASSERT_IF` alongside a throw.

Objects created by either importer are `SCORE_PARTID` and `ShareMode::All`. A brand-new object cannot be referenced by a linked part, so there is nothing to unshare from.

## Tests

Ten added. The font ones cover matching under a differing spelling, cloning, both zero paths, and the fallback's non-zero guarantee. The shape ones cover the font remap with independent pool numbering, the graphic refusal leaving no partial state, a blank shape owning no lists, and `nextFreeCmper` returning four different answers for four types in one document.

432/432 pass.