### PR TITLE
Add format-neutral fretboard display data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(MUSX_SRC_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/Arpeggio.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/Cue.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/EnigmaString.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/Fretboard.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/Layout.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/PseudoTieUtils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/musx/util/ShapeRecognize.cpp

--- a/src/music_theory/music_theory.hpp
+++ b/src/music_theory/music_theory.hpp
@@ -157,11 +157,15 @@ constexpr T sign(T n)
 /// @param n The number (positive or negative) for which to calculate the modulus
 /// @param d The base of the modulus. This must be a positive number.
 /// @return For non-negative, the result is the same as `%`. For negative numbers, the result is `-1 * (abs(n) % d)`.
+/// @note Since C++11 integer division is guaranteed to truncate toward zero, which makes `%` already
+/// carry the sign of @p n. Spelling this out with `abs` instead would defeat constant evaluation on any
+/// standard library that has not yet made `std::abs` constexpr, and is undefined for the most negative
+/// value of @p T.
 template <typename T>
 constexpr T signedModulus(T n, T d)
 {
     static_assert(std::is_integral_v<T>, "signedModulus requires an integer type");
-    return sign(n) * (std::abs(n) % d);
+    return n % d;
 }
 
 /// @brief Calculates a positive modulus in the range [0, d-1], even for negative dividends.
@@ -181,6 +185,41 @@ constexpr T positiveModulus(T n, T d, T* q = nullptr)
         if (q) --(*q);
     }
     return result;
+}
+
+/// @brief Calculates the pitch class of a spelled note name.
+/// @details The pitch class is the note's chromatic position within one octave, counting from the
+/// natural note name and then applying the alteration. Enharmonics share a pitch class, so C♯ and D♭
+/// both return 1 in 12-EDO.
+///
+/// @p keyMap gives the EDO division of each natural note name in C-first order, which is the same
+/// thing as the major scale rooted at C. It cannot be derived from @p numberOfEdoDivisions alone:
+/// 31-EDO places the naturals at `{ 0, 5, 10, 13, 18, 23, 28 }`, so both values are needed, exactly
+/// as @ref Transposer takes them. Note that a key signature's own key map is relative to its tonal
+/// center, so it suits @ref Transposer rather than this function.
+/// @param noteName The diatonic note name.
+/// @param alteration The alteration relative to the natural note name, in EDO divisions.
+/// @param numberOfEdoDivisions The number of divisions in the EDO. (E.g., 31-EDO would pass 31.)
+/// @param keyMap A 7-element map giving the EDO division of each natural note name, C first.
+/// @return The pitch class, in the range [0, @p numberOfEdoDivisions - 1].
+constexpr int calcPitchClass(NoteName noteName, int alteration = 0,
+    int numberOfEdoDivisions = STANDARD_12EDO_STEPS,
+    const std::array<int, STANDARD_DIATONIC_STEPS>& keyMap = MAJOR_KEYMAP)
+{
+    const int natural = keyMap[positiveModulus(int(noteName), STANDARD_DIATONIC_STEPS)];
+    return positiveModulus(natural + alteration, numberOfEdoDivisions);
+}
+
+/// @brief Calculates the pitch class of a spelled pitch, ignoring its octave.
+/// @param pitch The pitch to convert. Its alteration is relative to the natural note name.
+/// @param numberOfEdoDivisions The number of divisions in the EDO. (E.g., 31-EDO would pass 31.)
+/// @param keyMap A 7-element map giving the EDO division of each natural note name, C first.
+/// @return The pitch class, in the range [0, @p numberOfEdoDivisions - 1].
+constexpr int calcPitchClass(const Pitch& pitch,
+    int numberOfEdoDivisions = STANDARD_12EDO_STEPS,
+    const std::array<int, STANDARD_DIATONIC_STEPS>& keyMap = MAJOR_KEYMAP)
+{
+    return calcPitchClass(pitch.noteName, pitch.alteration, numberOfEdoDivisions, keyMap);
 }
 
 /// @brief Calculates the number of 12-EDO chromatic halfsteps in the specified interval

