### PR TITLE
Recognize empty shape instruction lists as blank

### DIFF
--- a/src/musx/dom/ShapeDesigner.cpp
+++ b/src/musx/dom/ShapeDesigner.cpp
@@ -499,6 +499,24 @@ CurveContourDirection ShapeDef::calcSlurContour() const
     return (topExtent >= bottomExtent) ? CurveContourDirection::Up : CurveContourDirection::Down;
 }
 
+bool ShapeDef::isBlank() const
+{
+    if (instructionList == 0) {
+        return true;
+    }
+    // Some legacy documents retain a nonzero reference to an intentionally empty
+    // instruction collection. A missing collection is unresolved rather than blank.
+    const auto instructions = getDocument()->getOthers()->get<ShapeInstructionList>(
+        getRequestedPartId(), instructionList);
+    if (!instructions) {
+        util::Logger::log(util::Logger::LogLevel::Verbose,
+            "ShapeDef " + std::to_string(getCmper()) + " references missing instruction list "
+                + std::to_string(instructionList) + ".");
+        return false;
+    }
+    return instructions->instructions.empty();
+}
+
 bool ShapeDef::iterateInstructions(std::function<bool(ShapeDefInstructionType, std::vector<int>)> callback) const
 {
     if (instructionList == 0 && dataList == 0) {

--- a/src/musx/dom/ShapeDesigner.h
+++ b/src/musx/dom/ShapeDesigner.h
@@ -558,9 +558,8 @@ public:
     Cmper dataList{};           ///< Instruction data list @ref Cmper.
     ShapeType shapeType{};      ///< Shape type (specifies which type of entity this shape pertains to)
 
-    /// @brief Returns true if this shape does not draw anything.
-    bool isBlank() const
-    { return instructionList == 0; }
+    /// @brief Returns true if this shape has no instruction list or its resolved list is empty.
+    bool isBlank() const;
 
     /// @brief Iterates through the instructions in the shape
     /// @param callback The callback function. Returning `false` from this function aborts the iteration loop.

--- a/tests/others/shape.cpp
+++ b/tests/others/shape.cpp
@@ -312,6 +312,64 @@ TEST(ShapeDefTest, RecognizeShapes)
     }
 }
 
+TEST(ShapeDefTest, RecognizeResolvedEmptyInstructionListAsBlank)
+{
+    constexpr musxtest::string_view xml = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+    <others>
+        <shapeDef cmper="1">
+            <instList>9</instList>
+            <dataList>9</dataList>
+        </shapeDef>
+        <shapeList cmper="9"/>
+    </others>
+</finale>
+)xml";
+    auto document = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(xml);
+    ASSERT_TRUE(document);
+    const auto shape = document->getOthers()->get<others::ShapeDef>(SCORE_PARTID, 1);
+    ASSERT_TRUE(shape);
+    EXPECT_EQ(shape->instructionList, 9);
+    EXPECT_EQ(shape->dataList, 9);
+    EXPECT_TRUE(shape->isBlank());
+    EXPECT_EQ(shape->recognize(), KnownShapeDefType::Blank);
+}
+
+TEST(ShapeDefTest, MissingInstructionListIsVerboseAndNotBlank)
+{
+    constexpr musxtest::string_view xml = R"xml(
+<?xml version="1.0" encoding="UTF-8"?>
+<finale>
+    <others>
+        <shapeDef cmper="1">
+            <instList>9</instList>
+            <dataList>9</dataList>
+        </shapeDef>
+    </others>
+</finale>
+)xml";
+    auto document = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(xml);
+    ASSERT_TRUE(document);
+    const auto shape = document->getOthers()->get<others::ShapeDef>(SCORE_PARTID, 1);
+    ASSERT_TRUE(shape);
+
+    auto previousLogger = musx::util::Logger::getCallback();
+    struct LoggerRestorer {
+        musx::util::Logger::LogCallback callback;
+        ~LoggerRestorer() { musx::util::Logger::setCallback(std::move(callback)); }
+    } loggerRestorer{previousLogger};
+    std::vector<std::pair<musx::util::Logger::LogLevel, std::string>> diagnostics;
+    musx::util::Logger::setCallback([&](musx::util::Logger::LogLevel level, const std::string& message) {
+        diagnostics.emplace_back(level, message);
+    });
+
+    EXPECT_FALSE(shape->isBlank());
+    ASSERT_EQ(diagnostics.size(), 1u);
+    EXPECT_EQ(diagnostics[0].first, musx::util::Logger::LogLevel::Verbose);
+    EXPECT_EQ(diagnostics[0].second, "ShapeDef 1 references missing instruction list 9.");
+}
+
 TEST(ShapeDefTest, RecognizeVerticalLineRightHooks)
 {
     auto doc = musx::factory::DocumentFactory::create<musx::xml::rapidxml::Document>(verticalLineRightHooksXml);


### PR DESCRIPTION
## Summary

- move `ShapeDef::isBlank()` out of the header so it can resolve the referenced instruction list
- recognize a present but empty instruction list as a blank shape
- keep a nonzero missing instruction list nonblank and emit a verbose diagnostic
- cover both the resolved-empty and unresolved-reference cases

## Motivation

Some legacy Finale documents preserve nonzero shape instruction/data cmpers while the referenced instruction list is intentionally empty. Finale displays these shapes as blank, and importers should be able to preserve the original references without preventing `ShapeRecognizer` from classifying the shape as `Blank`.

## Testing

- focused ShapeDef tests: 3 passed
- full musxdom suite: 438 passed
- downstream finale-mus-reader suite: 46 passed
- downstream unity build and suite: 46 passed