### PR TITLE
Fix legacy ShapeDef graphic resolution

### DIFF
--- a/src/musx/dom/Graphics.cpp
+++ b/src/musx/dom/Graphics.cpp
@@ -38,7 +38,7 @@ MusxInstance<ShapeGraphicAssign> ShapeGraphicAssign::findForGraphic(
     // up without that incidence does not match its object key. Older documents may also key
     // assignments independently and carry the instruction comparator in graphicCmper.
     if (auto assignment = document->getOthers()
-            ->get<ShapeGraphicAssign>(partId, graphicCmper, Inci{})) {
+            ->get<ShapeGraphicAssign>(partId, graphicCmper, Inci(0))) {
         return assignment;
     }
     for (const auto& assignment : document->getOthers()

--- a/src/musx/dom/Graphics.cpp
+++ b/src/musx/dom/Graphics.cpp
@@ -38,7 +38,7 @@ MusxInstance<ShapeGraphicAssign> ShapeGraphicAssign::findForGraphic(
     // up without that incidence does not match its object key. Older documents may also key
     // assignments independently and carry the instruction comparator in graphicCmper.
     if (auto assignment = document->getOthers()
-            ->get<ShapeGraphicAssign>(partId, graphicCmper, 0)) {
+            ->get<ShapeGraphicAssign>(partId, graphicCmper, Inci{})) {
         return assignment;
     }
     for (const auto& assignment : document->getOthers()

--- a/src/musx/dom/Graphics.cpp
+++ b/src/musx/dom/Graphics.cpp
@@ -30,6 +30,24 @@ namespace musx {
 namespace dom {
 namespace others {
 
+MusxInstance<ShapeGraphicAssign> ShapeGraphicAssign::findForGraphic(
+    const DocumentPtr& document, Cmper partId, Cmper graphicCmper)
+{
+    if (!document || !document->getOthers()) return {};
+    // ShapeGraphicAssign is an incident class whose observed incidence is zero. Looking it
+    // up without that incidence does not match its object key. Older documents may also key
+    // assignments independently and carry the instruction comparator in graphicCmper.
+    if (auto assignment = document->getOthers()
+            ->get<ShapeGraphicAssign>(partId, graphicCmper, 0)) {
+        return assignment;
+    }
+    for (const auto& assignment : document->getOthers()
+            ->getArray<ShapeGraphicAssign>(partId)) {
+        if (assignment->graphicCmper == graphicCmper) return assignment;
+    }
+    return {};
+}
+
 // *****************************
 // ***** PageGraphicAssign *****
 // *****************************

--- a/src/musx/dom/Graphics.h
+++ b/src/musx/dom/Graphics.h
@@ -313,6 +313,14 @@ public:
     Evpu origHeight{};      ///< Original (intrinsic) height in Evpu
     Cmper graphicCmper{};   ///< Graphic instance Cmper. (See #others::PageGraphicAssign::graphicCmper for full explanation.)
 
+    /// @brief Finds the assignment used by a ShapeDef ExternalGraphic instruction.
+    /// @param document The document containing the shape and assignment.
+    /// @param partId The requested part ID.
+    /// @param graphicCmper The comparator stored by the ExternalGraphic instruction.
+    /// @return The matching assignment, or an empty instance when none exists.
+    static MusxInstance<ShapeGraphicAssign> findForGraphic(
+        const DocumentPtr& document, Cmper partId, Cmper graphicCmper);
+
     constexpr static std::string_view XmlNodeName = "shapeGraphicAssign"; ///< The XML node name for this type.
     static const xml::XmlElementArray<ShapeGraphicAssign>& xmlMappingArray(); ///< Required for musx::factory::FieldPopulator.
 };

--- a/src/musx/util/SvgConvert.cpp
+++ b/src/musx/util/SvgConvert.cpp
@@ -2359,18 +2359,8 @@ std::string SvgConvert::toSvg(const dom::others::ShapeDef& shape,
             dom::MusxInstance<dom::others::ShapeGraphicAssign> assignment;
 
             if (auto doc = shape.getDocument()) {
-                if (auto others = doc->getOthers()) {
-                    assignment = others->get<dom::others::ShapeGraphicAssign>(shape.getRequestedPartId(), graphicCmper);
-                    if (!assignment) {
-                        auto assigns = others->getArray<dom::others::ShapeGraphicAssign>(shape.getRequestedPartId());
-                        for (const auto& nextAssign : assigns) {
-                            if (nextAssign->graphicCmper == graphicCmper) {
-                                assignment = nextAssign;
-                                break;
-                            }
-                        }
-                    }
-                }
+                assignment = dom::others::ShapeGraphicAssign::findForGraphic(
+                    doc, shape.getRequestedPartId(), graphicCmper);
             }
 
             std::optional<ExternalGraphicPayload> payload;

--- a/tests/others/graphics.cpp
+++ b/tests/others/graphics.cpp
@@ -304,7 +304,7 @@ TEST(ShapeGraphicAssignTest, PopulateFields)
       <savedRecord/>
       <origWidth>336</origWidth>
       <origHeight>168</origHeight>
-      <graphicCmper>1</graphicCmper>
+      <graphicCmper>0</graphicCmper>
     </shapeGraphicAssign>
   </others>
 </finale>
@@ -332,6 +332,10 @@ TEST(ShapeGraphicAssignTest, PopulateFields)
     EXPECT_EQ(g->hAlign, others::ShapeGraphicAssign::HorizontalAlignment::Left);
     EXPECT_EQ(g->vAlign, others::ShapeGraphicAssign::VerticalAlignment::Top);
 
+    // Legacy assignments may omit graphicCmper and are then identified by their own
+    // comparator. The lookup must include the class's mandatory zero incidence.
+    EXPECT_EQ(others::ShapeGraphicAssign::findForGraphic(doc, SCORE_PARTID, 1), g);
+
     // Boolean-presence nodes
     EXPECT_TRUE(g->fixedPerc);
     EXPECT_TRUE(g->savedRecord);
@@ -341,5 +345,5 @@ TEST(ShapeGraphicAssignTest, PopulateFields)
 
     EXPECT_EQ(g->origWidth, 336);
     EXPECT_EQ(g->origHeight, 168);
-    EXPECT_EQ(g->graphicCmper, 1);
+    EXPECT_EQ(g->graphicCmper, 0);
 }


### PR DESCRIPTION
## Summary
- add a single ShapeGraphicAssign lookup for ShapeDef ExternalGraphic operands
- include the mandatory zero incidence when the assignment comparator is the graphic comparator
- fall back to matching graphicCmper for later assignment layouts
- use the shared lookup from SVG conversion

## Validation
- ctest: 438/438 passed
- exercised by finale-mus-reader normal and unity builds: 54/54 passed