--- a/src/musx/dom/Details.h
+++ b/src/musx/dom/Details.h
@@ -1094,9 +1094,12 @@ public:
     class Barre
     {
     public:
-        int fret{};         ///< 0-based fret number, where 0 signifies the open string. (Finale allows nut barres.)
-        int startString{};  ///< Starting 1-based string number.
-        int endString{};    ///< Ending 1-based string number.
+        /// @brief 0-based fret number counting from the diagram's first fret, so 0 is the fret that
+        /// @ref Cell identifies as fret 1. This differs from @ref Cell::fret, which reserves 0 for the
+        /// open string; a barre's equivalent cell fret is always `fret + 1`.
+        int fret{};
+        int startString{};  ///< Starting 1-based string number. This is the lowest-numbered string in the barre.
+        int endString{};    ///< Ending 1-based string number. This is the highest-numbered string in the barre.
 
         static const xml::XmlElementArray<Barre>& xmlMappingArray(); ///< Required for musx::factory::FieldPopulator.
     };

--- a/src/musx/musx.h
+++ b/src/musx/musx.h
@@ -74,6 +74,7 @@
 #include "util/Cue.h"
 #include "util/DateTimeFormat.h"
 #include "util/EnigmaString.h"
+#include "util/Fretboard.h"
 #include "util/PseudoTieUtils.h"
 #include "util/ShapeRecognize.h"
 #include "util/SmartShapeRecognize.h"

--- a/src/musx/util/Fretboard.cpp
+++ b/src/musx/util/Fretboard.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2026, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "musx/util/Fretboard.h"
+
+#include <algorithm>
+
+#include "music_theory/music_theory.hpp"
+
+namespace musx::util {
+
+namespace {
+
+std::optional<dom::MusxInstance<dom::details::FretboardDiagram>> getDiagramForPitchClass(
+    const dom::MusxInstance<dom::others::FretboardGroup>& group,
+    int pitchClass)
+{
+    if (!group) {
+        return std::nullopt;
+    }
+
+    const auto diagrams = group->getFretboardDiagrams();
+    if (diagrams.empty()) {
+        return std::nullopt;
+    }
+
+    // Finale orders the twelve diagrams from A, so pitch class 0 (C) is the fourth of them.
+    const size_t diagramIndex = static_cast<size_t>(music_theory::positiveModulus(
+        pitchClass + 3, music_theory::STANDARD_12EDO_STEPS));
+    if (diagramIndex >= diagrams.size()) {
+        return std::nullopt;
+    }
+    return diagrams[diagramIndex];
+}
+
+int displayFret(int sourceFret, int fretboardNumber)
+{
+    if (sourceFret == 0 || fretboardNumber <= 1) {
+        return sourceFret;
+    }
+    return sourceFret + fretboardNumber - 1;
+}
+
+} // namespace
+
+std::optional<FretboardDisplayData> calcFretboardDisplayData(
+    const dom::MusxInstance<dom::details::ChordAssign>& chord,
+    const dom::MusxInstance<dom::KeySignature>& keySignature,
+    dom::KeySignature::KeyContext keyContext)
+{
+    if (!chord || !keySignature || !chord->showFretboard || chord->useFretboardFont) {
+        return std::nullopt;
+    }
+    // Finale suppresses a fretboard from three independent places: the chord assignment itself
+    // (checked above), the document-wide chord options, and the staff in effect where the chord sits.
+    const auto chordOptions = chord->getDocument()->getOptions()->get<dom::options::ChordOptions>();
+    if (!chordOptions || !chordOptions->showFretboards) {
+        return std::nullopt;
+    }
+    const auto staff = dom::others::StaffComposite::createCurrent(chord->getDocument(), chord->getRequestedPartId(),
+        static_cast<dom::StaffCmper>(chord->getCmper1()), static_cast<dom::MeasCmper>(chord->getCmper2()), chord->horzEdu);
+    if (!staff || staff->hideFretboards) {
+        return std::nullopt;
+    }
+
+    const auto group = chord->getFretboardGroup();
+    if (!group) {
+        return std::nullopt;
+    }
+    const auto instrument = group->getFretInstrument();
+    if (!instrument) {
+        return std::nullopt;
+    }
+    const auto root = keySignature->calcPitch(chord->rootScaleNum, chord->rootAlter, keyContext);
+    // A fretboard group always stores exactly twelve diagrams, one per 12-EDO pitch class, so the root
+    // selects one of them in 12-EDO regardless of the key signature's own EDO.
+    const auto diagram = getDiagramForPitchClass(group, music_theory::calcPitchClass(root));
+    if (!diagram) {
+        return std::nullopt;
+    }
+
+    FretboardDisplayData result;
+    result.stringCount = instrument->numStrings;
+    result.fretCount = (*diagram)->numFrets;
+    result.fretboardNumber = (*diagram)->fretboardNum;
+    result.showFretboardNumber = (*diagram)->showNum;
+    result.cells.reserve((*diagram)->cells.size());
+    for (const auto& cell : (*diagram)->cells) {
+        result.cells.push_back({ cell->string, displayFret(cell->fret, (*diagram)->fretboardNum), cell->shape, cell->fingerNum });
+    }
+    for (int stringNumber = 1; stringNumber <= result.stringCount; ++stringNumber) {
+        const auto cell = std::find_if(result.cells.begin(), result.cells.end(),
+            [stringNumber](const auto& candidate) {
+                return candidate.string == stringNumber;
+            });
+        if (cell == result.cells.end()) {
+            result.unplayedStringDisplay = UnplayedStringDisplay::Blank;
+            break;
+        }
+    }
+    const auto mutedCell = std::find_if(result.cells.begin(), result.cells.end(),
+        [](const auto& cell) {
+            return cell.shape == dom::details::FretboardDiagram::Shape::Muted;
+        });
+    if (mutedCell != result.cells.end()) {
+        result.unplayedStringDisplay = UnplayedStringDisplay::Muted;
+    }
+    result.barres.reserve((*diagram)->barres.size());
+    for (const auto& barre : (*diagram)->barres) {
+        // Barre frets count from zero at the diagram's first fret, one less than the cell coordinate
+        // in which zero is the open string. Shift into the cell coordinate before adding the display offset.
+        result.barres.push_back({ displayFret(barre->fret + 1, (*diagram)->fretboardNum), barre->startString, barre->endString });
+    }
+    return result;
+}
+
+} // namespace musx::util

