### PR TITLE
Document synchronized music theory header

### DIFF
--- a/.agents/music-theory-sync/SKILL.md
+++ b/.agents/music-theory-sync/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: music-theory-sync
+description: Keep the shared music_theory.hpp implementation synchronized between musxdom and mnxdom.
+---
+
+# Music theory synchronization
+
+`src/music_theory/music_theory.hpp` is shared by musxdom and mnxdom. Any change
+to that header is a coordinated two-repository change.
+
+When editing the header:
+
+- Apply the same change to both repositories in the same work item.
+- Keep the two copies byte-identical unless a repository-specific difference is
+  explicitly authorized.
+- Compare the files after editing with `cmp` or an equivalent byte-for-byte
+  check.
+- Build and run the relevant tests in both repositories before handing off.
+- Keep the commits or pull requests linked so the synchronization is visible.
+
+If the other repository is unavailable, do not treat a one-sided header change
+as complete; report the synchronization blocker and identify the pending copy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Guidance for coding agents and contributors working in this repository.
 
+## Skills
+
+- `.agents/music-theory-sync/SKILL.md` — changes to `src/music_theory/music_theory.hpp` must be synchronized with mnxdom.
+
 ## Project Context
 
 This repository implements a C++ document object model for Finale `musx` / EnigmaXml data. Prefer changes that preserve the existing DOM/factory/test structure and keep Finale-specific interpretation in musxdom while leaving export-format policy decisions to caller layers.


### PR DESCRIPTION
## Summary
Add repository guidance requiring src/music_theory/music_theory.hpp changes to stay synchronized with mnxdom.

The guidance requires byte-for-byte verification and relevant tests in both repositories.