--- a/src/musx/util/Fretboard.h
+++ b/src/musx/util/Fretboard.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "musx/dom/Details.h"
+#include "musx/dom/Others.h"
+
+namespace musx::util {
+
+/// @brief How strings without frame notes should be displayed.
+enum class UnplayedStringDisplay {
+    None, ///< Every instrument string has a played frame cell.
+    Blank, ///< One or more strings have no frame note, with no explicit muted marker.
+    Muted ///< One or more omitted strings are explicitly marked muted.
+};
+
+/// @brief Format-neutral display data for one Finale fretboard diagram.
+/// @details Fret values are absolute display fret numbers. A cell with fret zero is a string marker
+/// whose meaning comes from #Cell::shape, and multiple cells on one string are retained in source order.
+/// Exporters may collapse or reinterpret those values according to their target format.
+struct FretboardDisplayData
+{
+    /// @brief One marker or fretted position in the diagram.
+    struct Cell
+    {
+        int string{}; ///< 1-based string number.
+        int fret{}; ///< Absolute display fret number; zero is the open-string/marker position.
+        dom::details::FretboardDiagram::Shape shape{}; ///< Source marker or dot shape.
+        int finger{}; ///< Finger number; zero means no fingering is specified.
+    };
+
+    /// @brief A barre spanning a range of strings.
+    struct Barre
+    {
+        int fret{}; ///< Absolute display fret number using the same coordinate as #Cell::fret.
+        int startString{}; ///< 1-based first string in the barre.
+        int endString{}; ///< 1-based last string in the barre.
+    };
+
+    int stringCount{}; ///< Number of strings in the associated fret instrument.
+    int fretCount{}; ///< Number of frets displayed by the diagram.
+    int fretboardNumber{}; ///< Starting fret number stored by Finale.
+    bool showFretboardNumber{}; ///< Whether Finale displays #fretboardNumber.
+    UnplayedStringDisplay unplayedStringDisplay{UnplayedStringDisplay::None}; ///< Display state for strings without frame notes.
+    std::vector<Cell> cells; ///< Diagram cells in Finale source order.
+    std::vector<Barre> barres; ///< Diagram barres in Finale source order.
+};
+
+/// @brief Resolve the format-neutral display data for a fretboard diagram.
+/// @details The chord assignment supplies the staff and measure identity through its instance coordinates,
+/// and supplies the root scale degree and alteration. The effective key signature is an input because callers
+/// commonly already have it resolved for the staff and measure. The key signature and context are used to
+/// calculate the root's chromatic pitch class and select Finale's corresponding diagram.
+///
+/// This function owns the entire visibility decision. Finale suppresses a fretboard from the chord assignment,
+/// from @ref dom::options::ChordOptions, and from the staff in effect at the chord's position, and all three
+/// are checked here. Callers need not consult them, and in particular need not resolve a
+/// @ref dom::others::StaffComposite of their own to do so.
+/// @param chord Chord assignment whose fretboard is to be resolved.
+/// @param keySignature Effective key signature for the chord's staff and measure.
+/// @param keyContext Whether the written or concert key-signature interpretation should be used.
+/// @return Display data, or std::nullopt when no fretboard is displayed for this chord or when its source
+/// data is unavailable.
+[[nodiscard]] std::optional<FretboardDisplayData> calcFretboardDisplayData(
+    const dom::MusxInstance<dom::details::ChordAssign>& chord,
+    const dom::MusxInstance<dom::KeySignature>& keySignature,
+    dom::KeySignature::KeyContext keyContext);
+
+} // namespace musx::util

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,6 +132,7 @@ add_executable(musxdomtests
     util/arpeggio.cpp
     util/cue.cpp
     util/fraction.cpp
+    util/fretboard.cpp
     util/svg_arrowheads.cpp
     util/svg_convert.cpp
     util/svg_ext_graphics.cpp

--- a/tests/details/fretboards_diagrams.cpp
+++ b/tests/details/fretboards_diagrams.cpp
@@ -183,7 +183,9 @@ TEST(FretboardDiagramTest, PopulateFields)
     {
         auto b0 = fb->barres[0];
         ASSERT_TRUE(b0);
-        EXPECT_EQ(b0->fret, 0); // Finale allows nut/capo representation as fret 0
+        // Barre frets count from zero at the diagram's first fret, so 0 here is the fret that the cells
+        // above call fret 1. See FretboardDisplayData for the conversion into display frets.
+        EXPECT_EQ(b0->fret, 0);
         EXPECT_EQ(b0->startString, 1);
         EXPECT_EQ(b0->endString, 5);
     }

--- a/tests/music_theory/transpose.cpp
+++ b/tests/music_theory/transpose.cpp
@@ -420,3 +420,50 @@ TEST(TransposerTest, CalcKeySigChangeFromInterval_Theoretical)
     // D# Transposition down: from your test {-1, -1} should produce -9
     EXPECT_EQ(calcKeySigChangeFromInterval(-1, -1), -9) << "interval should be down aug 2nd {-1, -1}";
 }
+
+TEST(MusicTheoryTest, CalcPitchClass)
+{
+    // The naturals are the major scale rooted at C.
+    EXPECT_EQ(calcPitchClass(NoteName::C), 0);
+    EXPECT_EQ(calcPitchClass(NoteName::D), 2);
+    EXPECT_EQ(calcPitchClass(NoteName::E), 4);
+    EXPECT_EQ(calcPitchClass(NoteName::F), 5);
+    EXPECT_EQ(calcPitchClass(NoteName::G), 7);
+    EXPECT_EQ(calcPitchClass(NoteName::A), 9);
+    EXPECT_EQ(calcPitchClass(NoteName::B), 11);
+
+    // Enharmonics share a pitch class.
+    EXPECT_EQ(calcPitchClass(NoteName::C, 1), calcPitchClass(NoteName::D, -1));
+    EXPECT_EQ(calcPitchClass(NoteName::E, 1), calcPitchClass(NoteName::F));
+    EXPECT_EQ(calcPitchClass(NoteName::B, 1), calcPitchClass(NoteName::C));
+
+    // Alterations wrap in both directions rather than escaping the octave.
+    EXPECT_EQ(calcPitchClass(NoteName::B, 1), 0);
+    EXPECT_EQ(calcPitchClass(NoteName::C, -1), 11);
+    EXPECT_EQ(calcPitchClass(NoteName::C, -2), 10);
+    EXPECT_EQ(calcPitchClass(NoteName::B, 2), 1);
+
+    // An alteration larger than an octave still lands in range.
+    EXPECT_EQ(calcPitchClass(NoteName::C, 13), 1);
+    EXPECT_EQ(calcPitchClass(NoteName::C, -13), 11);
+
+    // The octave is ignored when converting a spelled pitch.
+    EXPECT_EQ(calcPitchClass(Pitch(NoteName::E, 4, -1)), 3);
+    EXPECT_EQ(calcPitchClass(Pitch(NoteName::E, 9, -1)), calcPitchClass(Pitch(NoteName::E, -2, -1)));
+
+    // A non-12 EDO needs its own key map, which its EDO count alone does not supply.
+    constexpr std::array<int, STANDARD_DIATONIC_STEPS> major31EDO = { 0, 5, 10, 13, 18, 23, 28 };
+    EXPECT_EQ(calcPitchClass(NoteName::E, 0, 31, major31EDO), 10);
+    EXPECT_EQ(calcPitchClass(NoteName::B, 3, 31, major31EDO), 0);
+    EXPECT_EQ(calcPitchClass(NoteName::C, -1, 31, major31EDO), 30);
+
+    // In 31-EDO a sharp and its enharmonic flat are distinct pitches, unlike in 12-EDO.
+    EXPECT_NE(calcPitchClass(NoteName::C, 2, 31, major31EDO), calcPitchClass(NoteName::D, -2, 31, major31EDO));
+
+    // These are usable in a constant expression, which also guards the modulus helpers they rest on
+    // against regaining a dependency on a non-constexpr std::abs.
+    static_assert(calcPitchClass(NoteName::G, -1) == 6);
+    static_assert(calcPitchClass(Pitch(NoteName::B, 4, 1)) == 0);
+    static_assert(positiveModulus(-13, 12) == 11);
+    static_assert(signedModulus(-13, 12) == -1);
+}

--- a/tests/util/fretboard.cpp
+++ b/tests/util/fretboard.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (C) 2026, Robert Patterson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "musx/musx.h"
+#include "test_utils.h"
+
+using namespace musx::dom;
+using namespace musx::util;
+
+namespace {
+
+/// @brief The knobs Finale can use to suppress a fretboard, plus the root that selects the diagram.
+struct ChordSetup
+{
+    bool showFretboards{true};      ///< options::ChordOptions::showFretboards
+    bool hideFretboards{false};     ///< others::Staff::hideFretboards
+    bool showFretboard{true};       ///< details::ChordAssign::showFretboard
+    bool useFretboardFont{false};   ///< details::ChordAssign::useFretboardFont
+    int rootScaleNum{0};            ///< Selects which of the group's twelve diagrams is used.
+};
+
+/// @brief Emits one diagram, padding the group to the twelve that FretboardGroup requires.
+std::string diagram(int pitchClassIndex, const std::string& body)
+{
+    return "<fretboard cmper1=\"10\" cmper2=\"" + std::to_string(pitchClassIndex) + "\">" + body + "</fretboard>";
+}
+
+/// @brief Builds a one-chord document whose fretboard group carries three diagrams of interest.
+/// @details The document is in C major with no transposition, so the chord's scale degree maps to a pitch
+/// class and then to a diagram index: degree 0 (C) selects diagram 3, degree 1 (D) diagram 5, and degree 2
+/// (E) diagram 7. The remaining diagrams exist only to satisfy the group's twelve-diagram requirement.
+std::string makeXml(const ChordSetup& setup)
+{
+    const auto flag = [](bool value, const char* name) {
+        return value ? std::string("<") + name + "/>" : std::string();
+    };
+
+    // Diagram 3: every string played, a finger number, and a barre, on a diagram starting at fret 6.
+    std::string diagrams = diagram(3,
+        "<numFrets>4</numFrets><fretNum>6</fretNum><showNum/><numFretCells>6</numFretCells><numFretBarres>1</numFretBarres>"
+        "<cell><string>6</string><fret>1</fret><shape>closed</shape></cell>"
+        "<cell><string>5</string><fret>3</fret><shape>closed</shape></cell>"
+        "<cell><string>4</string><fret>3</fret><shape>closed</shape><fingerNum>3</fingerNum></cell>"
+        "<cell><string>3</string><fret>1</fret><shape>closed</shape></cell>"
+        "<cell><string>2</string><fret>1</fret><shape>closed</shape></cell>"
+        "<cell><string>1</string><fret>1</fret><shape>closed</shape></cell>"
+        "<barre><fret>0</fret><startString>1</startString><endString>6</endString></barre>");
+    // Diagram 5: every string has a cell, but one is explicitly muted.
+    diagrams += diagram(5,
+        "<numFrets>4</numFrets><fretNum>1</fretNum><numFretCells>6</numFretCells>"
+        "<cell><string>6</string><fret>0</fret><shape>muted</shape></cell>"
+        "<cell><string>5</string><fret>3</fret><shape>closed</shape></cell>"
+        "<cell><string>4</string><fret>2</fret><shape>closed</shape></cell>"
+        "<cell><string>3</string><fret>0</fret><shape>open</shape></cell>"
+        "<cell><string>2</string><fret>1</fret><shape>closed</shape></cell>"
+        "<cell><string>1</string><fret>0</fret><shape>open</shape></cell>");
+    // Diagram 7: strings 5 and 6 have no cell at all and no muted marker.
+    diagrams += diagram(7,
+        "<numFrets>4</numFrets><fretNum>1</fretNum><numFretCells>4</numFretCells>"
+        "<cell><string>4</string><fret>2</fret><shape>closed</shape></cell>"
+        "<cell><string>3</string><fret>2</fret><shape>closed</shape></cell>"
+        "<cell><string>2</string><fret>1</fret><shape>closed</shape></cell>"
+        "<cell><string>1</string><fret>0</fret><shape>open</shape></cell>");
+    for (int index = 0; index < 12; index++) {
+        if (index != 3 && index != 5 && index != 7) {
+            diagrams += diagram(index, "<numFrets>4</numFrets><fretNum>1</fretNum>");
+        }
+    }
+
+    return
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        "<finale>"
+        "<options><chordOptions>" + flag(setup.showFretboards, "showFretboards") + "</chordOptions></options>"
+        "<others>"
+        "<staffSpec cmper=\"1\"><staffLines>5</staffLines>" + flag(setup.hideFretboards, "hideFretboards") + "</staffSpec>"
+        "<measSpec cmper=\"1\"><beats>4</beats><divbeat>1024</divbeat></measSpec>"
+        "<fretGroup cmper=\"10\" inci=\"0\"><fretInstID>1</fretInstID><name>Test Group</name></fretGroup>"
+        "<fretInst cmper=\"1\"><numFrets>21</numFrets><numStrings>6</numStrings><name>Standard Guitar</name>"
+        "<string><pitch>64</pitch></string><string><pitch>59</pitch></string><string><pitch>55</pitch></string>"
+        "<string><pitch>50</pitch></string><string><pitch>45</pitch></string><string><pitch>40</pitch></string>"
+        "</fretInst>"
+        "</others>"
+        "<details>"
+        "<chordAssign cmper1=\"1\" cmper2=\"1\" inci=\"0\">"
+        "<suffix>10</suffix><rootScaleNum>" + std::to_string(setup.rootScaleNum) + "</rootScaleNum>"
+        + flag(setup.showFretboard, "showFretboard") + flag(setup.useFretboardFont, "useFretFont") +
+        "</chordAssign>"
+        + diagrams +
+        "</details>"
+        "</finale>";
+}
+
+std::optional<FretboardDisplayData> calcFor(const ChordSetup& setup)
+{
+    const auto xml = makeXml(setup);
+    const auto doc = musx::factory::DocumentFactory::create<musx::xml::tinyxml2::Document>(xml);
+    EXPECT_TRUE(doc);
+    if (!doc) {
+        return std::nullopt;
+    }
+    const auto chord = doc->getDetails()->get<details::ChordAssign>(SCORE_PARTID, 1, 1, 0);
+    EXPECT_TRUE(chord);
+    const auto measure = doc->getOthers()->get<others::Measure>(SCORE_PARTID, 1);
+    EXPECT_TRUE(measure);
+    if (!chord || !measure) {
+        return std::nullopt;
+    }
+    return calcFretboardDisplayData(chord, measure->createKeySignature(StaffCmper(1)),
+        KeySignature::KeyContext::Written);
+}
+
+} // namespace
+
+TEST(FretboardDisplayDataTest, ResolvesCellsAndBarresInDisplayFrets)
+{
+    const auto fretboard = calcFor(ChordSetup{});
+    ASSERT_TRUE(fretboard);
+    EXPECT_EQ(fretboard->stringCount, 6);
+    EXPECT_EQ(fretboard->fretCount, 4);
+    EXPECT_EQ(fretboard->fretboardNumber, 6);
+    EXPECT_TRUE(fretboard->showFretboardNumber);
+    EXPECT_EQ(fretboard->unplayedStringDisplay, UnplayedStringDisplay::None);
+
+    // Cells keep Finale's source order, shifted from the diagram-relative fret to the display fret.
+    ASSERT_EQ(fretboard->cells.size(), static_cast<size_t>(6));
+    const auto expectCell = [&](size_t index, int string, int fret, int finger) {
+        EXPECT_EQ(fretboard->cells[index].string, string) << "cell " << index;
+        EXPECT_EQ(fretboard->cells[index].fret, fret) << "cell " << index;
+        EXPECT_EQ(fretboard->cells[index].finger, finger) << "cell " << index;
+    };
+    expectCell(0, 6, 6, 0);
+    expectCell(1, 5, 8, 0);
+    expectCell(2, 4, 8, 3);
+    expectCell(3, 3, 6, 0);
+    expectCell(4, 2, 6, 0);
+    expectCell(5, 1, 6, 0);
+
+    // The barre is stored as fret 0, meaning the diagram's first fret. That is the cell coordinate's fret 1,
+    // which on a diagram starting at fret 6 displays as fret 6, coinciding with the cells on strings 1 and 6.
+    ASSERT_EQ(fretboard->barres.size(), static_cast<size_t>(1));
+    EXPECT_EQ(fretboard->barres[0].fret, 6);
+    EXPECT_EQ(fretboard->barres[0].startString, 1);
+    EXPECT_EQ(fretboard->barres[0].endString, 6);
+}
+
+TEST(FretboardDisplayDataTest, ReportsUnplayedStrings)
+{
+    auto setup = ChordSetup{};
+
+    // Diagram 5 covers every string but marks one of them muted.
+    setup.rootScaleNum = 1;
+    const auto muted = calcFor(setup);
+    ASSERT_TRUE(muted);
+    EXPECT_EQ(muted->unplayedStringDisplay, UnplayedStringDisplay::Muted);
+
+    // Diagram 7 leaves strings 5 and 6 out entirely, with no muted marker to show for them.
+    setup.rootScaleNum = 2;
+    const auto blank = calcFor(setup);
+    ASSERT_TRUE(blank);
+    EXPECT_EQ(blank->unplayedStringDisplay, UnplayedStringDisplay::Blank);
+
+    // A diagram whose first fret is 1 needs no shift, so open strings and stopped frets pass through.
+    ASSERT_EQ(blank->cells.size(), static_cast<size_t>(4));
+    EXPECT_EQ(blank->cells[0].fret, 2);
+    EXPECT_EQ(blank->cells[3].fret, 0);
+}
+
+TEST(FretboardDisplayDataTest, SuppressedByChordOptions)
+{
+    auto setup = ChordSetup{};
+    setup.showFretboards = false;
+    EXPECT_FALSE(calcFor(setup));
+}
+
+TEST(FretboardDisplayDataTest, SuppressedByStaff)
+{
+    auto setup = ChordSetup{};
+    setup.hideFretboards = true;
+    EXPECT_FALSE(calcFor(setup));
+}
+
+TEST(FretboardDisplayDataTest, SuppressedByChordAssignment)
+{
+    auto setup = ChordSetup{};
+    setup.showFretboard = false;
+    EXPECT_FALSE(calcFor(setup));
+
+    // A fretboard rendered from a font carries no structured diagram to report.
+    setup = ChordSetup{};
+    setup.useFretboardFont = true;
+    EXPECT_FALSE(calcFor(setup));
+}


### PR DESCRIPTION
## Summary
- add a format-neutral utility for resolving Finale fretboard display data
- normalize display frets and barre coordinates
- derive unplayed-string display state
- add pitch-class support and focused utility tests

## Verification
- cmake --build build
- musxdomtests focused fretboard and pitch-class tests from tests/data: 10/10 passed